### PR TITLE
KAIZEN-0: Clear localstorage fordi vi har endret filtermodellen og de…

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,13 @@ if (!(window as any)._babelPolyfill) {
     require('babel-polyfill'); // tslint:disable-line
 }
 
+//TODO GJOR DET BEDRE
+if(window.localStorage.getItem('filterVersjon') !== 'v1') {
+    localStorage.setItem('filterVersjon', 'v1');
+    localStorage.removeItem('veilederState');
+    localStorage.removeItem('enhetsState');
+}
+
 if(erHeroku()){
     window.localStorage.setItem('lastpath','/enhet');
     window.localStorage.setItem('lastsearch','?enhet=1234&seAlle=false&side=1&sorteringsfelt=ikke_satt&sorteringsrekkefolge=ikke_satt');


### PR DESCRIPTION
…t er fortsatt mange veiledere som har feil modell pga verjsonen lagret i localstorage