### PR TITLE
legg til aria-live

### DIFF
--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -216,6 +216,7 @@ function Sidebar(props: SidebarProps) {
         <div
             ref={sidebarRef}
             aria-label={`Sidenavigasjon er nå ${props.isSidebarHidden ? 'lukket' : 'åpen'}`}
+            aria-live="polite"
             className={classNames('sidebar', props.isSidebarHidden && 'sidebar__hidden', 'tabs')}
         >
             <div


### PR DESCRIPTION
Bruk av `aria-live` slik at skjermleser leser opp endringer i tab-containeren selv om fokus er på en av tabene. 

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions