### PR TITLE
[JSFIX] Major version upgrade of react-redux from version 7.2.1 to 8.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
                 "react-document-title": "2.0.3",
                 "react-dom": "17.0.2",
                 "react-modal": "3.11.2",
-                "react-redux": "7.2.1",
+                "react-redux": "^8.0.2",
                 "react-router": "^5.2.0",
                 "react-router-dom": "^5.2.0",
                 "react-scripts": "3.4.4",
@@ -3762,7 +3762,6 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
             "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-            "dev": true,
             "dependencies": {
                 "@types/react": "*",
                 "hoist-non-react-statics": "^3.3.0"
@@ -4000,7 +3999,7 @@
             "version": "17.0.11",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
             "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "@types/react": "*"
             }
@@ -4098,6 +4097,11 @@
             "dependencies": {
                 "source-map": "^0.6.1"
             }
+        },
+        "node_modules/@types/use-sync-external-store": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+            "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
         },
         "node_modules/@types/webpack": {
             "version": "4.41.32",
@@ -18364,28 +18368,47 @@
             "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
         },
         "node_modules/react-redux": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.1.tgz",
-            "integrity": "sha512-T+VfD/bvgGTUA74iW9d2i5THrDQWbweXP0AVNI8tNd1Rk5ch1rnMiJkDD67ejw7YBKM4+REvcvqRuWJb7BLuEg==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
+            "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
             "dependencies": {
-                "@babel/runtime": "^7.5.5",
-                "hoist-non-react-statics": "^3.3.0",
-                "loose-envify": "^1.4.0",
-                "prop-types": "^15.7.2",
-                "react-is": "^16.9.0"
+                "@babel/runtime": "^7.12.1",
+                "@types/hoist-non-react-statics": "^3.3.1",
+                "@types/use-sync-external-store": "^0.0.3",
+                "hoist-non-react-statics": "^3.3.2",
+                "react-is": "^18.0.0",
+                "use-sync-external-store": "^1.0.0"
             },
             "peerDependencies": {
-                "react": "^16.8.3",
-                "redux": "^2.0.0 || ^3.0.0 || ^4.0.0-0"
+                "@types/react": "^16.8 || ^17.0 || ^18.0",
+                "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0",
+                "react-native": ">=0.59",
+                "redux": "^4"
             },
             "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                },
                 "react-dom": {
                     "optional": true
                 },
                 "react-native": {
                     "optional": true
+                },
+                "redux": {
+                    "optional": true
                 }
             }
+        },
+        "node_modules/react-redux/node_modules/react-is": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+            "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         },
         "node_modules/react-router": {
             "version": "5.2.0",
@@ -22642,6 +22665,14 @@
                 }
             }
         },
+        "node_modules/use-sync-external-store": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/util": {
             "version": "0.11.1",
             "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -26768,7 +26799,6 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
             "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-            "dev": true,
             "requires": {
                 "@types/react": "*",
                 "hoist-non-react-statics": "^3.3.0"
@@ -26974,7 +27004,7 @@
             "version": "17.0.11",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
             "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "@types/react": "*"
             }
@@ -27072,6 +27102,11 @@
             "requires": {
                 "source-map": "^0.6.1"
             }
+        },
+        "@types/use-sync-external-store": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+            "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
         },
         "@types/webpack": {
             "version": "4.41.32",
@@ -38308,15 +38343,23 @@
             }
         },
         "react-redux": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.1.tgz",
-            "integrity": "sha512-T+VfD/bvgGTUA74iW9d2i5THrDQWbweXP0AVNI8tNd1Rk5ch1rnMiJkDD67ejw7YBKM4+REvcvqRuWJb7BLuEg==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
+            "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
             "requires": {
-                "@babel/runtime": "^7.5.5",
-                "hoist-non-react-statics": "^3.3.0",
-                "loose-envify": "^1.4.0",
-                "prop-types": "^15.7.2",
-                "react-is": "^16.9.0"
+                "@babel/runtime": "^7.12.1",
+                "@types/hoist-non-react-statics": "^3.3.1",
+                "@types/use-sync-external-store": "^0.0.3",
+                "hoist-non-react-statics": "^3.3.2",
+                "react-is": "^18.0.0",
+                "use-sync-external-store": "^1.0.0"
+            },
+            "dependencies": {
+                "react-is": {
+                    "version": "18.2.0",
+                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+                    "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+                }
             }
         },
         "react-router": {
@@ -41661,6 +41704,12 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
             "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+            "requires": {}
+        },
+        "use-sync-external-store": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
             "requires": {}
         },
         "util": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
         "react-document-title": "2.0.3",
         "react-dom": "17.0.2",
         "react-modal": "3.11.2",
-        "react-redux": "7.2.1",
+        "react-redux": "^8.0.2",
         "react-router": "^5.2.0",
         "react-router-dom": "^5.2.0",
         "react-scripts": "3.4.4",


### PR DESCRIPTION
This pull request was created by [mtorp](https://github.com/mtorp) using the JSFIX tool (https://jsfix.live) by Coana.tech (https://coana.tech).
It upgrades react-redux to version 8.0.2.

The JSFIX tool used advanced program analysis to determine how react-redux is used by veilarbportefoljeflatefs and how it is affected by breaking changes in react-redux version 8.0.2 (see details below). JSFIX checked for the 3 breaking changes affecting react-redux version 8.0.2 and found 1 occurrences in veilarbportefoljeflatefs. 1 of the occurrences must be manually audited. 

<strong>Install the [JSFIX GitHub app](https://github.com/apps/jsfix-updater) to receive other package upgrades from JSFIX.</strong>

***

<h3>Breaking change details</h3>

<details open><summary><strong> 🚧 - Not automatically fixed breaking changes (please check before merging)</strong></summary><blockquote class="pr-blockquote"><details open>
<summary>Affects all applications (not related to specific API usages in your code).</summary>

* If you are using Typescript, React-Redux is now written in TS and includes its own types. You should remove any dependencies on @types/react-redux.
</details>

</blockquote></details><details>
<summary>Breaking changes where JSFIX found that there were no occurrences.</summary>

* The connectAdvanced API is now deprecated 
* The pure option for connect has been removed.
</details>



***

<strong>Visit [https://jsfix.live/about-jsfix](https://jsfix.live/about-jsfix) to learn more about how JSFIX works.</strong>


If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request.