### PR TITLE
TC-291 legg til queryParam for bruk av veilarbportefolje api v2

### DIFF
--- a/src/middleware/api.ts
+++ b/src/middleware/api.ts
@@ -2,6 +2,7 @@
 import {fetchToJson, sjekkStatuskode} from '../ducks/utils';
 import {VeilederModell} from '../model-interfaces';
 import {NyttLagretFilter, RedigerLagretFilter, SorteringOgId} from '../ducks/lagret-filter';
+import {getBrukVeilarbportefoljeV2FraUrl} from '../utils/url-utils';
 
 export const API_BASE_URL = '/veilarbportefoljeflatefs/api';
 const credentials = 'same-origin';
@@ -14,7 +15,7 @@ const MED_CREDENTIALS: RequestInit = {
 };
 
 export const VEILARBVEILEDER_URL = '/veilarbveileder';
-export const VEILARBPORTEFOLJE_URL = '/veilarbportefolje/api';
+export const VEILARBPORTEFOLJE_URL = `/veilarbportefolje/api${getBrukVeilarbportefoljeV2FraUrl() ? '/v2' : ''}`;
 export const VEILARBOPPFOLGING_URL = '/veilarboppfolging';
 export const VEILARBFILTER_URL = '/veilarbfilter/api';
 export const FEATURE_URL = '/feature';

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -56,6 +56,6 @@ export function updateLastPath() {
     }
 }
 
-export function getBrukVeilarbportefoljeV2FraUrl() {
-    return queryString.parse(window.location.search).brukV2;
+export function getBrukVeilarbportefoljeV2FraUrl(): boolean {
+    return !!queryString.parse(window.location.search).brukV2;
 }

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -55,3 +55,7 @@ export function updateLastPath() {
         localStorage.setItem('lastsearch', search);
     }
 }
+
+export function getBrukVeilarbportefoljeV2FraUrl() {
+    return queryString.parse(window.location.search).brukV2;
+}


### PR DESCRIPTION
**Hva?**
Dersom `brukV2` er satt som queryparameter i url blir `v2` lagt til i url'en slik at alle kall får mot api/v2 av veilarbportefolje. 
Eks: `/veilarbportefolje/api/v2/enhet/1337/portefolje`

**Hvorfor?**
Slik at vi kan enkelt kan teste ut Postgres databasen ved å legge til `brukV2` slik: 
_https://app-q1.dev.adeo.no/veilarbportefoljeflatefs/enhet?enhet=0106&seAlle=false&side=1&sorteringsfelt=ikke_satt&sorteringsrekkefolge=ikke_satt&brukV2=true_