### PR TITLE
Integrer Sanity-basert endringslogg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "veilarbportefoljeflatefs",
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
@@ -22,6 +23,7 @@
                 "cypress-drag-drop": "^1.1.1",
                 "cypress-run": "^1.1.1",
                 "cypress-wait-until": "^1.7.1",
+                "endringslogg": "^2.0.4",
                 "express": "4.17.1",
                 "faker": "4.1.0",
                 "formik": "^2.2.6",
@@ -1657,6 +1659,11 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
         },
+        "node_modules/@emotion/hash": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+            "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+        },
         "node_modules/@hapi/address": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -1922,6 +1929,11 @@
                 "node": ">=4"
             }
         },
+        "node_modules/@navikt/ds-css": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-0.8.4.tgz",
+            "integrity": "sha512-f6GKJx0UL9j/QHRMAEI/1xM85bGeZtKiIIqcoY4D4SXBRIqsnP/iYBIokc9idWOIsGy5kz/uuTRcsQVdBenUMA=="
+        },
         "node_modules/@navikt/fnrvalidator": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@navikt/fnrvalidator/-/fnrvalidator-1.1.3.tgz",
@@ -1967,6 +1979,20 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@popperjs/core": {
+            "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.1.tgz",
+            "integrity": "sha512-HnUhk1Sy9IuKrxEMdIRCxpIqPw6BFsbYSEUO9p/hNw5sMld/+3OLMWQP80F8/db9qsv3qUjs7ZR5bS/R+iinXw==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/popperjs"
+            }
+        },
+        "node_modules/@rexxars/eventsource-polyfill": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rexxars/eventsource-polyfill/-/eventsource-polyfill-1.0.0.tgz",
+            "integrity": "sha512-YnrybIoM9WFqmeK1D8p/gutqjJnmXCVFWAU3ucka9M7Dzpen3f2Dy4KsC6k1wDHrCtHQuUHHwZovh3i5UPDaZw=="
+        },
         "node_modules/@samverschueren/stream-to-observable": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
@@ -1977,6 +2003,75 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/@sanity/block-content-to-hyperscript": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@sanity/block-content-to-hyperscript/-/block-content-to-hyperscript-3.0.0.tgz",
+            "integrity": "sha512-uoXWLdFY5LqO8A9sFJqnZWWDCBC+0r3Egeh0bwKQ2EK2Vil5L40iJGNXMZhDB8BnvH+6B4155SU8Q3vY59T6pA==",
+            "dependencies": {
+                "@sanity/generate-help-url": "^0.140.0",
+                "@sanity/image-url": "^0.140.15",
+                "hyperscript": "^2.0.2",
+                "object-assign": "^4.1.1"
+            }
+        },
+        "node_modules/@sanity/block-content-to-hyperscript/node_modules/@sanity/generate-help-url": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-0.140.0.tgz",
+            "integrity": "sha512-H/G/WA9S22TXcXST52CIiTsHx3S2hH0gvK7LnI5w76vfKS0obnDPh8jrPg4xeNRYGPuV9MHYRlyERGpRGoo4Qw=="
+        },
+        "node_modules/@sanity/client": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/@sanity/client/-/client-2.19.0.tgz",
+            "integrity": "sha512-y3VCTXx0z9n9tIroJUBT70rfCZuyJCNmRVZcMjRSjaLCK7vFJHvACX61OkbfbFo9t8r098g8jXP2XttBUiglLQ==",
+            "dependencies": {
+                "@sanity/eventsource": "2.14.0",
+                "@sanity/generate-help-url": "2.18.0",
+                "@sanity/observable": "2.0.9",
+                "deep-assign": "^2.0.0",
+                "get-it": "^5.0.3",
+                "make-error": "^1.3.0",
+                "object-assign": "^4.1.1"
+            }
+        },
+        "node_modules/@sanity/eventsource": {
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-2.14.0.tgz",
+            "integrity": "sha512-U1FgPUwB9//bGT5OO1VgtamSCM2Z3vpWP3mCgN8vPmEUJ0cofAWO+turDbOILahuicH8u7Xnmd+GSB33p4Mg9A==",
+            "dependencies": {
+                "@rexxars/eventsource-polyfill": "^1.0.0",
+                "eventsource": "^1.0.6"
+            }
+        },
+        "node_modules/@sanity/generate-help-url": {
+            "version": "2.18.0",
+            "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-2.18.0.tgz",
+            "integrity": "sha512-If8Qkw32LWPes16UzqwUsTLgfxF5d4ACdUvCLMl6grJc/5G8LKPAGCQUuA/d1F4W16yCJVV7Zv31HDRDXJSJkg=="
+        },
+        "node_modules/@sanity/image-url": {
+            "version": "0.140.22",
+            "resolved": "https://registry.npmjs.org/@sanity/image-url/-/image-url-0.140.22.tgz",
+            "integrity": "sha512-CAmQZnj+KM7FSEYiWlIGDit072syicYuAw0w7R2ctMzHiZ4p9mE/g6dBnYqrqFUrw2J+GpJgPt+RVspKP8vdqA==",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@sanity/observable": {
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/@sanity/observable/-/observable-2.0.9.tgz",
+            "integrity": "sha512-IUpzsEbhOhofTBUu2tiQ4Ymbkmhr6oe4UC4Ds1khZ9Td4t4mzzPGmGQIr5SBEDawz0UD7ZgZAb4LeEzV3hUrtA==",
+            "dependencies": {
+                "object-assign": "^4.1.1",
+                "rxjs": "^6.5.3"
+            }
+        },
+        "node_modules/@sanity/timed-out": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@sanity/timed-out/-/timed-out-4.0.2.tgz",
+            "integrity": "sha512-NBDKGj14g9Z+bopIvZcQKWCzJq5JSrdmzRR1CS+iyA3Gm8SnIWBfZa7I3mTg2X6Nu8LQXG0EPKXdOGozLS4i3w==",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/@sideway/address": {
@@ -2447,8 +2542,7 @@
         "node_modules/@types/prop-types": {
             "version": "15.7.3",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-            "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-            "dev": true
+            "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
         },
         "node_modules/@types/q": {
             "version": "1.5.4",
@@ -2468,7 +2562,6 @@
             "version": "16.9.46",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.46.tgz",
             "integrity": "sha512-dbHzO3aAq1lB3jRQuNpuZ/mnu+CdD3H0WVaaBQA8LTT3S33xhVBUj232T8M3tAhSWJs/D/UqORYUlJNl/8VQZg==",
-            "dev": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -2523,6 +2616,14 @@
                 "@types/history": "*",
                 "@types/react": "*",
                 "@types/react-router": "*"
+            }
+        },
+        "node_modules/@types/react-transition-group": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.3.tgz",
+            "integrity": "sha512-fUx5muOWSYP8Bw2BUQ9M9RK9+W1XBK/7FLJ8PTQpnpTEkn0ccyMffyEQvan4C3h53gHdx7KE5Qrxi/LnUGQtdg==",
+            "dependencies": {
+                "@types/react": "*"
             }
         },
         "node_modules/@types/sinonjs__fake-timers": {
@@ -4135,6 +4236,11 @@
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
             "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
         },
+        "node_modules/browser-split": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.0.tgz",
+            "integrity": "sha1-QUGcrvdpdVkp3VGJZ9PuwKYmJ3E="
+        },
         "node_modules/browser-stdout": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -4501,6 +4607,14 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
+        "node_modules/capture-stack-trace": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+            "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/case-sensitive-paths-webpack-plugin": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz",
@@ -4652,6 +4766,14 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "node_modules/class-list": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/class-list/-/class-list-0.1.1.tgz",
+            "integrity": "sha1-m5dFGSxBebXaCg12M2WOPHDXlss=",
+            "dependencies": {
+                "indexof": "0.0.1"
+            }
+        },
         "node_modules/class-utils": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -4678,9 +4800,9 @@
             }
         },
         "node_modules/classnames": {
-            "version": "2.2.6",
-            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-            "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+            "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
         },
         "node_modules/clean-css": {
             "version": "4.2.3",
@@ -4862,6 +4984,14 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/clsx": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+            "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/co": {
@@ -5169,6 +5299,14 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/copy-to-clipboard": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+            "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+            "dependencies": {
+                "toggle-selection": "^1.0.6"
+            }
+        },
         "node_modules/core-js": {
             "version": "2.6.11",
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
@@ -5237,6 +5375,17 @@
             "version": "4.11.9",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
             "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
+        "node_modules/create-error-class": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+            "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+            "dependencies": {
+                "capture-stack-trace": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/create-hash": {
             "version": "1.2.0",
@@ -5497,6 +5646,15 @@
             },
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "node_modules/css-vendor": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
+            "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.3",
+                "is-in-browser": "^1.0.2"
             }
         },
         "node_modules/css-what": {
@@ -6126,6 +6284,36 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/decompress-response": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+            "dependencies": {
+                "mimic-response": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/deep-assign": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-2.0.0.tgz",
+            "integrity": "sha1-6+BrHwfwja5ZdiDj3RYi83GhxXI=",
+            "dependencies": {
+                "is-obj": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/deep-assign/node_modules/is-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/deep-equal": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -6659,6 +6847,273 @@
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "dependencies": {
                 "once": "^1.4.0"
+            }
+        },
+        "node_modules/endringslogg": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/endringslogg/-/endringslogg-2.0.4.tgz",
+            "integrity": "sha512-SePqr51tJxt265l6LTU7TW5Pq1T0aGCWmBfiTtQL12MFdL+QpNh6h/Y9X9vLjqsKrr8qIFXhMckkBh3mRJ4A4g==",
+            "dependencies": {
+                "@navikt/ds-css": "^0.8.1",
+                "@navikt/ds-icons": "^0.5.2",
+                "@navikt/ds-react": "^0.8.0",
+                "@sanity/block-content-to-react": "^3.0.0",
+                "@sanity/client": "^2.15.0",
+                "@sanity/image-url": "^0.140.22",
+                "classnames": "^2.3.1",
+                "prop-types": "^15.7.2",
+                "react-modal": "^3.14.3",
+                "react-transition-group": "^4.4.2"
+            },
+            "peerDependencies": {
+                "react": "^16.12.0 || ^17.0.0",
+                "react-dom": "^16.12.0 || ^17.0.0"
+            }
+        },
+        "node_modules/endringslogg/node_modules/@material-ui/types": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
+            "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
+            "peerDependencies": {
+                "@types/react": "*"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/endringslogg/node_modules/@navikt/ds-icons": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-icons/-/ds-icons-0.5.4.tgz",
+            "integrity": "sha512-4lk4CTKZtNkqGJ2wAtJPheaCcwD6hILh6zWICO7071Lu/O+O+qSmxJSGFJmPh4pTAUuPONp6p8jOUqQwTi4yhw==",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0"
+            }
+        },
+        "node_modules/endringslogg/node_modules/@navikt/ds-react": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-react/-/ds-react-0.8.3.tgz",
+            "integrity": "sha512-M9ryqqKAdzihJap5KGzyLAr44KzKd5hsxk2cWPUXZgfSqkpbbvoR3r1P9bfgrJL0TqnKjsOX8VT7JceQyrOR3A==",
+            "dependencies": {
+                "@material-ui/core": "^4.12.3",
+                "@navikt/ds-icons": "^0.5.3",
+                "@popperjs/core": "^2.10.1",
+                "classnames": "^2.2.6",
+                "copy-to-clipboard": "^3.3.1",
+                "react-collapse": "^5.1.0",
+                "react-merge-refs": "^1.1.0",
+                "react-modal": "3.14.3",
+                "react-popper": "^2.2.5",
+                "uuid": "^8.3.2"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0"
+            }
+        },
+        "node_modules/endringslogg/node_modules/@navikt/ds-react/node_modules/@material-ui/core": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.3.tgz",
+            "integrity": "sha512-sdpgI/PL56QVsEJldwEe4FFaFTLUqN+rd7sSZiRCdx2E/C7z5yK0y/khAWVBH24tXwto7I1hCzNWfJGZIYJKnw==",
+            "dependencies": {
+                "@babel/runtime": "^7.4.4",
+                "@material-ui/styles": "^4.11.4",
+                "@material-ui/system": "^4.12.1",
+                "@material-ui/types": "5.1.0",
+                "@material-ui/utils": "^4.11.2",
+                "@types/react-transition-group": "^4.2.0",
+                "clsx": "^1.0.4",
+                "hoist-non-react-statics": "^3.3.2",
+                "popper.js": "1.16.1-lts",
+                "prop-types": "^15.7.2",
+                "react-is": "^16.8.0 || ^17.0.0",
+                "react-transition-group": "^4.4.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/material-ui"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.6 || ^17.0.0",
+                "react": "^16.8.0 || ^17.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/endringslogg/node_modules/@navikt/ds-react/node_modules/@material-ui/core/node_modules/@material-ui/styles": {
+            "version": "4.11.4",
+            "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.4.tgz",
+            "integrity": "sha512-KNTIZcnj/zprG5LW0Sao7zw+yG3O35pviHzejMdcSGCdWbiO8qzRgOYL8JAxAsWBKOKYwVZxXtHWaB5T2Kvxew==",
+            "dependencies": {
+                "@babel/runtime": "^7.4.4",
+                "@emotion/hash": "^0.8.0",
+                "@material-ui/types": "5.1.0",
+                "@material-ui/utils": "^4.11.2",
+                "clsx": "^1.0.4",
+                "csstype": "^2.5.2",
+                "hoist-non-react-statics": "^3.3.2",
+                "jss": "^10.5.1",
+                "jss-plugin-camel-case": "^10.5.1",
+                "jss-plugin-default-unit": "^10.5.1",
+                "jss-plugin-global": "^10.5.1",
+                "jss-plugin-nested": "^10.5.1",
+                "jss-plugin-props-sort": "^10.5.1",
+                "jss-plugin-rule-value-function": "^10.5.1",
+                "jss-plugin-vendor-prefixer": "^10.5.1",
+                "prop-types": "^15.7.2"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/material-ui"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.6 || ^17.0.0",
+                "react": "^16.8.0 || ^17.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/endringslogg/node_modules/@navikt/ds-react/node_modules/@material-ui/core/node_modules/@material-ui/system": {
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.1.tgz",
+            "integrity": "sha512-lUdzs4q9kEXZGhbN7BptyiS1rLNHe6kG9o8Y307HCvF4sQxbCgpL2qi+gUk+yI8a2DNk48gISEQxoxpgph0xIw==",
+            "dependencies": {
+                "@babel/runtime": "^7.4.4",
+                "@material-ui/utils": "^4.11.2",
+                "csstype": "^2.5.2",
+                "prop-types": "^15.7.2"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/material-ui"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.6 || ^17.0.0",
+                "react": "^16.8.0 || ^17.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/endringslogg/node_modules/@navikt/ds-react/node_modules/@material-ui/core/node_modules/@material-ui/utils": {
+            "version": "4.11.2",
+            "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
+            "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
+            "dependencies": {
+                "@babel/runtime": "^7.4.4",
+                "prop-types": "^15.7.2",
+                "react-is": "^16.8.0 || ^17.0.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0"
+            }
+        },
+        "node_modules/endringslogg/node_modules/@navikt/ds-react/node_modules/react-collapse": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/react-collapse/-/react-collapse-5.1.0.tgz",
+            "integrity": "sha512-5v0ywsn9HjiR/odNzbRDs0RZfrnbdSippJebWOBCFFDA12Vx8DddrbI4qWVf1P2wTiVagrpcSy07AU0b6+gM9Q==",
+            "peerDependencies": {
+                "react": ">=16.3.0"
+            }
+        },
+        "node_modules/endringslogg/node_modules/@navikt/ds-react/node_modules/react-popper": {
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+            "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+            "dependencies": {
+                "react-fast-compare": "^3.0.1",
+                "warning": "^4.0.2"
+            },
+            "peerDependencies": {
+                "@popperjs/core": "^2.0.0",
+                "react": "^16.8.0 || ^17"
+            }
+        },
+        "node_modules/endringslogg/node_modules/@sanity/block-content-to-react": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@sanity/block-content-to-react/-/block-content-to-react-3.0.0.tgz",
+            "integrity": "sha512-oHPLlIsulsnL3ITs93RIvUPBI6nAeoSFOUf16vX4T7z4wWywxP39N1DF9mAx2tV6Kjr1fJAx5GF7zfiMXYLaqA==",
+            "dependencies": {
+                "@sanity/block-content-to-hyperscript": "^3.0.0",
+                "prop-types": "^15.6.2"
+            },
+            "peerDependencies": {
+                "react": ">=15.0.0"
+            }
+        },
+        "node_modules/endringslogg/node_modules/csstype": {
+            "version": "2.6.18",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.18.tgz",
+            "integrity": "sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ=="
+        },
+        "node_modules/endringslogg/node_modules/react-fast-compare": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+            "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+        },
+        "node_modules/endringslogg/node_modules/react-modal": {
+            "version": "3.14.3",
+            "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.14.3.tgz",
+            "integrity": "sha512-+C2KODVKyu20zHXPJxfOOcf571L1u/EpFlH+oS/3YDn8rgVE51QZuxuuIwabJ8ZFnOEHaD+r6XNjqwtxZnXO0g==",
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.7.2",
+                "react-lifecycles-compat": "^3.0.0",
+                "warning": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16 || ^17",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17"
+            }
+        },
+        "node_modules/endringslogg/node_modules/react-transition-group": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
+            "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
+            "dependencies": {
+                "@babel/runtime": "^7.5.5",
+                "dom-helpers": "^5.0.1",
+                "loose-envify": "^1.4.0",
+                "prop-types": "^15.6.2"
+            },
+            "peerDependencies": {
+                "react": ">=16.6.0",
+                "react-dom": ">=16.6.0"
+            }
+        },
+        "node_modules/endringslogg/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/enhanced-resolve": {
@@ -8523,6 +8978,11 @@
                 "node": ">= 0.12"
             }
         },
+        "node_modules/form-urlencoded": {
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-2.0.9.tgz",
+            "integrity": "sha512-fWUzNiOnYa126vFAT6TFXd1mhJrvD8IqmQ9ilZPjkLYQfaRreBr5fIUoOpPlWtqaAG64nzoE7u5zSetifab9IA=="
+        },
         "node_modules/formik": {
             "version": "2.2.6",
             "resolved": "https://registry.npmjs.org/formik/-/formik-2.2.6.tgz",
@@ -8719,6 +9179,35 @@
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
                 "has-symbols": "^1.0.1"
+            }
+        },
+        "node_modules/get-it": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/get-it/-/get-it-5.0.5.tgz",
+            "integrity": "sha512-P5McakQI/9611hP0cYqyF0VlhxQj49ok21TvCbNEqBfsVVC/ZnmYPP91bky4N4/Oy1HmXFZ/CMh6CCH8nAgLpQ==",
+            "dependencies": {
+                "@sanity/timed-out": "^4.0.2",
+                "create-error-class": "^3.0.2",
+                "debug": "^2.6.8",
+                "decompress-response": "^3.3.0",
+                "follow-redirects": "^1.2.4",
+                "form-urlencoded": "^2.0.7",
+                "in-publish": "^2.0.0",
+                "into-stream": "^3.1.0",
+                "is-plain-object": "^2.0.4",
+                "is-retry-allowed": "^1.1.0",
+                "is-stream": "^1.1.0",
+                "nano-pubsub": "^1.0.2",
+                "object-assign": "^4.1.1",
+                "parse-headers": "^2.0.1",
+                "progress-stream": "^2.0.0",
+                "same-origin": "^0.1.1",
+                "simple-concat": "^1.0.0",
+                "tunnel-agent": "^0.6.0",
+                "url-parse": "^1.1.9"
+            },
+            "engines": {
+                "node": ">=8.0.0"
             }
         },
         "node_modules/get-own-enumerable-property-symbols": {
@@ -9189,6 +9678,17 @@
             "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
             "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg="
         },
+        "node_modules/html-element": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/html-element/-/html-element-2.3.1.tgz",
+            "integrity": "sha512-xnFt2ZkbFcjc+JoAtg3Hl89VeEZDjododu4VCPkRvFmBTHHA9U1Nt6hLUWfW2O+6Sl/rT1hHK/PivleX3PdBJQ==",
+            "dependencies": {
+                "class-list": "~0.1.1"
+            },
+            "engines": {
+                "node": ">=4.2"
+            }
+        },
         "node_modules/html-encoding-sniffer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -9377,6 +9877,21 @@
                 "node": ">=8.12.0"
             }
         },
+        "node_modules/hyperscript": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hyperscript/-/hyperscript-2.0.2.tgz",
+            "integrity": "sha1-ODnLpFVUvf4nu4HCFC0WhPgTWvU=",
+            "dependencies": {
+                "browser-split": "0.0.0",
+                "class-list": "~0.1.0",
+                "html-element": "^2.0.0"
+            }
+        },
+        "node_modules/hyphenate-style-name": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+            "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+        },
         "node_modules/iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -9502,6 +10017,17 @@
                 "node": ">=0.8.19"
             }
         },
+        "node_modules/in-publish": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
+            "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==",
+            "bin": {
+                "in-install": "in-install.js",
+                "in-publish": "in-publish.js",
+                "not-in-install": "not-in-install.js",
+                "not-in-publish": "not-in-publish.js"
+            }
+        },
         "node_modules/indent-string": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -9514,6 +10040,11 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
             "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+        },
+        "node_modules/indexof": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+            "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
         },
         "node_modules/infer-owner": {
             "version": "1.0.4",
@@ -9662,6 +10193,18 @@
             "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
             "engines": {
                 "node": ">= 0.10"
+            }
+        },
+        "node_modules/into-stream": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+            "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+            "dependencies": {
+                "from2": "^2.1.1",
+                "p-is-promise": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/invariant": {
@@ -9886,6 +10429,11 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-in-browser": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+            "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
+        },
         "node_modules/is-installed-globally": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
@@ -10025,6 +10573,14 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
             "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
+        },
+        "node_modules/is-retry-allowed": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+            "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/is-root": {
             "version": "2.1.0",
@@ -11034,6 +11590,88 @@
                 "verror": "1.10.0"
             }
         },
+        "node_modules/jss": {
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/jss/-/jss-10.8.0.tgz",
+            "integrity": "sha512-6fAMLJrVQ8epM5ghghxWqCwRR0ZamP2cKbOAtzPudcCMSNdAqtvmzQvljUZYR8OXJIeb/IpZeOXA1sDXms4R1w==",
+            "dependencies": {
+                "@babel/runtime": "^7.3.1",
+                "csstype": "^3.0.2",
+                "is-in-browser": "^1.1.3",
+                "tiny-warning": "^1.0.2"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/jss"
+            }
+        },
+        "node_modules/jss-plugin-camel-case": {
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.8.0.tgz",
+            "integrity": "sha512-yxlXrXwcCdGw+H4BC187dEu/RFyW8joMcWfj8Rk9UPgWTKu2Xh7Sib4iW3xXjHe/t5phOHF1rBsHleHykWix7g==",
+            "dependencies": {
+                "@babel/runtime": "^7.3.1",
+                "hyphenate-style-name": "^1.0.3",
+                "jss": "10.8.0"
+            }
+        },
+        "node_modules/jss-plugin-default-unit": {
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.8.0.tgz",
+            "integrity": "sha512-9XJV546cY9zV9OvIE/v/dOaxSi4062VfYQQfwbplRExcsU2a79Yn+qDz/4ciw6P4LV1Naq90U+OffAGRHfNq/Q==",
+            "dependencies": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.8.0"
+            }
+        },
+        "node_modules/jss-plugin-global": {
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.8.0.tgz",
+            "integrity": "sha512-H/8h/bHd4e7P0MpZ9zaUG8NQSB2ie9rWo/vcCP6bHVerbKLGzj+dsY22IY3+/FNRS8zDmUyqdZx3rD8k4nmH4w==",
+            "dependencies": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.8.0"
+            }
+        },
+        "node_modules/jss-plugin-nested": {
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.8.0.tgz",
+            "integrity": "sha512-MhmINZkSxyFILcFBuDoZmP1+wj9fik/b9SsjoaggkGjdvMQCES21mj4K5ZnRGVm448gIXyi9j/eZjtDzhaHUYQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.8.0",
+                "tiny-warning": "^1.0.2"
+            }
+        },
+        "node_modules/jss-plugin-props-sort": {
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.8.0.tgz",
+            "integrity": "sha512-VY+Wt5WX5GMsXDmd+Ts8+O16fpiCM81svbox++U3LDbJSM/g9FoMx3HPhwUiDfmgHL9jWdqEuvSl/JAk+mh6mQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.8.0"
+            }
+        },
+        "node_modules/jss-plugin-rule-value-function": {
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.8.0.tgz",
+            "integrity": "sha512-R8N8Ma6Oye1F9HroiUuHhVjpPsVq97uAh+rMI6XwKLqirIu2KFb5x33hPj+vNBMxSHc9jakhf5wG0BbQ7fSDOg==",
+            "dependencies": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.8.0",
+                "tiny-warning": "^1.0.2"
+            }
+        },
+        "node_modules/jss-plugin-vendor-prefixer": {
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.8.0.tgz",
+            "integrity": "sha512-G1zD0J8dFwKZQ+GaZaay7A/Tg7lhDw0iEkJ/iFFA5UPuvZFpMprCMQttXcTBhLlhhWnyZ8YPn4yqp+amrhQekw==",
+            "dependencies": {
+                "@babel/runtime": "^7.3.1",
+                "css-vendor": "^2.0.8",
+                "jss": "10.8.0"
+            }
+        },
         "node_modules/jsx-ast-utils": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
@@ -11864,6 +12502,11 @@
                 "node": ">=6"
             }
         },
+        "node_modules/make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+        },
         "node_modules/makeerror": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -12097,6 +12740,14 @@
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/mimic-response": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/mini-create-react-context": {
@@ -12550,6 +13201,11 @@
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
             "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
             "optional": true
+        },
+        "node_modules/nano-pubsub": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/nano-pubsub/-/nano-pubsub-1.0.2.tgz",
+            "integrity": "sha1-NM53b3r5WZFbj3rP6N1rnGbzvek="
         },
         "node_modules/nanoid": {
             "version": "3.1.12",
@@ -13556,6 +14212,14 @@
                 "node": ">=4"
             }
         },
+        "node_modules/p-is-promise": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+            "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/p-limit": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -13694,6 +14358,11 @@
                 "pbkdf2": "^3.0.3",
                 "safe-buffer": "^5.1.1"
             }
+        },
+        "node_modules/parse-headers": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
+            "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw=="
         },
         "node_modules/parse-json": {
             "version": "4.0.0",
@@ -13947,6 +14616,11 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/popper.js": {
+            "version": "1.16.1-lts",
+            "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+            "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
         },
         "node_modules/portfinder": {
             "version": "1.0.28",
@@ -15224,6 +15898,15 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/progress-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-2.0.0.tgz",
+            "integrity": "sha1-+sY6Cz0R3qy7CWmrzJOyFLzhntU=",
+            "dependencies": {
+                "speedometer": "~1.0.0",
+                "through2": "~2.0.3"
+            }
+        },
         "node_modules/promise": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
@@ -15687,6 +16370,15 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
             "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+        },
+        "node_modules/react-merge-refs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
+            "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/gregberge"
+            }
         },
         "node_modules/react-modal": {
             "version": "3.11.2",
@@ -17113,6 +17805,11 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
+        "node_modules/same-origin": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/same-origin/-/same-origin-0.1.1.tgz",
+            "integrity": "sha1-wih9MZJXffUXrLvW0UUanDw5FPU="
+        },
         "node_modules/sane": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
@@ -17510,6 +18207,25 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
             "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
         },
+        "node_modules/simple-concat": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
         "node_modules/simple-swizzle": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -17867,6 +18583,11 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/speedometer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
+            "integrity": "sha1-zWccsGdSwivKM3Di8zREC+T8YuI="
         },
         "node_modules/split": {
             "version": "0.3.3",
@@ -18976,6 +19697,11 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/toggle-selection": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+            "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
         },
         "node_modules/toidentifier": {
             "version": "1.0.0",
@@ -22520,6 +23246,11 @@
                 }
             }
         },
+        "@emotion/hash": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+            "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+        },
         "@hapi/address": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -22750,6 +23481,11 @@
                 "glob-to-regexp": "^0.3.0"
             }
         },
+        "@navikt/ds-css": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-0.8.4.tgz",
+            "integrity": "sha512-f6GKJx0UL9j/QHRMAEI/1xM85bGeZtKiIIqcoY4D4SXBRIqsnP/iYBIokc9idWOIsGy5kz/uuTRcsQVdBenUMA=="
+        },
         "@navikt/fnrvalidator": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@navikt/fnrvalidator/-/fnrvalidator-1.1.3.tgz",
@@ -22786,6 +23522,16 @@
                 "fastq": "^1.6.0"
             }
         },
+        "@popperjs/core": {
+            "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.1.tgz",
+            "integrity": "sha512-HnUhk1Sy9IuKrxEMdIRCxpIqPw6BFsbYSEUO9p/hNw5sMld/+3OLMWQP80F8/db9qsv3qUjs7ZR5bS/R+iinXw=="
+        },
+        "@rexxars/eventsource-polyfill": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rexxars/eventsource-polyfill/-/eventsource-polyfill-1.0.0.tgz",
+            "integrity": "sha512-YnrybIoM9WFqmeK1D8p/gutqjJnmXCVFWAU3ucka9M7Dzpen3f2Dy4KsC6k1wDHrCtHQuUHHwZovh3i5UPDaZw=="
+        },
         "@samverschueren/stream-to-observable": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
@@ -22794,6 +23540,71 @@
             "requires": {
                 "any-observable": "^0.3.0"
             }
+        },
+        "@sanity/block-content-to-hyperscript": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@sanity/block-content-to-hyperscript/-/block-content-to-hyperscript-3.0.0.tgz",
+            "integrity": "sha512-uoXWLdFY5LqO8A9sFJqnZWWDCBC+0r3Egeh0bwKQ2EK2Vil5L40iJGNXMZhDB8BnvH+6B4155SU8Q3vY59T6pA==",
+            "requires": {
+                "@sanity/generate-help-url": "^0.140.0",
+                "@sanity/image-url": "^0.140.15",
+                "hyperscript": "^2.0.2",
+                "object-assign": "^4.1.1"
+            },
+            "dependencies": {
+                "@sanity/generate-help-url": {
+                    "version": "0.140.0",
+                    "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-0.140.0.tgz",
+                    "integrity": "sha512-H/G/WA9S22TXcXST52CIiTsHx3S2hH0gvK7LnI5w76vfKS0obnDPh8jrPg4xeNRYGPuV9MHYRlyERGpRGoo4Qw=="
+                }
+            }
+        },
+        "@sanity/client": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/@sanity/client/-/client-2.19.0.tgz",
+            "integrity": "sha512-y3VCTXx0z9n9tIroJUBT70rfCZuyJCNmRVZcMjRSjaLCK7vFJHvACX61OkbfbFo9t8r098g8jXP2XttBUiglLQ==",
+            "requires": {
+                "@sanity/eventsource": "2.14.0",
+                "@sanity/generate-help-url": "2.18.0",
+                "@sanity/observable": "2.0.9",
+                "deep-assign": "^2.0.0",
+                "get-it": "^5.0.3",
+                "make-error": "^1.3.0",
+                "object-assign": "^4.1.1"
+            }
+        },
+        "@sanity/eventsource": {
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-2.14.0.tgz",
+            "integrity": "sha512-U1FgPUwB9//bGT5OO1VgtamSCM2Z3vpWP3mCgN8vPmEUJ0cofAWO+turDbOILahuicH8u7Xnmd+GSB33p4Mg9A==",
+            "requires": {
+                "@rexxars/eventsource-polyfill": "^1.0.0",
+                "eventsource": "^1.0.6"
+            }
+        },
+        "@sanity/generate-help-url": {
+            "version": "2.18.0",
+            "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-2.18.0.tgz",
+            "integrity": "sha512-If8Qkw32LWPes16UzqwUsTLgfxF5d4ACdUvCLMl6grJc/5G8LKPAGCQUuA/d1F4W16yCJVV7Zv31HDRDXJSJkg=="
+        },
+        "@sanity/image-url": {
+            "version": "0.140.22",
+            "resolved": "https://registry.npmjs.org/@sanity/image-url/-/image-url-0.140.22.tgz",
+            "integrity": "sha512-CAmQZnj+KM7FSEYiWlIGDit072syicYuAw0w7R2ctMzHiZ4p9mE/g6dBnYqrqFUrw2J+GpJgPt+RVspKP8vdqA=="
+        },
+        "@sanity/observable": {
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/@sanity/observable/-/observable-2.0.9.tgz",
+            "integrity": "sha512-IUpzsEbhOhofTBUu2tiQ4Ymbkmhr6oe4UC4Ds1khZ9Td4t4mzzPGmGQIr5SBEDawz0UD7ZgZAb4LeEzV3hUrtA==",
+            "requires": {
+                "object-assign": "^4.1.1",
+                "rxjs": "^6.5.3"
+            }
+        },
+        "@sanity/timed-out": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@sanity/timed-out/-/timed-out-4.0.2.tgz",
+            "integrity": "sha512-NBDKGj14g9Z+bopIvZcQKWCzJq5JSrdmzRR1CS+iyA3Gm8SnIWBfZa7I3mTg2X6Nu8LQXG0EPKXdOGozLS4i3w=="
         },
         "@sideway/address": {
             "version": "4.1.0",
@@ -23191,8 +24002,7 @@
         "@types/prop-types": {
             "version": "15.7.3",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-            "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-            "dev": true
+            "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
         },
         "@types/q": {
             "version": "1.5.4",
@@ -23212,7 +24022,6 @@
             "version": "16.9.46",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.46.tgz",
             "integrity": "sha512-dbHzO3aAq1lB3jRQuNpuZ/mnu+CdD3H0WVaaBQA8LTT3S33xhVBUj232T8M3tAhSWJs/D/UqORYUlJNl/8VQZg==",
-            "dev": true,
             "requires": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -23267,6 +24076,14 @@
                 "@types/history": "*",
                 "@types/react": "*",
                 "@types/react-router": "*"
+            }
+        },
+        "@types/react-transition-group": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.3.tgz",
+            "integrity": "sha512-fUx5muOWSYP8Bw2BUQ9M9RK9+W1XBK/7FLJ8PTQpnpTEkn0ccyMffyEQvan4C3h53gHdx7KE5Qrxi/LnUGQtdg==",
+            "requires": {
+                "@types/react": "*"
             }
         },
         "@types/sinonjs__fake-timers": {
@@ -24674,6 +25491,11 @@
                 }
             }
         },
+        "browser-split": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.0.tgz",
+            "integrity": "sha1-QUGcrvdpdVkp3VGJZ9PuwKYmJ3E="
+        },
         "browser-stdout": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -25009,6 +25831,11 @@
                 "rsvp": "^4.8.4"
             }
         },
+        "capture-stack-trace": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+            "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw=="
+        },
         "case-sensitive-paths-webpack-plugin": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz",
@@ -25127,6 +25954,14 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "class-list": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/class-list/-/class-list-0.1.1.tgz",
+            "integrity": "sha1-m5dFGSxBebXaCg12M2WOPHDXlss=",
+            "requires": {
+                "indexof": "0.0.1"
+            }
+        },
         "class-utils": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -25149,9 +25984,9 @@
             }
         },
         "classnames": {
-            "version": "2.2.6",
-            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-            "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+            "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
         },
         "clean-css": {
             "version": "4.2.3",
@@ -25291,6 +26126,11 @@
                 "lazy-cache": "^1.0.3",
                 "shallow-clone": "^0.1.2"
             }
+        },
+        "clsx": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+            "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
         },
         "co": {
             "version": "4.6.0",
@@ -25549,6 +26389,14 @@
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
         },
+        "copy-to-clipboard": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+            "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+            "requires": {
+                "toggle-selection": "^1.0.6"
+            }
+        },
         "core-js": {
             "version": "2.6.11",
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
@@ -25614,6 +26462,14 @@
                     "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
                     "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
                 }
+            }
+        },
+        "create-error-class": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+            "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+            "requires": {
+                "capture-stack-trace": "^1.0.0"
             }
         },
         "create-hash": {
@@ -25816,6 +26672,15 @@
             "requires": {
                 "mdn-data": "2.0.4",
                 "source-map": "^0.6.1"
+            }
+        },
+        "css-vendor": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
+            "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
+            "requires": {
+                "@babel/runtime": "^7.8.3",
+                "is-in-browser": "^1.0.2"
             }
         },
         "css-what": {
@@ -26340,6 +27205,29 @@
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
+        "decompress-response": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+            "requires": {
+                "mimic-response": "^1.0.0"
+            }
+        },
+        "deep-assign": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-2.0.0.tgz",
+            "integrity": "sha1-6+BrHwfwja5ZdiDj3RYi83GhxXI=",
+            "requires": {
+                "is-obj": "^1.0.0"
+            },
+            "dependencies": {
+                "is-obj": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+                    "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+                }
+            }
+        },
         "deep-equal": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -26802,6 +27690,182 @@
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "requires": {
                 "once": "^1.4.0"
+            }
+        },
+        "endringslogg": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/endringslogg/-/endringslogg-2.0.4.tgz",
+            "integrity": "sha512-SePqr51tJxt265l6LTU7TW5Pq1T0aGCWmBfiTtQL12MFdL+QpNh6h/Y9X9vLjqsKrr8qIFXhMckkBh3mRJ4A4g==",
+            "requires": {
+                "@navikt/ds-css": "^0.8.1",
+                "@navikt/ds-icons": "^0.5.2",
+                "@navikt/ds-react": "^0.8.0",
+                "@sanity/block-content-to-react": "^3.0.0",
+                "@sanity/client": "^2.15.0",
+                "@sanity/image-url": "^0.140.22",
+                "classnames": "^2.3.1",
+                "prop-types": "^15.7.2",
+                "react-modal": "^3.14.3",
+                "react-transition-group": "^4.4.2"
+            },
+            "dependencies": {
+                "@material-ui/types": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
+                    "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
+                    "requires": {}
+                },
+                "@navikt/ds-icons": {
+                    "version": "0.5.4",
+                    "resolved": "https://registry.npmjs.org/@navikt/ds-icons/-/ds-icons-0.5.4.tgz",
+                    "integrity": "sha512-4lk4CTKZtNkqGJ2wAtJPheaCcwD6hILh6zWICO7071Lu/O+O+qSmxJSGFJmPh4pTAUuPONp6p8jOUqQwTi4yhw==",
+                    "requires": {}
+                },
+                "@navikt/ds-react": {
+                    "version": "0.8.3",
+                    "resolved": "https://registry.npmjs.org/@navikt/ds-react/-/ds-react-0.8.3.tgz",
+                    "integrity": "sha512-M9ryqqKAdzihJap5KGzyLAr44KzKd5hsxk2cWPUXZgfSqkpbbvoR3r1P9bfgrJL0TqnKjsOX8VT7JceQyrOR3A==",
+                    "requires": {
+                        "@material-ui/core": "^4.12.3",
+                        "@navikt/ds-icons": "^0.5.3",
+                        "@popperjs/core": "^2.10.1",
+                        "classnames": "^2.2.6",
+                        "copy-to-clipboard": "^3.3.1",
+                        "react-collapse": "^5.1.0",
+                        "react-merge-refs": "^1.1.0",
+                        "react-modal": "3.14.3",
+                        "react-popper": "^2.2.5",
+                        "uuid": "^8.3.2"
+                    },
+                    "dependencies": {
+                        "@material-ui/core": {
+                            "version": "4.12.3",
+                            "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.3.tgz",
+                            "integrity": "sha512-sdpgI/PL56QVsEJldwEe4FFaFTLUqN+rd7sSZiRCdx2E/C7z5yK0y/khAWVBH24tXwto7I1hCzNWfJGZIYJKnw==",
+                            "requires": {
+                                "@babel/runtime": "^7.4.4",
+                                "@material-ui/styles": "^4.11.4",
+                                "@material-ui/system": "^4.12.1",
+                                "@material-ui/types": "5.1.0",
+                                "@material-ui/utils": "^4.11.2",
+                                "@types/react-transition-group": "^4.2.0",
+                                "clsx": "^1.0.4",
+                                "hoist-non-react-statics": "^3.3.2",
+                                "popper.js": "1.16.1-lts",
+                                "prop-types": "^15.7.2",
+                                "react-is": "^16.8.0 || ^17.0.0",
+                                "react-transition-group": "^4.4.0"
+                            },
+                            "dependencies": {
+                                "@material-ui/styles": {
+                                    "version": "4.11.4",
+                                    "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.4.tgz",
+                                    "integrity": "sha512-KNTIZcnj/zprG5LW0Sao7zw+yG3O35pviHzejMdcSGCdWbiO8qzRgOYL8JAxAsWBKOKYwVZxXtHWaB5T2Kvxew==",
+                                    "requires": {
+                                        "@babel/runtime": "^7.4.4",
+                                        "@emotion/hash": "^0.8.0",
+                                        "@material-ui/types": "5.1.0",
+                                        "@material-ui/utils": "^4.11.2",
+                                        "clsx": "^1.0.4",
+                                        "csstype": "^2.5.2",
+                                        "hoist-non-react-statics": "^3.3.2",
+                                        "jss": "^10.5.1",
+                                        "jss-plugin-camel-case": "^10.5.1",
+                                        "jss-plugin-default-unit": "^10.5.1",
+                                        "jss-plugin-global": "^10.5.1",
+                                        "jss-plugin-nested": "^10.5.1",
+                                        "jss-plugin-props-sort": "^10.5.1",
+                                        "jss-plugin-rule-value-function": "^10.5.1",
+                                        "jss-plugin-vendor-prefixer": "^10.5.1",
+                                        "prop-types": "^15.7.2"
+                                    }
+                                },
+                                "@material-ui/system": {
+                                    "version": "4.12.1",
+                                    "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.1.tgz",
+                                    "integrity": "sha512-lUdzs4q9kEXZGhbN7BptyiS1rLNHe6kG9o8Y307HCvF4sQxbCgpL2qi+gUk+yI8a2DNk48gISEQxoxpgph0xIw==",
+                                    "requires": {
+                                        "@babel/runtime": "^7.4.4",
+                                        "@material-ui/utils": "^4.11.2",
+                                        "csstype": "^2.5.2",
+                                        "prop-types": "^15.7.2"
+                                    }
+                                },
+                                "@material-ui/utils": {
+                                    "version": "4.11.2",
+                                    "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
+                                    "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
+                                    "requires": {
+                                        "@babel/runtime": "^7.4.4",
+                                        "prop-types": "^15.7.2",
+                                        "react-is": "^16.8.0 || ^17.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "react-collapse": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/react-collapse/-/react-collapse-5.1.0.tgz",
+                            "integrity": "sha512-5v0ywsn9HjiR/odNzbRDs0RZfrnbdSippJebWOBCFFDA12Vx8DddrbI4qWVf1P2wTiVagrpcSy07AU0b6+gM9Q==",
+                            "requires": {}
+                        },
+                        "react-popper": {
+                            "version": "2.2.5",
+                            "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+                            "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+                            "requires": {
+                                "react-fast-compare": "^3.0.1",
+                                "warning": "^4.0.2"
+                            }
+                        }
+                    }
+                },
+                "@sanity/block-content-to-react": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/@sanity/block-content-to-react/-/block-content-to-react-3.0.0.tgz",
+                    "integrity": "sha512-oHPLlIsulsnL3ITs93RIvUPBI6nAeoSFOUf16vX4T7z4wWywxP39N1DF9mAx2tV6Kjr1fJAx5GF7zfiMXYLaqA==",
+                    "requires": {
+                        "@sanity/block-content-to-hyperscript": "^3.0.0",
+                        "prop-types": "^15.6.2"
+                    }
+                },
+                "csstype": {
+                    "version": "2.6.18",
+                    "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.18.tgz",
+                    "integrity": "sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ=="
+                },
+                "react-fast-compare": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+                    "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+                },
+                "react-modal": {
+                    "version": "3.14.3",
+                    "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.14.3.tgz",
+                    "integrity": "sha512-+C2KODVKyu20zHXPJxfOOcf571L1u/EpFlH+oS/3YDn8rgVE51QZuxuuIwabJ8ZFnOEHaD+r6XNjqwtxZnXO0g==",
+                    "requires": {
+                        "exenv": "^1.2.0",
+                        "prop-types": "^15.7.2",
+                        "react-lifecycles-compat": "^3.0.0",
+                        "warning": "^4.0.3"
+                    }
+                },
+                "react-transition-group": {
+                    "version": "4.4.2",
+                    "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
+                    "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
+                    "requires": {
+                        "@babel/runtime": "^7.5.5",
+                        "dom-helpers": "^5.0.1",
+                        "loose-envify": "^1.4.0",
+                        "prop-types": "^15.6.2"
+                    }
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+                }
             }
         },
         "enhanced-resolve": {
@@ -28316,6 +29380,11 @@
                 "mime-types": "^2.1.12"
             }
         },
+        "form-urlencoded": {
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-2.0.9.tgz",
+            "integrity": "sha512-fWUzNiOnYa126vFAT6TFXd1mhJrvD8IqmQ9ilZPjkLYQfaRreBr5fIUoOpPlWtqaAG64nzoE7u5zSetifab9IA=="
+        },
         "formik": {
             "version": "2.2.6",
             "resolved": "https://registry.npmjs.org/formik/-/formik-2.2.6.tgz",
@@ -28489,6 +29558,32 @@
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
                 "has-symbols": "^1.0.1"
+            }
+        },
+        "get-it": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/get-it/-/get-it-5.0.5.tgz",
+            "integrity": "sha512-P5McakQI/9611hP0cYqyF0VlhxQj49ok21TvCbNEqBfsVVC/ZnmYPP91bky4N4/Oy1HmXFZ/CMh6CCH8nAgLpQ==",
+            "requires": {
+                "@sanity/timed-out": "^4.0.2",
+                "create-error-class": "^3.0.2",
+                "debug": "^2.6.8",
+                "decompress-response": "^3.3.0",
+                "follow-redirects": "^1.2.4",
+                "form-urlencoded": "^2.0.7",
+                "in-publish": "^2.0.0",
+                "into-stream": "^3.1.0",
+                "is-plain-object": "^2.0.4",
+                "is-retry-allowed": "^1.1.0",
+                "is-stream": "^1.1.0",
+                "nano-pubsub": "^1.0.2",
+                "object-assign": "^4.1.1",
+                "parse-headers": "^2.0.1",
+                "progress-stream": "^2.0.0",
+                "same-origin": "^0.1.1",
+                "simple-concat": "^1.0.0",
+                "tunnel-agent": "^0.6.0",
+                "url-parse": "^1.1.9"
             }
         },
         "get-own-enumerable-property-symbols": {
@@ -28883,6 +29978,14 @@
             "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
             "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg="
         },
+        "html-element": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/html-element/-/html-element-2.3.1.tgz",
+            "integrity": "sha512-xnFt2ZkbFcjc+JoAtg3Hl89VeEZDjododu4VCPkRvFmBTHHA9U1Nt6hLUWfW2O+6Sl/rT1hHK/PivleX3PdBJQ==",
+            "requires": {
+                "class-list": "~0.1.1"
+            }
+        },
         "html-encoding-sniffer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -29043,6 +30146,21 @@
             "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
             "dev": true
         },
+        "hyperscript": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hyperscript/-/hyperscript-2.0.2.tgz",
+            "integrity": "sha1-ODnLpFVUvf4nu4HCFC0WhPgTWvU=",
+            "requires": {
+                "browser-split": "0.0.0",
+                "class-list": "~0.1.0",
+                "html-element": "^2.0.0"
+            }
+        },
+        "hyphenate-style-name": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+            "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+        },
         "iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -29132,6 +30250,11 @@
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
         },
+        "in-publish": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
+            "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ=="
+        },
         "indent-string": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -29141,6 +30264,11 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
             "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+        },
+        "indexof": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+            "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
         },
         "infer-owner": {
             "version": "1.0.4",
@@ -29262,6 +30390,15 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
             "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+        },
+        "into-stream": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+            "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+            "requires": {
+                "from2": "^2.1.1",
+                "p-is-promise": "^1.1.0"
+            }
         },
         "invariant": {
             "version": "2.2.4",
@@ -29427,6 +30564,11 @@
                 "is-extglob": "^2.1.1"
             }
         },
+        "is-in-browser": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+            "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
+        },
         "is-installed-globally": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
@@ -29529,6 +30671,11 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
             "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
+        },
+        "is-retry-allowed": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+            "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
         },
         "is-root": {
             "version": "2.1.0",
@@ -30364,6 +31511,84 @@
                 "verror": "1.10.0"
             }
         },
+        "jss": {
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/jss/-/jss-10.8.0.tgz",
+            "integrity": "sha512-6fAMLJrVQ8epM5ghghxWqCwRR0ZamP2cKbOAtzPudcCMSNdAqtvmzQvljUZYR8OXJIeb/IpZeOXA1sDXms4R1w==",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "csstype": "^3.0.2",
+                "is-in-browser": "^1.1.3",
+                "tiny-warning": "^1.0.2"
+            }
+        },
+        "jss-plugin-camel-case": {
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.8.0.tgz",
+            "integrity": "sha512-yxlXrXwcCdGw+H4BC187dEu/RFyW8joMcWfj8Rk9UPgWTKu2Xh7Sib4iW3xXjHe/t5phOHF1rBsHleHykWix7g==",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "hyphenate-style-name": "^1.0.3",
+                "jss": "10.8.0"
+            }
+        },
+        "jss-plugin-default-unit": {
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.8.0.tgz",
+            "integrity": "sha512-9XJV546cY9zV9OvIE/v/dOaxSi4062VfYQQfwbplRExcsU2a79Yn+qDz/4ciw6P4LV1Naq90U+OffAGRHfNq/Q==",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.8.0"
+            }
+        },
+        "jss-plugin-global": {
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.8.0.tgz",
+            "integrity": "sha512-H/8h/bHd4e7P0MpZ9zaUG8NQSB2ie9rWo/vcCP6bHVerbKLGzj+dsY22IY3+/FNRS8zDmUyqdZx3rD8k4nmH4w==",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.8.0"
+            }
+        },
+        "jss-plugin-nested": {
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.8.0.tgz",
+            "integrity": "sha512-MhmINZkSxyFILcFBuDoZmP1+wj9fik/b9SsjoaggkGjdvMQCES21mj4K5ZnRGVm448gIXyi9j/eZjtDzhaHUYQ==",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.8.0",
+                "tiny-warning": "^1.0.2"
+            }
+        },
+        "jss-plugin-props-sort": {
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.8.0.tgz",
+            "integrity": "sha512-VY+Wt5WX5GMsXDmd+Ts8+O16fpiCM81svbox++U3LDbJSM/g9FoMx3HPhwUiDfmgHL9jWdqEuvSl/JAk+mh6mQ==",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.8.0"
+            }
+        },
+        "jss-plugin-rule-value-function": {
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.8.0.tgz",
+            "integrity": "sha512-R8N8Ma6Oye1F9HroiUuHhVjpPsVq97uAh+rMI6XwKLqirIu2KFb5x33hPj+vNBMxSHc9jakhf5wG0BbQ7fSDOg==",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "jss": "10.8.0",
+                "tiny-warning": "^1.0.2"
+            }
+        },
+        "jss-plugin-vendor-prefixer": {
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.8.0.tgz",
+            "integrity": "sha512-G1zD0J8dFwKZQ+GaZaay7A/Tg7lhDw0iEkJ/iFFA5UPuvZFpMprCMQttXcTBhLlhhWnyZ8YPn4yqp+amrhQekw==",
+            "requires": {
+                "@babel/runtime": "^7.3.1",
+                "css-vendor": "^2.0.8",
+                "jss": "10.8.0"
+            }
+        },
         "jsx-ast-utils": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
@@ -31029,6 +32254,11 @@
                 "semver": "^5.6.0"
             }
         },
+        "make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+        },
         "makeerror": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -31224,6 +32454,11 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+        },
+        "mimic-response": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
         },
         "mini-create-react-context": {
             "version": "0.4.1",
@@ -31595,6 +32830,11 @@
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
             "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
             "optional": true
+        },
+        "nano-pubsub": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/nano-pubsub/-/nano-pubsub-1.0.2.tgz",
+            "integrity": "sha1-NM53b3r5WZFbj3rP6N1rnGbzvek="
         },
         "nanoid": {
             "version": "3.1.12",
@@ -32462,6 +33702,11 @@
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
             "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
         },
+        "p-is-promise": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+            "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+        },
         "p-limit": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -32583,6 +33828,11 @@
                 "pbkdf2": "^3.0.3",
                 "safe-buffer": "^5.1.1"
             }
+        },
+        "parse-headers": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
+            "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw=="
         },
         "parse-json": {
             "version": "4.0.0",
@@ -32780,6 +34030,11 @@
             "requires": {
                 "ts-pnp": "^1.1.6"
             }
+        },
+        "popper.js": {
+            "version": "1.16.1-lts",
+            "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+            "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
         },
         "portfinder": {
             "version": "1.0.28",
@@ -33843,6 +35098,15 @@
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
         },
+        "progress-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-2.0.0.tgz",
+            "integrity": "sha1-+sY6Cz0R3qy7CWmrzJOyFLzhntU=",
+            "requires": {
+                "speedometer": "~1.0.0",
+                "through2": "~2.0.3"
+            }
+        },
         "promise": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
@@ -34246,6 +35510,11 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
             "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+        },
+        "react-merge-refs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
+            "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ=="
         },
         "react-modal": {
             "version": "3.11.2",
@@ -35441,6 +36710,11 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
+        "same-origin": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/same-origin/-/same-origin-0.1.1.tgz",
+            "integrity": "sha1-wih9MZJXffUXrLvW0UUanDw5FPU="
+        },
         "sane": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
@@ -35775,6 +37049,11 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
             "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
         },
+        "simple-concat": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+        },
         "simple-swizzle": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -36086,6 +37365,11 @@
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 }
             }
+        },
+        "speedometer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
+            "integrity": "sha1-zWccsGdSwivKM3Di8zREC+T8YuI="
         },
         "split": {
             "version": "0.3.3",
@@ -37005,6 +38289,11 @@
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
             }
+        },
+        "toggle-selection": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+            "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
         },
         "toidentifier": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "cypress-drag-drop": "^1.1.1",
         "cypress-run": "^1.1.1",
         "cypress-wait-until": "^1.7.1",
+        "endringslogg": "^2.0.4",
         "express": "4.17.1",
         "faker": "4.1.0",
         "formik": "^2.2.6",

--- a/src/topp-meny/topp-meny.tsx
+++ b/src/topp-meny/topp-meny.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import EndringsloggTourWrapper from '../components/endringslogg/endringslogg-tour-wrapper';
 import './lenker.less';
 import Toasts from '../components/toast/toast';
 import {Lenker} from './lenker';
+import {Endringslogg} from 'endringslogg';
+import 'endringslogg/dist/bundle.css';
 import {useSelector} from 'react-redux';
 import {AppState} from '../reducer';
 import {STATUS} from '../ducks/utils';
@@ -24,8 +25,16 @@ function ToppMeny(props: {erPaloggetVeileder?: boolean}) {
         <div className={classNames('topp-meny', erAlertstripeFeilmeldingFeatureTogglePa && 'topp-meny__alertstripe')}>
             <Lenker erPaloggetVeileder={!!props.erPaloggetVeileder} />
             {harDarkModeFeatureToggle && <DarkModeToggle />}
+            <div style={{gridColumn: 4, justifySelf: 'end'}}>
+                <Endringslogg
+                    userId="1"
+                    appId="afolg"
+                    backendUrl="http://localhost:8080"
+                    appName="Arbeidsrettet oppfølging"
+                    alignLeft
+                />
+            </div>
             <Toasts />
-            <EndringsloggTourWrapper />
         </div>
     );
 }


### PR DESCRIPTION
Denne PRen bytter ut den nåværende endringsloggen med en Sanity-basert endringslogg.

Foreløpig er `userId` satt til "1" og backendUrl `localhost:8080`. Endringsloggen henter ut data fra et sanity testprosjekt som inneholder all dataen fra nåværende endringslogg.

![montage](https://user-images.githubusercontent.com/8820347/135258851-e3482795-690e-4abb-9caa-e1d2e5da687d.png)

Merk: PRen fjerner ikke noe av logikken knyttet til den gamle endringsloggen (ligger i `components/endringslogg` og `components/modal/tour-modal`).
