### PR TITLE
FS-214375 flytt datovelger over datofeltet i arbeidslistemodalen

### DIFF
--- a/src/components/modal/arbeidsliste/arbeidsliste.less
+++ b/src/components/modal/arbeidsliste/arbeidsliste.less
@@ -47,7 +47,7 @@
         }
 
         .datovelger__DayPicker {
-            top: 0;
+            top: -22rem;
         }
 
         .modal-footer {


### PR DESCRIPTION
En raskfiks så de som ikke har mulighet til å skrolle uten å klikke (utenfor datovelgeren) kan fortsette sitt gode arbeid! 🖱️ 