### PR TITLE
Tc 233 bumpe radiobuttons og checkboxes del2

### DIFF
--- a/cypress/integration/sidebar_spec.js
+++ b/cypress/integration/sidebar_spec.js
@@ -21,6 +21,8 @@ const aasen = 'Aasen';
 const minstEnVeileder = 'Du må legge til veiledere.';
 let antallVeiledergrupper = 0;
 
+const navDsRadioButtonsSelector = ".navds-radio-buttons"
+
 before('Start server', () => {
     cy.configure();
 });
@@ -235,6 +237,7 @@ describe('Mine filter', () => {
         cy.getByTestId('drag-drop_infotekst').should('not.exist');
 
         cy.getByTestId('mine-filter_radio-container')
+            .get(navDsRadioButtonsSelector)
             .children()
             .last()
             .contains(testFilterNavn);
@@ -260,6 +263,7 @@ describe('Mine filter', () => {
         cy.getByTestId('drag-drop_infotekst').should('not.exist');
 
         cy.getByTestId('mine-filter_radio-container')
+            .get(navDsRadioButtonsSelector)
             .children()
             .last()
             .contains(testFilterNavn);
@@ -277,6 +281,7 @@ describe('Mine filter', () => {
         cy.getByTestId('drag-drop_infotekst').should('not.exist');
 
         cy.getByTestId('mine-filter_radio-container')
+            .get(navDsRadioButtonsSelector)
             .children()
             .first()
             .next()

--- a/cypress/integration/veilederoversikt_spec.js
+++ b/cypress/integration/veilederoversikt_spec.js
@@ -24,6 +24,7 @@ describe('Annen veileder', () => {
         cy.gaTilOversikt('veileder-oversikt');
         cy.getByTestId('veilederoversikt_sok-veileder-input').click();
         cy.getByTestId('veilederoversikt_sok-veileder_veilederliste')
+            .get(".navds-checkboxes")
             .children()
             .should('have.length', 41);
         cy.getByTestId('veilederoversikt_sok-veileder-input').type('Gloslido');
@@ -35,6 +36,7 @@ describe('Annen veileder', () => {
             .clear()
             .type('Glosli');
         cy.getByTestId('veilederoversikt_sok-veileder_veilederliste')
+            .get(".navds-checkboxes")
             .children()
             .should('have.length', 1);
         cy.getByTestId('veileder-checkbox-filterform_nullstill-knapp').should('be.disabled');

--- a/src/components/barinput/barinput-checkbox.tsx
+++ b/src/components/barinput/barinput-checkbox.tsx
@@ -1,34 +1,40 @@
 import React, {ChangeEventHandler} from 'react';
 import {mapFilternavnTilFilterValue} from '../../filtrering/filter-konstanter';
 import './bar.css';
-import {Label} from '@navikt/ds-react';
+import {Checkbox, Label} from '@navikt/ds-react';
 
 interface BarInputCheckboxProps {
+    antall: number;
+    checked: boolean;
     filterNavn: string;
     handleChange: ChangeEventHandler<HTMLInputElement>;
-    checked: boolean;
-    antall: number;
     labelTekst?: React.ReactNode;
+    kompakt?: boolean;
 }
 
-function BarInputCheckbox({filterNavn, handleChange, checked, antall, labelTekst}: BarInputCheckboxProps) {
+function BarInputCheckbox({
+    antall,
+    checked,
+    filterNavn,
+    handleChange,
+    labelTekst,
+    kompakt = false
+}: BarInputCheckboxProps) {
     const filterVerdi = mapFilternavnTilFilterValue[filterNavn];
 
     return (
         <div className="barinput-checkbox">
-            <label className="barlabel__labeltext">
-                <input
-                    data-testid={`filter_checkboks-container_${filterNavn}`}
-                    type="checkbox"
-                    name="ferdigfilter"
-                    id={filterNavn}
-                    value={filterVerdi}
-                    onChange={handleChange}
-                    checked={checked}
-                    className="barinput-checkbox__input"
-                />
+            <Checkbox
+                data-testid={`filter_checkboks-container_${filterNavn}`}
+                name="ferdigfilter"
+                id={filterNavn}
+                value={filterVerdi}
+                onChange={handleChange}
+                checked={checked}
+                size={kompakt ? 'small' : 'medium'}
+            >
                 {labelTekst}
-            </label>
+            </Checkbox>
             {(antall || antall === 0) && (
                 <Label className="barlabel__antall" size="small">
                     {antall}

--- a/src/components/barinput/barinput-checkbox.tsx
+++ b/src/components/barinput/barinput-checkbox.tsx
@@ -9,7 +9,6 @@ interface BarInputCheckboxProps {
     filterNavn: string;
     handleChange: ChangeEventHandler<HTMLInputElement>;
     labelTekst?: React.ReactNode;
-    kompakt?: boolean;
 }
 
 function BarInputCheckbox({
@@ -18,7 +17,6 @@ function BarInputCheckbox({
     filterNavn,
     handleChange,
     labelTekst,
-    kompakt = false
 }: BarInputCheckboxProps) {
     const filterVerdi = mapFilternavnTilFilterValue[filterNavn];
 
@@ -31,7 +29,7 @@ function BarInputCheckbox({
                 value={filterVerdi}
                 onChange={handleChange}
                 checked={checked}
-                size={kompakt ? 'small' : 'medium'}
+                size="small"
             >
                 {labelTekst}
             </Checkbox>

--- a/src/components/barinput/barinput-radio.tsx
+++ b/src/components/barinput/barinput-radio.tsx
@@ -1,17 +1,15 @@
 import React, {ChangeEventHandler} from 'react';
 import {ferdigfilterListe, mapFilternavnTilFilterValue} from '../../filtrering/filter-konstanter';
 import './bar.css';
-import {Radio} from 'nav-frontend-skjema';
-import {Label} from '@navikt/ds-react';
+import {Label, Radio} from '@navikt/ds-react';
 
 interface BarinputRadioProps {
     filterNavn: string;
     handleChange: ChangeEventHandler<HTMLInputElement>;
-    checked?: boolean;
     antall: number;
 }
 
-export const BarInputRadio = ({filterNavn, handleChange, antall, checked}: BarinputRadioProps) => {
+export const BarInputRadio = ({filterNavn, handleChange, antall}: BarinputRadioProps) => {
     const filterVerdi = mapFilternavnTilFilterValue[filterNavn];
     const labelTekst = ferdigfilterListe[filterVerdi];
 
@@ -19,14 +17,15 @@ export const BarInputRadio = ({filterNavn, handleChange, antall, checked}: Barin
         <div className="barinput-radio">
             <Radio
                 className="mine-filter__filternavn"
+                data-testid={`filter_checkboks-container_${filterNavn}`}
                 key={filterNavn}
                 name="ferdigfilter"
-                label={labelTekst}
-                value={filterVerdi}
                 onChange={handleChange}
-                checked={checked}
-                data-testid={`filter_checkboks-container_${filterNavn}`}
-            />
+                value={filterVerdi}
+                size="small"
+            >
+                {labelTekst}
+            </Radio>
             {(antall || antall === 0) && (
                 <Label className="barlabel__antall" size="small">
                     {antall}

--- a/src/components/knapper/rediger-knapp.tsx
+++ b/src/components/knapper/rediger-knapp.tsx
@@ -16,6 +16,7 @@ function RedigerKnapp(props: {aria: string; onClick: () => void; dataTestid?: st
             aria-describedby={props.aria}
             onClick={props.onClick}
             data-testid={props.dataTestid}
+            size="small"
         >
             {hover ? <EditFilled /> : <Edit />}
         </Button>

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -4,13 +4,12 @@ import {connect, useDispatch, useSelector} from 'react-redux';
 import {tildelVeileder} from '../../../ducks/portefolje';
 import {VeilederModell} from '../../../model-interfaces';
 import {AppState} from '../../../reducer';
-import {Radio} from 'nav-frontend-skjema';
 import '../../toolbar/toolbar.css';
 import SokFilter from '../../sok-veiledere/sok-filter';
 import classNames from 'classnames';
 import {nameToStateSliceMap} from '../../../ducks/utils';
 import {useSelectGjeldendeVeileder} from '../../../hooks/portefolje/use-select-gjeldende-veileder';
-import {Button} from '@navikt/ds-react';
+import {Button, Radio, RadioGroup} from '@navikt/ds-react';
 
 interface TildelVeilederProps {
     oversiktType?: string;
@@ -71,19 +70,17 @@ interface TildelVeilederRendererProps {
 function TildelVeilederRenderer({data, onSubmit, ident, onChange, btnOnClick}: TildelVeilederRendererProps) {
     return (
         <form className="skjema radio-filterform" onSubmit={onSubmit} data-testid="tildel-veileder_dropdown">
-            <div className="radio-filterform__valg">
+            <RadioGroup hideLegend legend="" className="radio-filterform__valg" onChange={onChange}>
                 {data.map((veileder, index) => (
                     <Radio
-                        name="veileder"
-                        key={veileder.ident}
-                        label={`${veileder.etternavn}, ${veileder.fornavn}`}
-                        value={veileder.ident}
-                        checked={ident ? ident === veileder.ident : false}
-                        onChange={e => onChange(e.target.value)}
                         data-testid={`tildel-veileder_valg_${index}`}
-                    />
+                        key={veileder.ident}
+                        name="veileder"
+                        size="small"
+                        value={veileder.ident}
+                    >{`${veileder.etternavn}, ${veileder.fornavn}`}</Radio>
                 ))}
-            </div>
+            </RadioGroup>
             <div className="filterform__under-valg">
                 <Button
                     onClick={btnOnClick}

--- a/src/components/modal/veiledergruppe/søk-veiledere-veiledergrupper.tsx
+++ b/src/components/modal/veiledergruppe/søk-veiledere-veiledergrupper.tsx
@@ -3,14 +3,14 @@ import {useSelector} from 'react-redux';
 import '../../../style.css';
 import {AppState} from '../../../reducer';
 import SokFilterVeilederliste from './sok-filter-veilederliste';
-import {Checkbox} from 'nav-frontend-skjema';
+import {CheckboxGroup, Checkbox} from '@navikt/ds-react';
 
 interface SokVeiledereProps {
-    erValgt: (ident: string) => boolean;
-    hanterVeilederValgt: (erValgt: boolean, veilederIdent: string) => void;
+    handterVeiledereValgt: (veilederIdenter: string[]) => void;
+    valgteVeiledere: string[];
 }
 
-function SokVeiledereVeiledergrupper({erValgt, hanterVeilederValgt}: SokVeiledereProps) {
+function SokVeiledereVeiledergrupper({handterVeiledereValgt, valgteVeiledere}: SokVeiledereProps) {
     const veilederePaEnheten = useSelector((state: AppState) => state.veiledere.data.veilederListe);
     const sorterteVeilederePaEtterNavn = veilederePaEnheten.sort((a, b) =>
         a.etternavn && b.etternavn ? a.etternavn.localeCompare(b.etternavn) : 1
@@ -19,19 +19,22 @@ function SokVeiledereVeiledergrupper({erValgt, hanterVeilederValgt}: SokVeileder
     return (
         <SokFilterVeilederliste data={sorterteVeilederePaEtterNavn} label="Velg veiledere:" placeholder="Søk veileder">
             {liste => (
-                <div className="checkbox-filterform__valg">
+                <CheckboxGroup
+                    className="checkbox-filterform__valg"
+                    hideLegend
+                    legend=""
+                    onChange={handterVeiledereValgt}
+                    value={valgteVeiledere}
+                >
                     {liste.map((elem, index) => (
                         <Checkbox
-                            role="checkbox"
-                            key={elem.ident}
-                            label={`${elem.etternavn}, ${elem.fornavn}`}
-                            value={elem.ident}
-                            checked={erValgt(elem.ident)}
-                            onChange={e => hanterVeilederValgt(e.target.checked, e.target.value)}
                             data-testid={`veiledergruppe_modal_veileder-checkbox_${index}`}
-                        />
+                            key={elem.ident}
+                            value={elem.ident}
+                            size="small"
+                        >{`${elem.etternavn}, ${elem.fornavn}`}</Checkbox>
                     ))}
-                </div>
+                </CheckboxGroup>
             )}
         </SokFilterVeilederliste>
     );

--- a/src/components/modal/veiledergruppe/veiledergruppe-form.tsx
+++ b/src/components/modal/veiledergruppe/veiledergruppe-form.tsx
@@ -7,7 +7,7 @@ import {BodyShort, TextField} from '@navikt/ds-react';
 
 interface VeiledergruppeFormProps {
     filterValg: FiltervalgModell;
-    hanterVeilederChange: (erValgt: boolean, veilederIdent: string) => void;
+    hanterVeilederChange: (veilederIdent: string[]) => void;
     gruppeNavn: string;
     setGruppeNavn: (nyttNavn: string) => void;
     modalTittel: string;
@@ -32,8 +32,8 @@ function VeiledergruppeForm(props: PropsWithChildren<VeiledergruppeFormProps>) {
             />
             <div className="veiledergruppe-modal__sokefilter">
                 <SokVeiledereVeiledergrupper
-                    erValgt={ident => (props.filterValg.veiledere ? props.filterValg.veiledere.includes(ident) : false)}
-                    hanterVeilederValgt={props.hanterVeilederChange}
+                    handterVeiledereValgt={props.hanterVeilederChange}
+                    valgteVeiledere={props.filterValg.veiledere}
                 />
             </div>
             <BodyShort
@@ -47,7 +47,11 @@ function VeiledergruppeForm(props: PropsWithChildren<VeiledergruppeFormProps>) {
             </BodyShort>
             <ValgtVeiledergruppeListe
                 valgteVeileder={props.filterValg.veiledere}
-                fjernValgtVeileder={veilederTarget => props.hanterVeilederChange(false, veilederTarget)}
+                fjernValgtVeileder={veilederTarget =>
+                    props.hanterVeilederChange(
+                        props.filterValg.veiledere.filter(veileder => veileder !== veilederTarget)
+                    )
+                }
                 feil={props.errors.filterValg}
             />
             {props.children}

--- a/src/components/modal/veiledergruppe/veiledergruppe-modal.css
+++ b/src/components/modal/veiledergruppe/veiledergruppe-modal.css
@@ -90,12 +90,6 @@
     border-radius: 0.25rem;
     grid-template-columns: 1fr 1fr;
 }
-.veiledergruppe-modal__sokefilter .checkbox-filterform__valg .navds-checkbox {
-    margin-left: 1rem;
-}
-.veiledergruppe-modal__sokefilter .checkbox-filterform__valg .navds-checkbox label {
-    padding-bottom: 0;
-}
 .veiledergruppe-modal__sokefilter .checkbox-filterform__alertstripe {
     max-height: 13rem;
     min-height: 13rem;

--- a/src/components/modal/veiledergruppe/veiledergruppe-modal.tsx
+++ b/src/components/modal/veiledergruppe/veiledergruppe-modal.tsx
@@ -62,19 +62,6 @@ export function VeiledergruppeModal(props: VeilederModalProps) {
         setHarForsoktSubmitte(false);
     }, [props.initialVerdi.filterValg, props.initialVerdi.gruppeNavn]);
 
-    const fjernVeiledereFraListen = (veilederTarget: string) => {
-        setFilterValg(prevState => ({
-            ...prevState,
-            veiledere: prevState.veiledere.filter(v => v !== veilederTarget)
-        }));
-        if (harForsoktSubmitte) {
-            validate(gruppeNavn, {
-                ...filterValg,
-                veiledere: filterValg.veiledere.filter(v => v !== veilederTarget)
-            });
-        }
-    };
-
     const hanterGruppeNavnChange = (nyttNavn: string) => {
         setGruppeNavn(nyttNavn);
         if (harForsoktSubmitte) {
@@ -82,20 +69,16 @@ export function VeiledergruppeModal(props: VeilederModalProps) {
         }
     };
 
-    const handleChange = (erValgt: boolean, veilederTarget: string) => {
-        if (erValgt) {
-            setFilterValg(prevState => ({
-                ...prevState,
-                veiledere: [...prevState.veiledere, veilederTarget]
-            }));
-            if (harForsoktSubmitte) {
-                validate(gruppeNavn, {
-                    ...filterValg,
-                    veiledere: [...filterValg.veiledere, veilederTarget]
-                });
-            }
-        } else {
-            fjernVeiledereFraListen(veilederTarget);
+    const handleChange = (valgteVeiledere: string[]) => {
+        setFilterValg(prevState => ({
+            ...prevState,
+            veiledere: [...valgteVeiledere]
+        }));
+        if (harForsoktSubmitte) {
+            validate(gruppeNavn, {
+                ...filterValg,
+                veiledere: [...filterValg.veiledere]
+            });
         }
     };
 

--- a/src/components/sok-veiledere/sok-veiledere.tsx
+++ b/src/components/sok-veiledere/sok-veiledere.tsx
@@ -4,14 +4,13 @@ import {AppState} from '../../reducer';
 import '../../filtrering/filtrering-filter/filterform/filterform.css';
 import '../../style.css';
 import SokFilter from './sok-filter';
-import {Button} from '@navikt/ds-react';
-import {Checkbox} from 'nav-frontend-skjema';
+import {Button, Checkbox, CheckboxGroup} from '@navikt/ds-react';
 
 interface SokVeiledereProps {
-    erValgt: (ident: string) => boolean;
-    hanterVeilederValgt: (erValgt: boolean, veilederIdent: string) => void;
+    handterVeiledereValgt: (veilederIdenter: string[]) => void;
     btnOnClick: () => void;
     harValg: boolean;
+    valgteVeiledere: string[];
 }
 
 function SokVeiledere(props: SokVeiledereProps) {
@@ -24,18 +23,22 @@ function SokVeiledere(props: SokVeiledereProps) {
         <SokFilter placeholder="Søk veileder" data={sorterteVeilederePaEtterNavn}>
             {liste => (
                 <div className="checkbox-filterform">
-                    <div className="checkbox-filterform__valg">
+                    <CheckboxGroup
+                        className="checkbox-filterform__valg"
+                        hideLegend
+                        legend=""
+                        onChange={props.handterVeiledereValgt}
+                        value={props.valgteVeiledere}
+                    >
                         {liste.map((elem, index) => (
                             <Checkbox
-                                key={elem.ident}
-                                label={`${elem.etternavn}, ${elem.fornavn}`}
-                                value={elem.ident}
-                                checked={props.erValgt(elem.ident)}
-                                onChange={e => props.hanterVeilederValgt(e.target.checked, e.target.value)}
                                 data-testid={`sok-veileder_rad_${index}`}
-                            />
+                                key={elem.ident}
+                                size="small"
+                                value={elem.ident}
+                            >{`${elem.etternavn}, ${elem.fornavn}`}</Checkbox>
                         ))}
-                    </div>
+                    </CheckboxGroup>
                     <div className=" filterform__under-valg">
                         <Button
                             onClick={props.btnOnClick}

--- a/src/components/toolbar/listevisning/listevisning-rad.tsx
+++ b/src/components/toolbar/listevisning/listevisning-rad.tsx
@@ -2,7 +2,7 @@ import {Kolonne} from '../../../ducks/ui/listevisning';
 import {alternativerConfig} from './listevisning-utils';
 import {ChangeEvent} from 'react';
 import * as React from 'react';
-import {Checkbox} from 'nav-frontend-skjema';
+import {Checkbox} from '@navikt/ds-react';
 
 interface ListevisningRadProps {
     kolonneoverskrift: Kolonne;
@@ -22,16 +22,17 @@ function ListevisningRad(props: ListevisningRadProps) {
     return (
         <li>
             <Checkbox
-                label={alternativ.tekstlabel}
-                value={kolonneoverskrift}
                 checked={props.valgt}
-                disabled={props.disabled || alternativ.checkboxDisabled}
+                data-testid={`velg-kolonne-rad_${kolonneoverskrift}`}
+                disabled={props.disabled}
                 onChange={(e: ChangeEvent<HTMLInputElement>) =>
                     props.onChange(props.kolonneoverskrift, e.target.checked)
                 }
-                data-testid={`velg-kolonne-rad_${kolonneoverskrift}`}
-                role="checkbox"
-            />
+                size="small"
+                value={kolonneoverskrift}
+            >
+                {alternativ.tekstlabel}
+            </Checkbox>
         </li>
     );
 }

--- a/src/components/toolbar/listevisning/listevisning-utils.ts
+++ b/src/components/toolbar/listevisning/listevisning-utils.ts
@@ -2,7 +2,6 @@ import {Kolonne} from '../../../ducks/ui/listevisning';
 
 export interface Alternativ {
     tekstlabel: string;
-    checkboxDisabled?: boolean;
 }
 
 export const alternativerConfig = new Map<Kolonne, Alternativ>();

--- a/src/components/toolbar/sok-veileder.tsx
+++ b/src/components/toolbar/sok-veileder.tsx
@@ -37,11 +37,6 @@ function SokVeilederFilter(props: AllProps) {
 
     const harValg = valgteVeileder.length > 0;
 
-    const hanterChange = (erValgt, veilederTarget) =>
-        erValgt
-            ? setValgteVeileder([veilederTarget, ...valgteVeileder])
-            : setValgteVeileder(valgteVeileder.filter(veileder => veileder !== veilederTarget));
-
     const createHandleOnSubmit = (filterverdi: string[]) => {
         props.onClick();
         if (harValg) {
@@ -53,10 +48,10 @@ function SokVeilederFilter(props: AllProps) {
 
     return (
         <SokVeiledere
-            erValgt={ident => valgteVeileder.includes(ident)}
-            hanterVeilederValgt={hanterChange}
+            handterVeiledereValgt={setValgteVeileder}
             btnOnClick={() => createHandleOnSubmit(valgteVeileder)}
             harValg={harValg}
+            valgteVeiledere={valgteVeileder}
         />
     );
 }

--- a/src/components/toolbar/velgalle-checkboks.tsx
+++ b/src/components/toolbar/velgalle-checkboks.tsx
@@ -3,33 +3,29 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {markerAlleBrukere} from '../../ducks/portefolje';
 import './toolbar.css';
-import {Checkbox} from 'nav-frontend-skjema';
+import {Checkbox} from '@navikt/ds-react';
 
 interface VelgalleCheckboksProps {
-    skalVises: boolean;
     disabled: boolean;
     alleMarkert: boolean;
     markerAlle: (markert: boolean) => void;
     className: string;
 }
 
-function VelgAlleCheckboks({skalVises, disabled, markerAlle, alleMarkert, className}: VelgalleCheckboksProps) {
-    if (!skalVises) {
-        return null;
-    }
+function VelgAlleCheckboks({disabled, markerAlle, alleMarkert, className}: VelgalleCheckboksProps) {
     const onClickHandler = () => markerAlle(!alleMarkert);
 
     return (
         <Checkbox
-            label={''}
             className={className}
             checked={alleMarkert}
             disabled={disabled}
+            hideLabel
             onChange={onClickHandler}
-            title="Velg alle checkbox"
-            aria-label="Velg alle checkboxer"
-            role="checkbox"
-        />
+            size="small"
+        >
+            Velg alle
+        </Checkbox>
     );
 }
 

--- a/src/enhetsportefolje/brukerliste.css
+++ b/src/enhetsportefolje/brukerliste.css
@@ -26,11 +26,7 @@
     align-items: center;
 }
 .veilarbportefoljeflatefs .brukerliste__innhold .velgalle-checkboks {
-    height: 1.5rem;
-    margin-bottom: 0;
-}
-.veilarbportefoljeflatefs .brukerliste__innhold .velgalle-checkboks .skjemaelement__label {
-    height: 1.5rem;
+    padding-right: var(--navds-spacing-2);
 }
 .veilarbportefoljeflatefs .brukerliste .arbeidsliste--ikon {
     margin: 7px 5px 0;
@@ -81,7 +77,7 @@
     margin-right: 8px;
 }
 .veilarbportefoljeflatefs .brukerliste__checkbox {
-    bottom: 12px;
+    padding-right: var(--navds-spacing-2);
 }
 .veilarbportefoljeflatefs .brukerliste__etiketter {
     width: 100%;

--- a/src/enhetsportefolje/enhet-brukerpanel.tsx
+++ b/src/enhetsportefolje/enhet-brukerpanel.tsx
@@ -10,7 +10,7 @@ import './brukerliste.css';
 import {OrNothing} from '../utils/types/types';
 import {useFeatureSelector} from '../hooks/redux/use-feature-selector';
 import {VEDTAKSTOTTE} from '../konstanter';
-import {Checkbox} from 'nav-frontend-skjema';
+import {Checkbox} from '@navikt/ds-react';
 
 interface EnhetBrukerpanelProps {
     bruker: BrukerModell;
@@ -55,12 +55,14 @@ function EnhetBrukerpanel({
             <div className="brukerliste__gutter-left">
                 <Checkbox
                     checked={bruker.markert}
-                    disabled={bruker.fnr === ''}
-                    onChange={() => settMarkert(bruker.fnr, !bruker.markert)}
-                    label=""
-                    role="checkbox"
                     className="brukerliste__checkbox"
-                />
+                    disabled={bruker.fnr === ''}
+                    hideLabel
+                    onChange={() => settMarkert(bruker.fnr, !bruker.markert)}
+                    size="small"
+                >
+                    {''}
+                </Checkbox>
             </div>
             <EnhetKolonner
                 className="brukerliste__innhold flex flex--center"

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -12,7 +12,7 @@ import {
     ytelseUtlopsSortering
 } from '../filtrering/filter-konstanter';
 import {FiltervalgModell, Sorteringsfelt, Sorteringsrekkefolge} from '../model-interfaces';
-import {Kolonne, OversiktType} from '../ducks/ui/listevisning';
+import {Kolonne} from '../ducks/ui/listevisning';
 import {AktiviteterValg} from '../ducks/filtrering';
 import Header from '../components/tabell/header';
 import VelgalleCheckboks from '../components/toolbar/velgalle-checkboks';
@@ -36,7 +36,6 @@ interface EnhetListehodeProps {
     valgteKolonner: Kolonne[];
     filtervalg: FiltervalgModell;
     sorteringsfelt: OrNothing<Sorteringsfelt>;
-    oversiktType: OversiktType;
 }
 
 function EnhetListehode({
@@ -44,8 +43,7 @@ function EnhetListehode({
     sorteringOnClick,
     filtervalg,
     sorteringsfelt,
-    valgteKolonner,
-    oversiktType
+    valgteKolonner
 }: EnhetListehodeProps) {
     const {ytelse} = filtervalg;
     const erAapYtelse = Object.keys(ytelseAapSortering).includes(ytelse!);
@@ -69,10 +67,7 @@ function EnhetListehode({
         <div className="brukerliste__header brukerliste__sorteringheader">
             <div className="brukerliste__gutter-left" />
             <div className="brukerliste__innhold" data-testid="brukerliste_innhold">
-                <VelgalleCheckboks
-                    skalVises={oversiktType in OversiktType}
-                    className="velgalle-checkboks col col-xs-2"
-                />
+                <VelgalleCheckboks className="velgalle-checkboks" />
                 <SorteringHeader
                     sortering={Sorteringsfelt.ETTERNAVN}
                     onClick={sorteringOnClick}

--- a/src/enhetsportefolje/enhetsportefolje-tabelloverskrift.tsx
+++ b/src/enhetsportefolje/enhetsportefolje-tabelloverskrift.tsx
@@ -19,7 +19,6 @@ function EnhetTabellOverskrift() {
             filtervalg={filtervalg}
             sorteringsfelt={sorteringsfelt}
             valgteKolonner={listevisning.valgte}
-            oversiktType={OversiktType.enhetensOversikt}
         />
     );
 }

--- a/src/filtrering/filtrering-filter/filterform/aktiviteter-filterform/aktivitet-filterform-avansert.tsx
+++ b/src/filtrering/filtrering-filter/filterform/aktiviteter-filterform/aktivitet-filterform-avansert.tsx
@@ -3,7 +3,7 @@ import '../filterform.css';
 import NullstillKnapp from '../../../../components/nullstill-valg-knapp/nullstill-knapp';
 import {Dictionary} from '../../../../utils/types/types';
 import {FiltervalgModell} from '../../../../model-interfaces';
-import {BodyShort, Button, Label} from '@navikt/ds-react';
+import {BodyShort, Button, Label, Radio, RadioGroup} from '@navikt/ds-react';
 
 interface AktivitetFilterformProps {
     valg: Dictionary<string>;
@@ -48,42 +48,26 @@ function AktivitetFilterformAvansert({
                 {Object.entries(valg).map(([kode, verdi]) => [
                     <div key={kode} className="aktivitetvalg">
                         <BodyShort size="small">{verdi as string}</BodyShort>
-                        <div className="radioknapp-gruppe">
-                            <input
-                                id={`aktivitet-${kode}-ja`}
-                                name={kode}
-                                value="JA"
-                                type="radio"
-                                checked={valgteAvanserteAktiviteter[kode] === 'JA'}
-                                className="skjemaelement__input radioknapp"
-                                onChange={() => handleChange(kode, 'JA')}
-                                key={`Ja, ${verdi}`}
-                                data-testid={`aktivitet-filterform-${kode}-ja`}
-                            />
-                            <label
-                                htmlFor={`aktivitet-${kode}-ja`}
-                                className="skjemaelement__label aktivitet_radioknapp_label"
-                            >
-                                <span className="sr-only">Ja, {verdi}</span>
-                            </label>
-                            <input
-                                id={`aktivitet-${kode}-nei`}
-                                name={kode}
-                                value="NEI"
-                                type="radio"
-                                checked={valgteAvanserteAktiviteter[kode] === 'NEI'}
-                                className="skjemaelement__input radioknapp"
-                                onChange={() => handleChange(kode, 'NEI')}
-                                key={`NEI, ${verdi}`}
+                        <RadioGroup
+                            legend=""
+                            hideLegend
+                            onChange={(verdi: string) => handleChange(kode, verdi)}
+                            value={valgteAvanserteAktiviteter[kode]}
+                        >
+                            <Radio data-testid={`aktivitet-filterform-${kode}-ja`} name={kode} size="small" value="JA">
+                                {/* Radio har (per 18.08.22) ikke støtte for å skjule label - gjør derfor dette manuelt */}
+                                <span className="navds-sr-only">Ja, {verdi}</span>
+                            </Radio>
+                            <Radio
                                 data-testid={`aktivitet-filterform-${kode}-nei`}
-                            />
-                            <label
-                                htmlFor={`aktivitet-${kode}-nei`}
-                                className="skjemaelement__label aktivitet_radioknapp_label"
+                                name={kode}
+                                size="small"
+                                value="NEI"
                             >
-                                <span className="sr-only">Nei, {verdi}</span>
-                            </label>
-                        </div>
+                                {/* Radio har (per 18.08.22) ikke støtte for å skjule label - gjør derfor dette manuelt */}
+                                <span className="navds-sr-only">Nei, {verdi}</span>
+                            </Radio>
+                        </RadioGroup>
                     </div>
                 ])}
             </div>

--- a/src/filtrering/filtrering-filter/filterform/aktiviteter-filterform/aktivitet-filterform-forenklet.tsx
+++ b/src/filtrering/filtrering-filter/filterform/aktiviteter-filterform/aktivitet-filterform-forenklet.tsx
@@ -23,30 +23,28 @@ function AktivitetFilterformForenklet({
     valgteForenkledeAktiviteter,
     harAvanserteAktiviteter
 }: AktivitetFilterformProps) {
-    const velgCheckBox = e => {
-        e.persist();
+    const velgCheckBox = (filtre: string[]) => {
         if (harAvanserteAktiviteter) {
             nullstillAvanserteAktiviteter();
         }
-        return e.target.checked
-            ? endreFiltervalg('aktiviteterForenklet', [...valgteForenkledeAktiviteter, e.target.value])
-            : endreFiltervalg(
-                  'aktiviteterForenklet',
-                  valgteForenkledeAktiviteter.filter(value => value !== e.target.value)
-              );
+        endreFiltervalg('aktiviteterForenklet', filtre);
     };
 
     return (
         <form className="skjema aktivitetfilterform-forenklet" data-testid="aktivitet-filterform-forenklet">
-            <CheckboxGroup legend="" size="small">
+            <CheckboxGroup
+                hideLegend
+                legend=""
+                size="small"
+                onChange={velgCheckBox}
+                value={valgteForenkledeAktiviteter}
+            >
                 {Object.entries(valg).map(([filterKey, filterValue]) => (
                     <Checkbox
-                        key={filterKey}
                         className="aktivitetvalg"
-                        onChange={e => velgCheckBox(e)}
-                        value={filterKey}
-                        checked={valgteForenkledeAktiviteter.includes(filterKey)}
                         data-testid={`aktivitet-forenklet_${filterKey}`}
+                        key={filterKey}
+                        value={filterKey}
                     >
                         {filterValue}
                     </Checkbox>

--- a/src/filtrering/filtrering-filter/filterform/alder-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/alder-filterform.tsx
@@ -7,7 +7,7 @@ import './filterform.css';
 import {logEvent} from '../../../utils/frontend-logger';
 import {finnSideNavn} from '../../../middleware/metrics-middleware';
 import NullstillKnapp from '../../../components/nullstill-valg-knapp/nullstill-knapp';
-import {BodyShort, Button, TextField} from '@navikt/ds-react';
+import {BodyShort, Button, Checkbox, CheckboxGroup, TextField} from '@navikt/ds-react';
 
 interface AlderFilterformProps {
     form: string;
@@ -43,28 +43,18 @@ function AlderFilterform({endreFiltervalg, valg, closeDropdown, form, filtervalg
         });
     }, [filtervalg, form, valg]);
 
-    const velgCheckBox = e => {
+    const submitCheckBoxValg = (checkboxValg: string[]) => {
         setInputAlderTil('');
         setInputAlderFra('');
         setFeil(false);
-        e.persist();
-        return e.target.checked
-            ? setCheckBoxValg(prevState => [...prevState, e.target.value])
-            : setCheckBoxValg(prevState => prevState.filter(value => value !== e.target.value));
-    };
 
-    const submitCheckBox = e => {
-        velgCheckBox(e);
+        setCheckBoxValg(checkboxValg);
+        endreFiltervalg(form, checkboxValg);
+
         logEvent('portefolje.metrikker.aldersfilter', {
             checkbox: true,
             sideNavn: finnSideNavn()
         });
-        return e.target.checked
-            ? endreFiltervalg(form, [...checkBoxValg, e.target.value])
-            : endreFiltervalg(
-                  form,
-                  checkBoxValg.filter(value => value !== e.target.value)
-              );
     };
 
     const onChangeInput = (e, til) => {
@@ -109,15 +99,18 @@ function AlderFilterform({endreFiltervalg, valg, closeDropdown, form, filtervalg
             });
         }
     };
+
     const fjernTegn = e => {
         (e.key === 'e' || e.key === '.' || e.key === ',' || e.key === '-' || e.key === '+') && e.preventDefault();
     };
+
     const nullstillValg = () => {
         setInputAlderFra('');
         setInputAlderTil('');
         setCheckBoxValg([]);
         endreFiltervalg(form, []);
     };
+
     return (
         <form
             className="skjema checkbox-filterform"
@@ -129,24 +122,15 @@ function AlderFilterform({endreFiltervalg, valg, closeDropdown, form, filtervalg
             {harValg && (
                 <>
                     <div className={classNames('checkbox-filterform__valg', className)}>
-                        <Grid columns={2}>
-                            {Object.entries(valg).map(([filterKey, filterValue]) => (
-                                <div className="skjemaelement skjemaelement--horisontal" key={filterKey}>
-                                    <input
-                                        id={filterKey}
-                                        type="checkbox"
-                                        className="skjemaelement__input checkboks"
-                                        value={filterKey}
-                                        checked={checkBoxValg.includes(filterKey)}
-                                        onChange={e => submitCheckBox(e)}
-                                        data-testid={`filter_${filterKey}`}
-                                    />
-                                    <label htmlFor={filterKey} className="skjemaelement__label">
+                        <CheckboxGroup hideLegend legend="" value={checkBoxValg} onChange={submitCheckBoxValg}>
+                            <Grid columns={2}>
+                                {Object.entries(valg).map(([filterKey, filterValue]) => (
+                                    <Checkbox data-testid={`filter_${filterKey}`} size="small" value={filterKey}>
                                         {filterValue}
-                                    </label>
-                                </div>
-                            ))}
-                        </Grid>
+                                    </Checkbox>
+                                ))}
+                            </Grid>
+                        </CheckboxGroup>
                     </div>
                     <hr className="alder-border" />
                     <div className={classNames('alder-input', feil && 'alder-input__validering')}>

--- a/src/filtrering/filtrering-filter/filterform/alder-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/alder-filterform.tsx
@@ -125,7 +125,7 @@ function AlderFilterform({endreFiltervalg, valg, closeDropdown, form, filtervalg
                         <CheckboxGroup hideLegend legend="" value={checkBoxValg} onChange={submitCheckBoxValg}>
                             <Grid columns={2}>
                                 {Object.entries(valg).map(([filterKey, filterValue]) => (
-                                    <Checkbox data-testid={`filter_${filterKey}`} size="small" value={filterKey}>
+                                    <Checkbox data-testid={`filter_${filterKey}`} key={filterKey} size="small" value={filterKey}>
                                         {filterValue}
                                     </Checkbox>
                                 ))}

--- a/src/filtrering/filtrering-filter/filterform/checkbox-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/checkbox-filterform.tsx
@@ -35,16 +35,6 @@ function CheckboxFilterform({
         setCheckBoxValg(filtervalg[form]);
     }, [filtervalg, form]);
 
-    const velgCheckBox = e => {
-        e.persist();
-        return e.target.checked
-            ? endreFiltervalg(form, [...checkBoxValg, e.target.value])
-            : endreFiltervalg(
-                  form,
-                  checkBoxValg.filter(value => value !== e.target.value)
-              );
-    };
-
     const nullstillValg = () => {
         endreFiltervalg(form, []);
     };
@@ -54,27 +44,39 @@ function CheckboxFilterform({
             {harValg && (
                 <div className={classNames('checkbox-filterform__valg', className)}>
                     <Grid columns={gridColumns}>
-                        <CheckboxGroup legend="" value={checkBoxValg} size="small">
-                        {Object.entries(valg).map(([filterKey, filterValue]) =>
-                            tooltips && tooltips[filterKey] ? (
-                                <Tooltip
-                                    content={tooltips[filterKey]}
-                                    placement="right"
-                                    offset={-130}
-                                    maxChar={999}
-                                    key={`tooltip-${filterKey}`}
-                                >
-                                    <Checkbox key={filterKey} value={filterKey} onChange={velgCheckBox} data-testid={`filter_${filterKey}`}>
+                        <CheckboxGroup
+                            hideLegend
+                            legend=""
+                            onChange={(filtre: string[]) => endreFiltervalg(form, filtre)}
+                            size="small"
+                            value={checkBoxValg}
+                        >
+                            {Object.entries(valg).map(([filterKey, filterValue]) =>
+                                tooltips && tooltips[filterKey] ? (
+                                    <Tooltip
+                                        content={tooltips[filterKey]}
+                                        placement="right"
+                                        offset={-130}
+                                        maxChar={999}
+                                        key={`tooltip-${filterKey}`}
+                                    >
+                                        {/* Wrapper i div for at Tooltip-en skal legge seg ved label-en og ikke rett ved checkbox-en */}
+                                        <div>
+                                            <Checkbox
+                                                data-testid={`filter_${filterKey}`}
+                                                key={filterKey}
+                                                value={filterKey}
+                                            >
+                                                {filterValue}
+                                            </Checkbox>
+                                        </div>
+                                    </Tooltip>
+                                ) : (
+                                    <Checkbox data-testid={`filter_${filterKey}`} key={filterKey} value={filterKey}>
                                         {filterValue}
                                     </Checkbox>
-
-                                </Tooltip>
-                            ) : (
-                              <Checkbox key={filterKey} value={filterKey} onChange={velgCheckBox} data-testid={`filter_${filterKey}`}>
-                                  {filterValue}
-                              </Checkbox>
-                            )
-                        )}
+                                )
+                            )}
                         </CheckboxGroup>
                     </Grid>
                 </div>

--- a/src/filtrering/filtrering-filter/filterform/double-checkbox-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/double-checkbox-filterform.tsx
@@ -5,7 +5,7 @@ import './filterform.css';
 import classNames from 'classnames';
 import {utdanningBestatt, utdanningGodkjent} from '../../filter-konstanter';
 import NullstillKnapp from '../../../components/nullstill-valg-knapp/nullstill-knapp';
-import {Label} from '@navikt/ds-react';
+import {Checkbox, CheckboxGroup, Label} from '@navikt/ds-react';
 import Grid from '../../../components/grid/grid';
 
 interface DoubleCheckboxFilterformProps {
@@ -36,24 +36,11 @@ function DoubleCheckboxFilterform({endreFiltervalg, filtervalg, className}: Doub
         setCheckBoxValgBestatt(filtervalg[formUtdanningBestatt]);
     }, [filtervalg]);
 
-    const velgCheckBox = (e, typeForm) => {
-        e.persist();
-        const id = e.target.value.replace(`${typeForm}_`, '');
-        if (typeForm === formUtdanningGodkjent)
-            return e.target.checked
-                ? endreFiltervalg(formUtdanningGodkjent, [...checkBoxValgGodkjent, id])
-                : endreFiltervalg(
-                      formUtdanningGodkjent,
-                      checkBoxValgGodkjent.filter(value => value !== id)
-                  );
-        else if (typeForm === formUtdanningBestatt)
-            return e.target.checked
-                ? endreFiltervalg(formUtdanningBestatt, [...checkBoxValgBestatt, id])
-                : endreFiltervalg(
-                      formUtdanningBestatt,
-                      checkBoxValgBestatt.filter(value => value !== id)
-                  );
-        return;
+    const velgCheckBox = (valg: string[], typeForm) => {
+        endreFiltervalg(
+            typeForm,
+            valg.map(v => v.replace(`${typeForm}_`, ''))
+        );
     };
 
     const nullstillValg = () => {
@@ -76,7 +63,7 @@ function DoubleCheckboxFilterform({endreFiltervalg, filtervalg, className}: Doub
                         <RenderFields
                             valg={uniqueValgGodkjent}
                             form={formUtdanningGodkjent}
-                            velgCheckBox={e => velgCheckBox(e, formUtdanningGodkjent)}
+                            velgCheckBox={(valg: string[]) => velgCheckBox(valg, formUtdanningGodkjent)}
                             checkBoxValg={checkBoxValgGodkjent}
                         />
                     </div>
@@ -92,7 +79,7 @@ function DoubleCheckboxFilterform({endreFiltervalg, filtervalg, className}: Doub
                         <RenderFields
                             valg={uniqueValgBestatt}
                             form={formUtdanningBestatt}
-                            velgCheckBox={e => velgCheckBox(e, formUtdanningBestatt)}
+                            velgCheckBox={(valg: string[]) => velgCheckBox(valg, formUtdanningBestatt)}
                             checkBoxValg={checkBoxValgBestatt}
                         />
                     </div>
@@ -111,28 +98,22 @@ function DoubleCheckboxFilterform({endreFiltervalg, filtervalg, className}: Doub
 function RenderFields(props: {
     valg: Dictionary<string>;
     form: string;
-    velgCheckBox: (e) => void;
+    velgCheckBox: (valg: string[]) => void;
     checkBoxValg: string[];
 }) {
     return (
-        <>
+        <CheckboxGroup
+            hideLegend
+            legend=""
+            onChange={props.velgCheckBox}
+            value={props.checkBoxValg.map(valg => `${props.form}_${valg}`)}
+        >
             {Object.entries(props.valg).map(([filterKey, filterValue]) => (
-                <div className="skjemaelement skjemaelement--horisontal" key={filterKey}>
-                    <input
-                        id={filterKey}
-                        type="checkbox"
-                        className="skjemaelement__input checkboks"
-                        value={filterKey}
-                        checked={props.checkBoxValg.includes(filterKey.replace(`${props.form}_`, ''))}
-                        onChange={props.velgCheckBox}
-                        data-testid={`filter_${filterKey}`}
-                    />
-                    <label htmlFor={filterKey} className="skjemaelement__label">
-                        {filterValue}
-                    </label>
-                </div>
+                <Checkbox data-testid={`filter_${filterKey}`} key={filterKey} value={filterKey} size="small">
+                    {filterValue}
+                </Checkbox>
             ))}
-        </>
+        </CheckboxGroup>
     );
 }
 

--- a/src/filtrering/filtrering-filter/filterform/hendelser-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/hendelser-filterform.tsx
@@ -107,7 +107,7 @@ export function HendelserFilterform({
                 )}
 
                 <div className="hendelser-filterform__radio-gruppe" id="lagtTilAvBruker">
-                    <RadioGroup legend="Siste aktivitet lagt til av bruker" value={hendelserValg} size="small">
+                    <RadioGroup legend="Siste aktivitet lagt til av bruker" value={hendelserValg ?? ''} size="small">
                         {lagtTilAvBruker.map(key => (
                             <Radio
                                 onChange={e => onRadioChange(e)}
@@ -120,7 +120,7 @@ export function HendelserFilterform({
                             </Radio>
                         ))}
                     </RadioGroup>
-                    <RadioGroup legend="Siste aktivitet fullført av bruker" value={hendelserValg} size="small">
+                    <RadioGroup legend="Siste aktivitet fullført av bruker" value={hendelserValg ?? ''} size="small">
                         {fullfortAvBruker.map(key => (
                             <Radio
                                 onChange={e => onRadioChange(e)}
@@ -133,7 +133,7 @@ export function HendelserFilterform({
                             </Radio>
                         ))}
                     </RadioGroup>
-                    <RadioGroup legend="Siste aktivitet avbrutt av bruker" value={hendelserValg} size="small">
+                    <RadioGroup legend="Siste aktivitet avbrutt av bruker" value={hendelserValg ?? ''} size="small">
                         {avbruttAvBruker.map(key => (
                             <Radio
                                 onChange={e => onRadioChange(e)}
@@ -146,7 +146,7 @@ export function HendelserFilterform({
                             </Radio>
                         ))}
                     </RadioGroup>
-                    <RadioGroup legend="Andre" value={hendelserValg} size="small">
+                    <RadioGroup legend="Andre" value={hendelserValg ?? ''} size="small">
                         <Radio
                             onChange={e => onRadioChange(e)}
                             name="sisteEndringKategori"

--- a/src/filtrering/filtrering-filter/filterform/radio-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/radio-filterform.tsx
@@ -32,7 +32,7 @@ export function RadioFilterform({form, endreFiltervalg, valg, filtervalg, gridCo
 
     return (
         <form className="skjema radio-filterform" data-testid="radio-filterform">
-            <RadioGroup legend="" value={valgtFilterValg} size="small">
+            <RadioGroup hideLegend legend="" value={valgtFilterValg} size="small">
                 <Grid columns={gridColumns} className="radio-filterform__valg">
                     {Object.keys(valg).map(key => (
                         <Radio

--- a/src/filtrering/filtrering-mine-filter/drag-and-drop/drag-and-drop.tsx
+++ b/src/filtrering/filtrering-mine-filter/drag-and-drop/drag-and-drop.tsx
@@ -117,7 +117,6 @@ function DragAndDrop({stateFilterOrder, oversiktType, isDraggable, setisDraggabl
             legend=""
             onChange={velgFilter}
             value={valgtFilter}
-            defaultValue={valgtFilter}
         >
             {dragAndDropOrder.map((filter, idx) => (
                 <MineFilterRad

--- a/src/filtrering/filtrering-mine-filter/drag-and-drop/drag-and-drop.tsx
+++ b/src/filtrering/filtrering-mine-filter/drag-and-drop/drag-and-drop.tsx
@@ -117,6 +117,7 @@ function DragAndDrop({stateFilterOrder, oversiktType, isDraggable, setisDraggabl
             legend=""
             onChange={velgFilter}
             value={valgtFilter}
+            size="small"
         >
             {dragAndDropOrder.map((filter, idx) => (
                 <MineFilterRad

--- a/src/filtrering/filtrering-mine-filter/drag-and-drop/drag-and-drop.tsx
+++ b/src/filtrering/filtrering-mine-filter/drag-and-drop/drag-and-drop.tsx
@@ -3,12 +3,18 @@ import './drag-and-drop.css';
 import {lagreSorteringForFilter} from '../../../ducks/mine-filter';
 import DragAndDropContainer from './drag-and-drop-container';
 import MineFilterRad from '../mine-filter-rad';
-import {useDispatch} from 'react-redux';
+import {useDispatch, useSelector} from 'react-redux';
 import {useOnlyOnUnmount} from './use-only-onUnmount-hook';
 import {LagretFilter} from '../../../ducks/lagret-filter';
 import {OversiktType} from '../../../ducks/ui/listevisning';
 import {OrNothing} from '../../../utils/types/types';
 import {Tiltak} from '../../../ducks/enhettiltak';
+import {RadioGroup} from '@navikt/ds-react';
+import {AppState} from '../../../reducer';
+import {logEvent} from '../../../utils/frontend-logger';
+import {finnSideNavn, mapVeilederIdentTilNonsens} from '../../../middleware/metrics-middleware';
+import {apneFeilTiltakModal, avmarkerValgtMineFilter, markerMineFilter} from '../../../ducks/lagret-filter-ui-state';
+import {velgMineFilter} from '../../../ducks/filtrering';
 
 export interface DragAndDropProps {
     stateFilterOrder: LagretFilter[];
@@ -22,6 +28,13 @@ function DragAndDrop({stateFilterOrder, oversiktType, isDraggable, setisDraggabl
     const [dragAndDropOrder, setDragAndDropOrder] = useState([...stateFilterOrder]);
     const [onUnmountRef, setOnUnmount] = useOnlyOnUnmount();
     const dispatch = useDispatch();
+
+    const veilederIdent = useSelector((state: AppState) => state.innloggetVeileder.data!);
+    const valgtMineFilter = useSelector((state: AppState) =>
+        oversiktType === OversiktType.minOversikt
+            ? state.mineFilterMinOversikt.valgtMineFilter
+            : state.mineFilterEnhetensOversikt.valgtMineFilter
+    );
 
     const lagreRekkefolge = useCallback(() => {
         const idAndPriorities = dragAndDropOrder.map((filter, idx) => ({
@@ -42,6 +55,33 @@ function DragAndDrop({stateFilterOrder, oversiktType, isDraggable, setisDraggabl
 
     const lagre = () => {
         setisDraggable(false);
+    };
+
+    const velgFilter = (filterId: number) => {
+        const filter: LagretFilter = dragAndDropOrder.find(sortertFilter => sortertFilter.filterId === filterId) as LagretFilter
+
+        logEvent(
+            'portefolje.metrikker.lagredefilter.valgt-lagret-filter',
+            {},
+            {
+                filterId: filter.filterId,
+                sideNavn: finnSideNavn(),
+                id: mapVeilederIdentTilNonsens(veilederIdent.ident)
+            }
+        );
+
+        const tiltaksfeil = filter.filterValg.tiltakstyper.some(
+            tiltak => enhettiltak && enhettiltak[tiltak] === undefined
+        );
+
+        if (tiltaksfeil) {
+            dispatch(markerMineFilter(filter, oversiktType));
+            dispatch(apneFeilTiltakModal(oversiktType));
+            dispatch(avmarkerValgtMineFilter(oversiktType));
+        } else {
+            dispatch(markerMineFilter(filter, oversiktType));
+            dispatch(velgMineFilter(filter, oversiktType));
+        }
     };
 
     useEffect(() => {
@@ -65,11 +105,22 @@ function DragAndDrop({stateFilterOrder, oversiktType, isDraggable, setisDraggabl
     }
 
     return (
-        <>
+        <RadioGroup
+            hideLegend
+            legend=""
+            onChange={velgFilter}
+            value={valgtMineFilter?.filterId}
+            defaultValue={valgtMineFilter?.filterId}
+        >
             {dragAndDropOrder.map((filter, idx) => (
-                <MineFilterRad key={idx} mineFilter={filter} oversiktType={oversiktType} enhettiltak={enhettiltak} />
+                <MineFilterRad
+                    key={idx}
+                    filter={filter}
+                    oversiktType={oversiktType}
+                    erValgt={valgtMineFilter?.filterId === filter.filterId}
+                />
             ))}
-        </>
+        </RadioGroup>
     );
 }
 

--- a/src/filtrering/filtrering-mine-filter/drag-and-drop/drag-and-drop.tsx
+++ b/src/filtrering/filtrering-mine-filter/drag-and-drop/drag-and-drop.tsx
@@ -9,7 +9,7 @@ import {LagretFilter} from '../../../ducks/lagret-filter';
 import {OversiktType} from '../../../ducks/ui/listevisning';
 import {OrNothing} from '../../../utils/types/types';
 import {Tiltak} from '../../../ducks/enhettiltak';
-import {Radio, RadioGroup} from '@navikt/ds-react';
+import {RadioGroup} from '@navikt/ds-react';
 import {AppState} from '../../../reducer';
 import {logEvent} from '../../../utils/frontend-logger';
 import {finnSideNavn, mapVeilederIdentTilNonsens} from '../../../middleware/metrics-middleware';

--- a/src/filtrering/filtrering-mine-filter/drag-and-drop/drag-and-drop.tsx
+++ b/src/filtrering/filtrering-mine-filter/drag-and-drop/drag-and-drop.tsx
@@ -9,7 +9,7 @@ import {LagretFilter} from '../../../ducks/lagret-filter';
 import {OversiktType} from '../../../ducks/ui/listevisning';
 import {OrNothing} from '../../../utils/types/types';
 import {Tiltak} from '../../../ducks/enhettiltak';
-import {RadioGroup} from '@navikt/ds-react';
+import {Radio, RadioGroup} from '@navikt/ds-react';
 import {AppState} from '../../../reducer';
 import {logEvent} from '../../../utils/frontend-logger';
 import {finnSideNavn, mapVeilederIdentTilNonsens} from '../../../middleware/metrics-middleware';
@@ -27,6 +27,7 @@ export interface DragAndDropProps {
 function DragAndDrop({stateFilterOrder, oversiktType, isDraggable, setisDraggable, enhettiltak}: DragAndDropProps) {
     const [dragAndDropOrder, setDragAndDropOrder] = useState([...stateFilterOrder]);
     const [onUnmountRef, setOnUnmount] = useOnlyOnUnmount();
+    const [valgtFilter, setValgtFilter] = useState("")
     const dispatch = useDispatch();
 
     const veilederIdent = useSelector((state: AppState) => state.innloggetVeileder.data!);
@@ -57,8 +58,8 @@ function DragAndDrop({stateFilterOrder, oversiktType, isDraggable, setisDraggabl
         setisDraggable(false);
     };
 
-    const velgFilter = (filterId: number) => {
-        const filter: LagretFilter = dragAndDropOrder.find(sortertFilter => sortertFilter.filterId === filterId) as LagretFilter
+    const velgFilter = (filterId: string) => {
+        const filter: LagretFilter = dragAndDropOrder.find(sortertFilter => `${sortertFilter.filterId}` === filterId) as LagretFilter
 
         logEvent(
             'portefolje.metrikker.lagredefilter.valgt-lagret-filter',
@@ -92,6 +93,12 @@ function DragAndDrop({stateFilterOrder, oversiktType, isDraggable, setisDraggabl
         setDragAndDropOrder([...stateFilterOrder]);
     }, [stateFilterOrder]);
 
+    useEffect(() => {
+        if(valgtMineFilter !== undefined && valgtMineFilter !== null) {
+            setValgtFilter(`${valgtMineFilter.filterId}`)
+        }
+    }, [valgtMineFilter])
+
     if (isDraggable) {
         return (
             <DragAndDropContainer
@@ -109,8 +116,8 @@ function DragAndDrop({stateFilterOrder, oversiktType, isDraggable, setisDraggabl
             hideLegend
             legend=""
             onChange={velgFilter}
-            value={valgtMineFilter?.filterId}
-            defaultValue={valgtMineFilter?.filterId}
+            value={valgtFilter}
+            defaultValue={valgtFilter}
         >
             {dragAndDropOrder.map((filter, idx) => (
                 <MineFilterRad

--- a/src/filtrering/filtrering-mine-filter/mine-filter-rad.tsx
+++ b/src/filtrering/filtrering-mine-filter/mine-filter-rad.tsx
@@ -1,73 +1,21 @@
-import {useDispatch, useSelector} from 'react-redux';
-import {AppState} from '../../reducer';
-import {finnSideNavn, mapVeilederIdentTilNonsens} from '../../middleware/metrics-middleware';
-import {logEvent} from '../../utils/frontend-logger';
-import {velgMineFilter} from '../../ducks/filtrering';
-import {
-    apneFeilTiltakModal,
-    apneMineFilterModal,
-    avmarkerValgtMineFilter,
-    markerMineFilter
-} from '../../ducks/lagret-filter-ui-state';
+import {useDispatch} from 'react-redux';
+import {apneMineFilterModal} from '../../ducks/lagret-filter-ui-state';
 import RedigerKnapp from '../../components/knapper/rediger-knapp';
-import React, {useEffect, useState} from 'react';
+import React, {useEffect} from 'react';
 import './mine-filter_innhold.css';
 import {OversiktType} from '../../ducks/ui/listevisning';
 import {LagretFilter} from '../../ducks/lagret-filter';
 import {kebabCase} from '../../utils/utils';
-import {OrNothing} from '../../utils/types/types';
-import {Tiltak} from '../../ducks/enhettiltak';
-import {Radio} from 'nav-frontend-skjema';
+import {Radio} from '@navikt/ds-react';
 
 interface MineFilterRadProps {
-    mineFilter: LagretFilter;
+    filter: LagretFilter;
     oversiktType: OversiktType;
-    enhettiltak: OrNothing<Tiltak>;
+    erValgt: boolean;
 }
 
-function MineFilterRad({mineFilter, oversiktType, enhettiltak}: MineFilterRadProps) {
+function MineFilterRad({filter, oversiktType, erValgt}: MineFilterRadProps) {
     const dispatch = useDispatch();
-
-    const valgtMineFilter = useSelector((state: AppState) =>
-        oversiktType === OversiktType.minOversikt
-            ? state.mineFilterMinOversikt.valgtMineFilter
-            : state.mineFilterEnhetensOversikt.valgtMineFilter
-    );
-
-    const veilederIdent = useSelector((state: AppState) => state.innloggetVeileder.data!);
-    const veilederIdentTilNonsens = mapVeilederIdentTilNonsens(veilederIdent.ident);
-
-    const [tiltaksfeil, setTiltaksfeil] = useState(false);
-
-    useEffect(() => {
-        mineFilter.filterValg.tiltakstyper.map(tiltak => {
-            if (enhettiltak && enhettiltak[tiltak] === undefined) {
-                setTiltaksfeil(true);
-            }
-            return tiltaksfeil;
-        });
-    });
-
-    function velgFilter() {
-        logEvent(
-            'portefolje.metrikker.lagredefilter.valgt-lagret-filter',
-            {},
-            {
-                filterId: mineFilter.filterId,
-                sideNavn: finnSideNavn(),
-                id: veilederIdentTilNonsens
-            }
-        );
-
-        if (tiltaksfeil) {
-            dispatch(markerMineFilter(mineFilter, oversiktType));
-            dispatch(apneFeilTiltakModal(oversiktType));
-            dispatch(avmarkerValgtMineFilter(oversiktType));
-        } else {
-            dispatch(markerMineFilter(mineFilter, oversiktType));
-            dispatch(velgMineFilter(mineFilter, oversiktType));
-        }
-    }
 
     function onClickRedigerKnapp() {
         dispatch(apneMineFilterModal(oversiktType));
@@ -77,19 +25,16 @@ function MineFilterRad({mineFilter, oversiktType, enhettiltak}: MineFilterRadPro
         <div className="mine-filter__rad" data-testid="mine-filter_rad-wrapper">
             <Radio
                 className="mine-filter__filternavn"
-                key={mineFilter.filterId}
-                name="mineFilter"
-                label={mineFilter.filterNavn}
-                value={mineFilter.filterId}
-                onChange={() => velgFilter()}
-                checked={valgtMineFilter?.filterId === mineFilter.filterId}
-                data-testid={`mine-filter-rad_${kebabCase(mineFilter.filterNavn)}`}
-            />
+                data-testid={`mine-filter-rad_${kebabCase(filter.filterNavn)}`}
+                value={filter.filterId}
+            >
+                {filter.filterNavn}
+            </Radio>
             <RedigerKnapp
-                hidden={valgtMineFilter?.filterId !== mineFilter.filterId}
+                hidden={!erValgt}
                 aria="Rediger mitt filter"
                 onClick={onClickRedigerKnapp}
-                dataTestid={`rediger-filter_knapp_${kebabCase(mineFilter.filterNavn)}`}
+                dataTestid={`rediger-filter_knapp_${kebabCase(filter.filterNavn)}`}
             />
         </div>
     );

--- a/src/filtrering/filtrering-mine-filter/mine-filter-rad.tsx
+++ b/src/filtrering/filtrering-mine-filter/mine-filter-rad.tsx
@@ -1,7 +1,7 @@
 import {useDispatch} from 'react-redux';
 import {apneMineFilterModal} from '../../ducks/lagret-filter-ui-state';
 import RedigerKnapp from '../../components/knapper/rediger-knapp';
-import React, {useEffect} from 'react';
+import React from 'react';
 import './mine-filter_innhold.css';
 import {OversiktType} from '../../ducks/ui/listevisning';
 import {LagretFilter} from '../../ducks/lagret-filter';

--- a/src/filtrering/filtrering-mine-filter/mine-filter-rad.tsx
+++ b/src/filtrering/filtrering-mine-filter/mine-filter-rad.tsx
@@ -26,7 +26,7 @@ function MineFilterRad({filter, oversiktType, erValgt}: MineFilterRadProps) {
             <Radio
                 className="mine-filter__filternavn"
                 data-testid={`mine-filter-rad_${kebabCase(filter.filterNavn)}`}
-                value={filter.filterId}
+                value={`${filter.filterId}`}
             >
                 {filter.filterNavn}
             </Radio>

--- a/src/filtrering/filtrering-mine-filter/mine-filter_innhold.css
+++ b/src/filtrering/filtrering-mine-filter/mine-filter_innhold.css
@@ -1,6 +1,9 @@
 .veilarbportefoljeflatefs .sidebar__content-container .mine-filter__valgfelt {
     padding: 0.5rem;
 }
+.veilarbportefoljeflatefs .sidebar__content-container .mine-filter__valgfelt .mine-filter__rad {
+    margin-bottom: 5px;
+}
 .veilarbportefoljeflatefs .mine-filter-wrapper__tekst {
     font-style: italic;
     margin: 0.5rem 0;
@@ -18,7 +21,6 @@
 .veilarbportefoljeflatefs .mine-filter__rad {
     display: flex;
     justify-content: space-between;
-    min-height: 3rem;
     align-items: center;
 }
 .veilarbportefoljeflatefs .mine-filter__filternavn {

--- a/src/filtrering/filtrering-status/arbeidsliste.tsx
+++ b/src/filtrering/filtrering-status/arbeidsliste.tsx
@@ -30,7 +30,6 @@ function FilterStatusMinArbeidsliste(props: FilterStatusMinArbeidslisteProps) {
                 filterNavn="minArbeidsliste"
                 handleChange={props.handleChange}
                 antall={statusTall.minArbeidsliste}
-                checked={props.checked}
             />
             {props.checked && (
                 <div className="minArbeidsliste__kategori-checkboxwrapper">

--- a/src/filtrering/filtrering-status/arbeidsliste.tsx
+++ b/src/filtrering/filtrering-status/arbeidsliste.tsx
@@ -45,6 +45,7 @@ function FilterStatusMinArbeidsliste(props: FilterStatusMinArbeidslisteProps) {
                         handleChange={props.handleChangeCheckbox}
                         checked={props.checked && props.ferdigfilterListe.includes(KategoriModell.BLA)}
                         antall={statusTall.minArbeidslisteBla}
+                        kompakt
                     />
                     <BarInputCheckbox
                         labelTekst={
@@ -57,6 +58,7 @@ function FilterStatusMinArbeidsliste(props: FilterStatusMinArbeidslisteProps) {
                         handleChange={props.handleChangeCheckbox}
                         checked={props.checked && props.ferdigfilterListe.includes(KategoriModell.GRONN)}
                         antall={statusTall.minArbeidslisteGronn}
+                        kompakt
                     />
                     <BarInputCheckbox
                         labelTekst={
@@ -69,6 +71,7 @@ function FilterStatusMinArbeidsliste(props: FilterStatusMinArbeidslisteProps) {
                         handleChange={props.handleChangeCheckbox}
                         checked={props.checked && props.ferdigfilterListe.includes(KategoriModell.LILLA)}
                         antall={statusTall.minArbeidslisteLilla}
+                        kompakt
                     />
                     <BarInputCheckbox
                         labelTekst={
@@ -81,6 +84,7 @@ function FilterStatusMinArbeidsliste(props: FilterStatusMinArbeidslisteProps) {
                         handleChange={props.handleChangeCheckbox}
                         checked={props.checked && props.ferdigfilterListe.includes(KategoriModell.GUL)}
                         antall={statusTall.minArbeidslisteGul}
+                        kompakt
                     />
                 </div>
             )}

--- a/src/filtrering/filtrering-status/arbeidsliste.tsx
+++ b/src/filtrering/filtrering-status/arbeidsliste.tsx
@@ -44,7 +44,6 @@ function FilterStatusMinArbeidsliste(props: FilterStatusMinArbeidslisteProps) {
                         handleChange={props.handleChangeCheckbox}
                         checked={props.checked && props.ferdigfilterListe.includes(KategoriModell.BLA)}
                         antall={statusTall.minArbeidslisteBla}
-                        kompakt
                     />
                     <BarInputCheckbox
                         labelTekst={
@@ -57,7 +56,6 @@ function FilterStatusMinArbeidsliste(props: FilterStatusMinArbeidslisteProps) {
                         handleChange={props.handleChangeCheckbox}
                         checked={props.checked && props.ferdigfilterListe.includes(KategoriModell.GRONN)}
                         antall={statusTall.minArbeidslisteGronn}
-                        kompakt
                     />
                     <BarInputCheckbox
                         labelTekst={
@@ -70,7 +68,6 @@ function FilterStatusMinArbeidsliste(props: FilterStatusMinArbeidslisteProps) {
                         handleChange={props.handleChangeCheckbox}
                         checked={props.checked && props.ferdigfilterListe.includes(KategoriModell.LILLA)}
                         antall={statusTall.minArbeidslisteLilla}
-                        kompakt
                     />
                     <BarInputCheckbox
                         labelTekst={
@@ -83,7 +80,6 @@ function FilterStatusMinArbeidsliste(props: FilterStatusMinArbeidslisteProps) {
                         handleChange={props.handleChangeCheckbox}
                         checked={props.checked && props.ferdigfilterListe.includes(KategoriModell.GUL)}
                         antall={statusTall.minArbeidslisteGul}
-                        kompakt
                     />
                 </div>
             )}

--- a/src/filtrering/filtrering-status/filter-utils.ts
+++ b/src/filtrering/filtrering-status/filter-utils.ts
@@ -1,7 +1,7 @@
 import {Tiltak} from '../../ducks/enhettiltak';
 import {OrNothing} from '../../utils/types/types';
 
-const CHECKBOX_FILTER = ['UFORDELTE_BRUKERE', 'NYE_BRUKERE_FOR_VEILEDER'];
+export const CHECKBOX_FILTER = ['UFORDELTE_BRUKERE', 'NYE_BRUKERE_FOR_VEILEDER'];
 
 export function leggTilFerdigFilter(filterListe: string[], filter: string): string[] {
     if (CHECKBOX_FILTER.includes(filter)) {

--- a/src/filtrering/filtrering-status/filtrering-status.tsx
+++ b/src/filtrering/filtrering-status/filtrering-status.tsx
@@ -1,24 +1,10 @@
 import React from 'react';
 import {useDispatch} from 'react-redux';
 import {endreFiltervalg} from '../../ducks/filtrering';
-import {fjernFerdigfilter, leggTilFerdigFilter} from './filter-utils';
+import {CHECKBOX_FILTER, fjernFerdigfilter, leggTilFerdigFilter} from './filter-utils';
 import {FiltervalgModell} from '../../model-interfaces';
 import {pagineringSetup} from '../../ducks/paginering';
-import {
-    ER_SYKMELDT_MED_ARBEIDSGIVER,
-    I_AVTALT_AKTIVITET,
-    IKKE_I_AVTALT_AKTIVITET,
-    INAKTIVE_BRUKERE,
-    MIN_ARBEIDSLISTE,
-    MOTER_IDAG,
-    NYE_BRUKERE_FOR_VEILEDER,
-    TRENGER_VURDERING,
-    UFORDELTE_BRUKERE,
-    UNDER_VURDERING,
-    UTLOPTE_AKTIVITETER,
-    VENTER_PA_SVAR_FRA_BRUKER,
-    VENTER_PA_SVAR_FRA_NAV
-} from '../filter-konstanter';
+import {MIN_ARBEIDSLISTE, NYE_BRUKERE_FOR_VEILEDER, UFORDELTE_BRUKERE} from '../filter-konstanter';
 import FilterStatusMinArbeidsliste from './arbeidsliste';
 import {OversiktType} from '../../ducks/ui/listevisning';
 import BarInputCheckbox from '../../components/barinput/barinput-checkbox';
@@ -27,7 +13,7 @@ import {BarInputRadio} from '../../components/barinput/barinput-radio';
 import {tekstAntallBrukere} from '../../utils/tekst-utils';
 import {useFeatureSelector} from '../../hooks/redux/use-feature-selector';
 import {VEDTAKSTOTTE} from '../../konstanter';
-import {Label} from '@navikt/ds-react';
+import {Label, RadioGroup} from '@navikt/ds-react';
 import './filtrering-status.css';
 
 interface FiltreringStatusProps {
@@ -95,85 +81,82 @@ export function FiltreringStatus(props: FiltreringStatusProps) {
                     />
                 )}
             </div>
-            <div className="forsteBarlabelIGruppe">
-                <BarInputRadio
-                    filterNavn="trengerVurdering"
-                    handleChange={handleRadioButtonChange}
-                    checked={ferdigfilterListe.includes(TRENGER_VURDERING)}
-                    antall={statusTall.trengerVurdering}
-                />
-                <BarInputRadio
-                    filterNavn="erSykmeldtMedArbeidsgiver"
-                    handleChange={handleRadioButtonChange}
-                    checked={ferdigfilterListe.includes(ER_SYKMELDT_MED_ARBEIDSGIVER)}
-                    antall={statusTall.erSykmeldtMedArbeidsgiver}
-                />
-                {erVedtaksStotteFeatureTogglePa && (
+            <RadioGroup
+                hideLegend
+                legend=""
+                value={ferdigfilterListe.filter(ferdigFilter => !CHECKBOX_FILTER.includes(ferdigFilter))[0]}
+                defaultValue={ferdigfilterListe.filter(ferdigFilter => !CHECKBOX_FILTER.includes(ferdigFilter))[0]}
+            >
+                <div className="forsteBarlabelIGruppe">
                     <BarInputRadio
-                        filterNavn="underVurdering"
+                        filterNavn="trengerVurdering"
                         handleChange={handleRadioButtonChange}
-                        checked={ferdigfilterListe.includes(UNDER_VURDERING)}
-                        antall={statusTall.underVurdering}
+                        antall={statusTall.trengerVurdering}
                     />
-                )}
-            </div>
-            <div className="forsteBarlabelIGruppe">
-                <BarInputRadio
-                    filterNavn="venterPaSvarFraNAV"
-                    antall={statusTall.venterPaSvarFraNAV}
+                    <BarInputRadio
+                        filterNavn="erSykmeldtMedArbeidsgiver"
+                        handleChange={handleRadioButtonChange}
+                        antall={statusTall.erSykmeldtMedArbeidsgiver}
+                    />
+                    {erVedtaksStotteFeatureTogglePa && (
+                        <BarInputRadio
+                            filterNavn="underVurdering"
+                            handleChange={handleRadioButtonChange}
+                            antall={statusTall.underVurdering}
+                        />
+                    )}
+                </div>
+                <div className="forsteBarlabelIGruppe">
+                    <BarInputRadio
+                        filterNavn="venterPaSvarFraNAV"
+                        antall={statusTall.venterPaSvarFraNAV}
+                        handleChange={handleRadioButtonChange}
+                    />
+                    <BarInputRadio
+                        filterNavn="venterPaSvarFraBruker"
+                        antall={statusTall.venterPaSvarFraBruker}
+                        handleChange={handleRadioButtonChange}
+                    />
+                    <BarInputRadio
+                        filterNavn="avtaltMoteMedNav"
+                        handleChange={handleRadioButtonChange}
+                        antall={statusTall.moterMedNAVIdag}
+                    />
+                </div>
+                <div className="forsteBarlabelIGruppe">
+                    <BarInputRadio
+                        filterNavn="utlopteAktiviteter"
+                        antall={statusTall.utlopteAktiviteter}
+                        handleChange={handleRadioButtonChange}
+                    />
+                    <BarInputRadio
+                        filterNavn="ikkeIavtaltAktivitet"
+                        antall={statusTall.ikkeIavtaltAktivitet}
+                        handleChange={handleRadioButtonChange}
+                    />
+                    <BarInputRadio
+                        filterNavn="iavtaltAktivitet"
+                        antall={statusTall.iavtaltAktivitet}
+                        handleChange={handleRadioButtonChange}
+                    />
+                </div>
+                <div className="forsteBarlabelIGruppe">
+                    <BarInputRadio
+                        filterNavn="inaktiveBrukere"
+                        handleChange={handleRadioButtonChange}
+                        antall={statusTall.inaktiveBrukere}
+                    />
+                </div>
+                <FilterStatusMinArbeidsliste
+                    ferdigfilterListe={kategoriliste}
                     handleChange={handleRadioButtonChange}
-                    checked={ferdigfilterListe.includes(VENTER_PA_SVAR_FRA_NAV)}
+                    handleChangeCheckbox={dispatchArbeidslisteKategoriChange}
+                    hidden={props.oversiktType !== OversiktType.minOversikt}
+                    filtervalg={props.filtervalg}
+                    endreFiltervalg={dispatchFiltreringStatusChanged}
+                    checked={ferdigfilterListe.includes(MIN_ARBEIDSLISTE)}
                 />
-                <BarInputRadio
-                    filterNavn="venterPaSvarFraBruker"
-                    antall={statusTall.venterPaSvarFraBruker}
-                    handleChange={handleRadioButtonChange}
-                    checked={ferdigfilterListe.includes(VENTER_PA_SVAR_FRA_BRUKER)}
-                />
-                <BarInputRadio
-                    filterNavn="avtaltMoteMedNav"
-                    handleChange={handleRadioButtonChange}
-                    antall={statusTall.moterMedNAVIdag}
-                    checked={ferdigfilterListe.includes(MOTER_IDAG)}
-                />
-            </div>
-            <div className="forsteBarlabelIGruppe">
-                <BarInputRadio
-                    filterNavn="utlopteAktiviteter"
-                    antall={statusTall.utlopteAktiviteter}
-                    handleChange={handleRadioButtonChange}
-                    checked={ferdigfilterListe.includes(UTLOPTE_AKTIVITETER)}
-                />
-                <BarInputRadio
-                    filterNavn="ikkeIavtaltAktivitet"
-                    antall={statusTall.ikkeIavtaltAktivitet}
-                    handleChange={handleRadioButtonChange}
-                    checked={ferdigfilterListe.includes(IKKE_I_AVTALT_AKTIVITET)}
-                />
-                <BarInputRadio
-                    filterNavn="iavtaltAktivitet"
-                    antall={statusTall.iavtaltAktivitet}
-                    handleChange={handleRadioButtonChange}
-                    checked={ferdigfilterListe.includes(I_AVTALT_AKTIVITET)}
-                />
-            </div>
-            <div className="forsteBarlabelIGruppe">
-                <BarInputRadio
-                    filterNavn="inaktiveBrukere"
-                    handleChange={handleRadioButtonChange}
-                    antall={statusTall.inaktiveBrukere}
-                    checked={ferdigfilterListe.includes(INAKTIVE_BRUKERE)}
-                />
-            </div>
-            <FilterStatusMinArbeidsliste
-                ferdigfilterListe={kategoriliste}
-                handleChange={handleRadioButtonChange}
-                handleChangeCheckbox={dispatchArbeidslisteKategoriChange}
-                hidden={props.oversiktType !== OversiktType.minOversikt}
-                filtervalg={props.filtervalg}
-                endreFiltervalg={dispatchFiltreringStatusChanged}
-                checked={ferdigfilterListe.includes(MIN_ARBEIDSLISTE)}
-            />
+            </RadioGroup>
         </div>
     );
 }

--- a/src/filtrering/filtrering-status/filtrering-status.tsx
+++ b/src/filtrering/filtrering-status/filtrering-status.tsx
@@ -82,6 +82,7 @@ export function FiltreringStatus(props: FiltreringStatusProps) {
                         handleChange={handleCheckboxChange}
                         checked={ferdigfilterListe.includes(NYE_BRUKERE_FOR_VEILEDER)}
                         labelTekst={'Nye brukere'}
+                        kompakt
                     />
                 ) : (
                     <BarInputCheckbox
@@ -90,6 +91,7 @@ export function FiltreringStatus(props: FiltreringStatusProps) {
                         handleChange={handleCheckboxChange}
                         checked={ferdigfilterListe.includes(UFORDELTE_BRUKERE)}
                         labelTekst={'Ufordelte brukere'}
+                        kompakt
                     />
                 )}
             </div>

--- a/src/filtrering/filtrering-status/filtrering-status.tsx
+++ b/src/filtrering/filtrering-status/filtrering-status.tsx
@@ -68,7 +68,6 @@ export function FiltreringStatus(props: FiltreringStatusProps) {
                         handleChange={handleCheckboxChange}
                         checked={ferdigfilterListe.includes(NYE_BRUKERE_FOR_VEILEDER)}
                         labelTekst={'Nye brukere'}
-                        kompakt
                     />
                 ) : (
                     <BarInputCheckbox
@@ -77,7 +76,6 @@ export function FiltreringStatus(props: FiltreringStatusProps) {
                         handleChange={handleCheckboxChange}
                         checked={ferdigfilterListe.includes(UFORDELTE_BRUKERE)}
                         labelTekst={'Ufordelte brukere'}
-                        kompakt
                     />
                 )}
             </div>

--- a/src/filtrering/filtrering-status/filtrering-status.tsx
+++ b/src/filtrering/filtrering-status/filtrering-status.tsx
@@ -84,8 +84,7 @@ export function FiltreringStatus(props: FiltreringStatusProps) {
             <RadioGroup
                 hideLegend
                 legend=""
-                value={ferdigfilterListe.filter(ferdigFilter => !CHECKBOX_FILTER.includes(ferdigFilter))[0]}
-                defaultValue={ferdigfilterListe.filter(ferdigFilter => !CHECKBOX_FILTER.includes(ferdigFilter))[0]}
+                value={ferdigfilterListe.filter(ferdigFilter => !CHECKBOX_FILTER.includes(ferdigFilter))[0] ?? ''}
             >
                 <div className="forsteBarlabelIGruppe">
                     <BarInputRadio

--- a/src/filtrering/filtrering-veileder-grupper/veiledergruppe-innhold.tsx
+++ b/src/filtrering/filtrering-veileder-grupper/veiledergruppe-innhold.tsx
@@ -18,6 +18,7 @@ import {LagretFilter} from '../../ducks/lagret-filter';
 import VeiledergruppeRad from './veiledergruppe_rad';
 import {kebabCase} from '../../utils/utils';
 import {hentMineFilterForVeileder} from '../../ducks/mine-filter';
+import {RadioGroup} from '@navikt/ds-react';
 
 interface VeiledergruppeInnholdProps {
     lagretFilter: LagretFilter[];
@@ -93,14 +94,19 @@ function VeiledergruppeInnhold(props: VeiledergruppeInnholdProps) {
 
     return (
         <div className="veileder-gruppe__valgfelt" ref={outerDivRef}>
-            {props.lagretFilter.map((veilederGruppe, index) => (
-                <VeiledergruppeRad
-                    key={index}
-                    veilederGruppe={veilederGruppe}
-                    onClickRedigerKnapp={() => setVisEndreGruppeModal(true)}
-                    oversiktType={props.oversiktType}
-                />
-            ))}
+            <RadioGroup hideLegend legend="" value={valgtGruppe?.filterId} defaultValue={valgtGruppe?.filterId}>
+                {props.lagretFilter.map((veilederGruppe, index) => {
+                    return (
+                        <VeiledergruppeRad
+                            key={index}
+                            veilederGruppe={veilederGruppe}
+                            onClickRedigerKnapp={() => setVisEndreGruppeModal(true)}
+                            oversiktType={props.oversiktType}
+                            erValgt={veilederGruppe.filterId === valgtGruppe?.filterId}
+                        />
+                    );
+                })}
+            </RadioGroup>
             {valgtGruppe && (
                 <VeiledergruppeModal
                     initialVerdi={{

--- a/src/filtrering/filtrering-veileder-grupper/veiledergruppe-innhold.tsx
+++ b/src/filtrering/filtrering-veileder-grupper/veiledergruppe-innhold.tsx
@@ -94,7 +94,7 @@ function VeiledergruppeInnhold(props: VeiledergruppeInnholdProps) {
 
     return (
         <div className="veileder-gruppe__valgfelt" ref={outerDivRef}>
-            <RadioGroup hideLegend legend="" value={valgtGruppe?.filterId} defaultValue={valgtGruppe?.filterId}>
+            <RadioGroup hideLegend legend="" value={valgtGruppe?.filterId} defaultValue={valgtGruppe?.filterId} size="small">
                 {props.lagretFilter.map((veilederGruppe, index) => {
                     return (
                         <VeiledergruppeRad

--- a/src/filtrering/filtrering-veileder-grupper/veiledergruppe.css
+++ b/src/filtrering/filtrering-veileder-grupper/veiledergruppe.css
@@ -5,7 +5,7 @@
 .veileder-gruppe__rad {
     display: flex;
     justify-content: space-between;
-    min-height: 3rem;
+    margin-bottom: 5px;
 }
 .veileder-gruppe__knapperad {
     display: flex;

--- a/src/filtrering/filtrering-veileder-grupper/veiledergruppe_rad.tsx
+++ b/src/filtrering/filtrering-veileder-grupper/veiledergruppe_rad.tsx
@@ -1,4 +1,3 @@
-import {Radio} from 'nav-frontend-skjema';
 import RedigerKnapp from '../../components/knapper/rediger-knapp';
 import React from 'react';
 import {endreFiltervalg} from '../../ducks/filtrering';
@@ -11,23 +10,17 @@ import {AppState} from '../../reducer';
 import {markerValgtVeiledergruppe} from '../../ducks/lagret-filter-ui-state';
 import {veilederlisterErLik} from '../../components/modal/mine-filter';
 import {kebabCase} from '../../utils/utils';
+import {Radio} from '@navikt/ds-react';
 
 interface VeiledergruppeRadProps {
     veilederGruppe: LagretFilter;
     onClickRedigerKnapp: () => void;
     oversiktType: OversiktType;
+    erValgt: boolean;
 }
 
-function VeiledergruppeRad({veilederGruppe, onClickRedigerKnapp, oversiktType}: VeiledergruppeRadProps) {
+function VeiledergruppeRad({veilederGruppe, onClickRedigerKnapp, oversiktType, erValgt}: VeiledergruppeRadProps) {
     const dispatch = useDispatch();
-    const valgtGruppeEnhetensOversikt = useSelector(
-        (state: AppState) => state.mineFilterEnhetensOversikt.valgtVeiledergruppe
-    );
-    const valgtGruppeVeilederOversikt = useSelector(
-        (state: AppState) => state.mineFilterVeilederOversikt.valgtVeiledergruppe
-    );
-    const valgtGruppe =
-        oversiktType === OversiktType.veilederOversikt ? valgtGruppeVeilederOversikt : valgtGruppeEnhetensOversikt;
 
     const lagredeGrupper = useSelector((state: AppState) =>
         state.veiledergrupper.data.filter(v => v.filterId !== veilederGruppe.filterId)
@@ -57,16 +50,16 @@ function VeiledergruppeRad({veilederGruppe, onClickRedigerKnapp, oversiktType}: 
         <div className="veileder-gruppe__rad" data-testid="veiledergruppe_rad-wrapper">
             <Radio
                 className="veileder-gruppe__gruppenavn"
+                data-testid={`veiledergruppe-rad_${kebabCase(veilederGruppe.filterNavn)}`}
                 key={veilederGruppe.filterId}
                 name="veiledergruppe"
-                label={veilederGruppe.filterNavn}
-                value={veilederGruppe.filterId}
                 onChange={() => velgGruppe()}
-                checked={valgtGruppe?.filterId === veilederGruppe.filterId}
-                data-testid={`veiledergruppe-rad_${kebabCase(veilederGruppe.filterNavn)}`}
-            />
+                value={veilederGruppe.filterId}
+            >
+                {veilederGruppe.filterNavn}
+            </Radio>
             <RedigerKnapp
-                hidden={valgtGruppe?.filterId !== veilederGruppe.filterId}
+                hidden={!erValgt}
                 aria="Rediger veiledergruppe"
                 onClick={onClickRedigerKnapp}
                 dataTestid={`rediger-veiledergruppe_knapp_${kebabCase(veilederGruppe.filterNavn)}`}

--- a/src/minoversikt/minoversikt-bruker-panel.tsx
+++ b/src/minoversikt/minoversikt-bruker-panel.tsx
@@ -15,8 +15,7 @@ import {useFeatureSelector} from '../hooks/redux/use-feature-selector';
 import {VEDTAKSTOTTE} from '../konstanter';
 import {logEvent} from '../utils/frontend-logger';
 import {Collapse} from 'react-collapse';
-import {Tag} from '@navikt/ds-react';
-import {Checkbox} from 'nav-frontend-skjema';
+import {Checkbox, Tag} from '@navikt/ds-react';
 
 interface MinOversiktBrukerPanelProps {
     bruker: BrukerModell;
@@ -83,14 +82,16 @@ function MinoversiktBrukerPanel(props: MinOversiktBrukerPanelProps) {
             <div className="brukerliste__element">
                 <div className="brukerliste__gutter-left brukerliste--min-width-minside">
                     <Checkbox
-                        checked={bruker.markert}
-                        disabled={bruker.fnr === ''}
-                        onChange={() => settMarkert(bruker.fnr, !bruker.markert)}
-                        label=""
-                        role="checkbox"
                         className="brukerliste__checkbox"
+                        checked={bruker.markert}
                         data-testid={`min-oversikt_brukerliste-checkbox${testIdArbeidslisteAktiv}${testIdDisabled}`}
-                    />
+                        disabled={bruker.fnr === ''}
+                        hideLabel
+                        onChange={() => settMarkert(bruker.fnr, !bruker.markert)}
+                        size="small"
+                    >
+                        {''}
+                    </Checkbox>
                     <ArbeidslistekategoriVisning
                         skalVises={arbeidslisteAktiv}
                         kategori={bruker.arbeidsliste?.kategori}

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -14,7 +14,7 @@ import {
     ytelseAapSortering,
     ytelseUtlopsSortering
 } from '../filtrering/filter-konstanter';
-import {Kolonne, OversiktType} from '../ducks/ui/listevisning';
+import {Kolonne} from '../ducks/ui/listevisning';
 import Header from '../components/tabell/header';
 import VelgalleCheckboks from '../components/toolbar/velgalle-checkboks';
 import './minoversikt.css';
@@ -38,7 +38,6 @@ interface MinOversiktListehodeProps {
     filtervalg: FiltervalgModell;
     brukere: BrukerModell[];
     valgteKolonner: Kolonne[];
-    oversiktType: OversiktType;
 }
 
 function MinOversiktListeHode({
@@ -46,8 +45,7 @@ function MinOversiktListeHode({
     sorteringOnClick,
     filtervalg,
     sorteringsfelt,
-    valgteKolonner,
-    oversiktType
+    valgteKolonner
 }: MinOversiktListehodeProps) {
     const {ytelse} = filtervalg;
     const erAapYtelse = Object.keys(ytelseAapSortering).includes(ytelse!);
@@ -71,10 +69,7 @@ function MinOversiktListeHode({
         <div className="brukerliste__header brukerliste__sorteringheader">
             <div className="brukerliste__gutter-left" />
             <div className="brukerliste__innhold" data-testid="brukerliste_innhold">
-                <VelgalleCheckboks
-                    skalVises={oversiktType in OversiktType}
-                    className="velgalle-checkboks col col-xs-2"
-                />
+                <VelgalleCheckboks className="velgalle-checkboks" />
                 <SorteringHeader
                     className="arbeidslistekategori__sorteringsheader"
                     sortering={Sorteringsfelt.ARBEIDSLISTEKATEGORI}

--- a/src/minoversikt/minoversikt-portefolje-tabelloverskrift.tsx
+++ b/src/minoversikt/minoversikt-portefolje-tabelloverskrift.tsx
@@ -23,7 +23,6 @@ function MinoversiktTabellOverskrift(props: MinOversiktTabellProps) {
             sorteringsfelt={sorteringsfelt}
             valgteKolonner={listevisning.valgte}
             brukere={brukere}
-            oversiktType={OversiktType.enhetensOversikt}
         />
     );
 }


### PR DESCRIPTION
Dette er en fortsettelse på å ta i bruk Checkbox/Radio komponentene fra nytt designsystem (@navikt/ds-react).
PR-en vart ganske stor då det er ein del plasser der gamle komponenter har blitt brukt. I tillegg så er komponent API-et til dei nye komponentene noko annerledes.

Der vi har brukt mykje custom styling så har eg bevisst latt vere å bruke nye komponenter fra designsystemet da vi uansett hadde endt opp med å overstyre stylingen (eit eksempel på dette er "Min oversikt > Filter > Fødselsdato" som egentlig er checkbox-er men med eit eige design som ikkje matcher designsystemet).

Eg har forsøkt å bruke det nye komponent API-et slik det er tiltenkt (bla.a. ved å wrappe i henholdsvis CheckboxGroup og RadioGroup) og dette medfører derfor litt refaktorering. Det er nok potensiale for å rydde opp meir enn det eg har gjort her, men for å holde PR-en minst mulig så har eg forsøkt å legge meg på en mellomting.