### PR TITLE
fjern margin slik at border ikke forsvinner

### DIFF
--- a/src/enhetsportefolje/enhetsportefolje.less
+++ b/src/enhetsportefolje/enhetsportefolje.less
@@ -56,9 +56,5 @@
         max-width: 40%;
         min-width: 16rem;
         margin: 0.5rem 5% 0.5rem 0;
-
-        .skjemaelement {
-            margin-bottom: 0;
-        }
     }
 }


### PR DESCRIPTION
**Hva?**
Søkefeltet for fødselsnummer og navn vises ikke på "Min oversikt". 

Før: 
<img width="953" alt="Skjermbilde 2021-03-16 kl  11 30 34" src="https://user-images.githubusercontent.com/19923661/111336937-f2ef5980-8675-11eb-8411-49366c315841.png">

Etter: 
<img width="1023" alt="Skjermbilde 2021-03-16 kl  16 34 09" src="https://user-images.githubusercontent.com/19923661/111336975-faaefe00-8675-11eb-8a4a-9170a0708133.png">