### PR TITLE
FS-216531 handter visning av seFlere i egen state for enhetensoversikt

### DIFF
--- a/src/components/toolbar/paginering/paginering-selector.ts
+++ b/src/components/toolbar/paginering/paginering-selector.ts
@@ -8,6 +8,10 @@ export function selectSeFlere(state: AppState): boolean {
     return state.paginering.seFlere;
 }
 
+export function selectSeFlereEnhetensOversikt(state: AppState): boolean {
+    return state.paginering.seFlereEnhetensOversikt;
+}
+
 export function selectSideStorrelse(state: AppState): number {
     return state.paginering.sideStorrelse;
 }

--- a/src/components/toolbar/paginering/paginering.tsx
+++ b/src/components/toolbar/paginering/paginering.tsx
@@ -3,30 +3,37 @@ import {useDispatch, useSelector} from 'react-redux';
 import classNames from 'classnames';
 import KnappPanel from './knapp-panel';
 import {pagineringSetup} from '../../../ducks/paginering';
-import {selectSeFlere, selectSide, selectSideStorrelse} from './paginering-selector';
+import {selectSeFlere, selectSeFlereEnhetensOversikt, selectSide, selectSideStorrelse} from './paginering-selector';
 import './paginering.less';
 import {AppState} from '../../../reducer';
 import {DEFAULT_PAGINERING_STORRELSE, SE_FLERE_PAGINERING_STORRELSE} from '../../../konstanter';
 import {Back, Next} from '@navikt/ds-icons';
-
+import {OversiktType} from '../../../ducks/ui/listevisning';
 
 interface PagineringProps {
     className: string;
     antallTotalt: number;
     onChange?: (fra?: number, til?: number) => void;
+    oversiktType: OversiktType;
 }
 
-function Paginering({className, antallTotalt, onChange}: PagineringProps) {
+function Paginering({className, antallTotalt, onChange, oversiktType}: PagineringProps) {
     const side = useSelector((state: AppState) => selectSide(state));
 
-    const seFlere = useSelector((state: AppState) => selectSeFlere(state));
+    const seFlere = useSelector((state: AppState) =>
+        oversiktType === OversiktType.enhetensOversikt ? selectSeFlereEnhetensOversikt(state) : selectSeFlere(state)
+    );
 
     const sideStorrelse = useSelector((state: AppState) => selectSideStorrelse(state));
 
     const dispatch = useDispatch();
 
     const endrePaginering = (side, seFlere, sideStorrelse) => {
-        dispatch(pagineringSetup({side, seFlere, sideStorrelse}));
+        if (oversiktType === OversiktType.enhetensOversikt) {
+            dispatch(pagineringSetup({side, sideStorrelse, seFlereEnhetensOversikt: seFlere}));
+        } else {
+            dispatch(pagineringSetup({side, seFlere, sideStorrelse}));
+        }
     };
 
     const antallSider: number = Math.ceil(antallTotalt / sideStorrelse) ? Math.ceil(antallTotalt / sideStorrelse) : 1;

--- a/src/components/toolbar/toolbar.tsx
+++ b/src/components/toolbar/toolbar.tsx
@@ -105,6 +105,7 @@ function Toolbar(props: ToolbarProps) {
                     className="toolbar--skille-mellom-elementer"
                     onChange={onPaginering}
                     antallTotalt={antallTotalt}
+                    oversiktType={oversiktType}
                 />
             </div>
         </div>

--- a/src/ducks/paginering.ts
+++ b/src/ducks/paginering.ts
@@ -6,12 +6,14 @@ export const SETUP = 'veilarbportefoljeflatefs/paginering/SETUP';
 export interface PagineringState {
     side: number;
     seFlere: boolean;
+    seFlereEnhetensOversikt: boolean;
     sideStorrelse: number;
 }
 
 const initialState: PagineringState = {
     side: 1,
     seFlere: false,
+    seFlereEnhetensOversikt: false,
     sideStorrelse: DEFAULT_PAGINERING_STORRELSE
 };
 
@@ -28,6 +30,7 @@ export default function pagineringReducer(state = initialState, action) {
 export interface PageringOppdatering {
     side: number;
     seFlere?: boolean;
+    seFlereEnhetensOversikt?: boolean;
     sideStorrelse?: number;
 }
 


### PR DESCRIPTION
**Hva?**
- Fikser bug der knappetekst "vis 200" blir feil dersom man navigerer mellom `enhetensoversikt` og `minoversikt`