### PR TITLE
Småfiks: knappeikoner etter DSv1

### DIFF
--- a/src/components/knapper/rediger-knapp.tsx
+++ b/src/components/knapper/rediger-knapp.tsx
@@ -17,9 +17,8 @@ function RedigerKnapp(props: {aria: string; onClick: () => void; dataTestid?: st
             onClick={props.onClick}
             data-testid={props.dataTestid}
             size="small"
-        >
-            {hover ? <EditFilled /> : <Edit />}
-        </Button>
+            icon={hover ? <EditFilled /> : <Edit />}
+        ></Button>
     );
 }
 

--- a/src/components/modal/arbeidsliste/arbeidsliste-informasjonsmelding.tsx
+++ b/src/components/modal/arbeidsliste/arbeidsliste-informasjonsmelding.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {Alert, Link} from '@navikt/ds-react';
+import {ExternalLink} from '@navikt/ds-icons';
 
 const ArbeidslisteInformasjonsmelding = () => (
     <Alert variant="info" className="arbeidsliste-alert" size="small">
@@ -7,12 +8,14 @@ const ArbeidslisteInformasjonsmelding = () => (
         Personen har ikke innsyn i arbeidslisten og derfor skal du ikke skrive sensitive opplysninger eller annen
         informasjon som er relevant for personen.
         <br />
-        <Link
-            href="https://navno.sharepoint.com/sites/fag-og-ytelser-arbeid-arbeidsrettet-brukeroppfolging/SitePages/Arbeidslisten-i-Oversikten-i-Modia.aspx"
-            target="_blank"
-        >
-            <b>Les mer om hvordan bruke arbeidslisten på Navet.</b>
-        </Link>
+        <b>
+            <Link
+                href="https://navno.sharepoint.com/sites/fag-og-ytelser-arbeid-arbeidsrettet-brukeroppfolging/SitePages/Arbeidslisten-i-Oversikten-i-Modia.aspx"
+                target="_blank"
+            >
+                Les mer om hvordan bruke arbeidslisten på Navet <ExternalLink />
+            </Link>
+        </b>
     </Alert>
 );
 

--- a/src/components/modal/arbeidsliste/rediger-arbeidsliste-form.tsx
+++ b/src/components/modal/arbeidsliste/rediger-arbeidsliste-form.tsx
@@ -71,13 +71,13 @@ function RedigerArbeidsliste(props: RedigerArbeidslisteProps) {
                     Avbryt
                 </Button>
                 <Button
+                    className="fjern--knapp"
                     variant="danger"
                     type="button"
                     onClick={fjernBruker}
-                    className="fjern--knapp"
+                    icon={<Delete />}
                     data-testid="modal_rediger-arbeidsliste_fjern-knapp"
                 >
-                    <Delete />
                     <BodyShort size="small">Fjern</BodyShort>
                 </Button>
             </div>

--- a/src/components/modal/mine-filter/feil-tiltak-modal.tsx
+++ b/src/components/modal/mine-filter/feil-tiltak-modal.tsx
@@ -57,8 +57,12 @@ export function FeilTiltakModal({gammeltFilterNavn, filterId, lukkModal, oversik
                     <Button data-testid="la-sta-knapp" onClick={lukkModal}>
                         La stå
                     </Button>
-                    <Button variant="danger" onClick={e => bekreftSletting(e)} data-testid="slett-knapp">
-                        <Delete />
+                    <Button
+                        variant="danger"
+                        onClick={e => bekreftSletting(e)}
+                        icon={<Delete />}
+                        data-testid="slett-knapp"
+                    >
                         Slett
                     </Button>
                 </div>

--- a/src/components/modal/mine-filter/mine-filter-oppdater.tsx
+++ b/src/components/modal/mine-filter/mine-filter-oppdater.tsx
@@ -91,9 +91,9 @@ export function OppdaterMineFilter({gammeltFilterNavn, filterId, lukkModal, over
                     <Button
                         variant="danger"
                         onClick={e => bekreftSletting(e)}
+                        icon={<Delete />}
                         data-testid="rediger-filter_modal_slett-knapp"
                     >
-                        <Delete />
                         Slett
                     </Button>
                 </div>

--- a/src/components/modal/varselmodal/bekreft-sletting-modal.tsx
+++ b/src/components/modal/varselmodal/bekreft-sletting-modal.tsx
@@ -40,9 +40,9 @@ function BekreftSlettingModal(props: BekreftSlettingModalProps) {
                     variant="danger"
                     type="submit"
                     onClick={slettKnapp}
+                    icon={<Delete />}
                     data-testid="bekreft-sletting_modal_slett-knapp"
                 >
-                    <Delete />
                     Slett
                 </Button>
                 <Button variant="secondary" type="button" onClick={props.onRequestClose}>

--- a/src/components/modal/veiledergruppe/valgt-veiledergruppe-liste.tsx
+++ b/src/components/modal/veiledergruppe/valgt-veiledergruppe-liste.tsx
@@ -47,10 +47,9 @@ function ValgtVeiledergruppeListe(props: ValgtVeiledergruppeListeProps) {
                                         className="fjern--knapp"
                                         type="button"
                                         onClick={() => props.fjernValgtVeileder(veileder.ident)}
+                                        icon={<Delete />}
                                         data-testid="veiledergruppe_modal_valgt-veileder_fjern-knapp"
-                                    >
-                                        <Delete />
-                                    </Button>
+                                    ></Button>
                                 </div>
                             ))}
                         </div>

--- a/src/components/modal/veiledergruppe/veiledergruppe-modal.tsx
+++ b/src/components/modal/veiledergruppe/veiledergruppe-modal.tsx
@@ -242,13 +242,13 @@ export function VeiledergruppeModal(props: VeilederModalProps) {
                                 </Button>
                                 {props.onSlett && (
                                     <Button
-                                        variant="danger"
                                         className="veiledergruppe-modal__knappegruppe__slett"
-                                        onClick={() => setSletteVeiledergruppeModal(true)}
+                                        variant="danger"
                                         type="button"
+                                        onClick={() => setSletteVeiledergruppeModal(true)}
+                                        icon={<Delete />}
                                         data-testid="veiledergruppe_modal_slette-knapp"
                                     >
-                                        <Delete />
                                         Slett gruppe
                                     </Button>
                                 )}

--- a/src/components/tabell/arbeidslistebutton.tsx
+++ b/src/components/tabell/arbeidslistebutton.tsx
@@ -17,15 +17,14 @@ interface ArbeidslisteButtonProps {
 const arbeidslisteButton = ({className, onClick, apen, dataTestid, skalVises}: ArbeidslisteButtonProps) =>
     skalVises ? (
         <Button
-            variant="tertiary"
             className={classnames('knapp brukerliste__arbeidslisteknapp', className)}
+            variant="tertiary"
             onClick={onClick}
+            icon={apen ? <Collapse className="collapse" /> : <Expand className="expand" />}
             aria-expanded={apen}
             data-testid={dataTestid}
             aria-label="Chevron for arbeidliste"
-        >
-            {apen ? <Collapse className="collapse" /> : <Expand className="expand" />}
-        </Button>
+        ></Button>
     ) : (
         <div className="brukerliste__arbeidslisteknapp" />
     );

--- a/src/components/til-toppen-knapp/til-toppen-knapp.tsx
+++ b/src/components/til-toppen-knapp/til-toppen-knapp.tsx
@@ -38,14 +38,13 @@ export const TilToppenKnapp = () => {
 
     return (
         <Button
+            className={classNames('til-toppen-knapp', 'knapp', !knappSkalVises && 'til-toppen-knapp--skjul')}
             variant="secondary"
             ref={knappRef}
-            className={classNames('til-toppen-knapp', 'knapp', !knappSkalVises && 'til-toppen-knapp--skjul')}
             hidden={!knappSkalVises}
             onClick={onClick}
+            icon={<Up />}
             data-testid="til-toppen_knapp"
-        >
-            <Up />
-        </Button>
+        ></Button>
     );
 };

--- a/src/filtrering/filtrering-label-arbeidsliste.tsx
+++ b/src/filtrering/filtrering-label-arbeidsliste.tsx
@@ -31,11 +31,12 @@ function FiltreringLabelArbeidsliste({
             aria-label="Slett filter"
             className={buttonClassnames}
             onClick={slettFilter}
+            icon={<FilterIkon />}
+            iconPosition="right"
         >
             <span className="filtreringlabel__container">
                 <ArbeidslistekategoriVisning skalVises kategori={kategori} />
                 {lagConfig(label).label}
-                <FilterIkon />
             </span>
         </Button>
     );

--- a/src/filtrering/filtrering-label.css
+++ b/src/filtrering/filtrering-label.css
@@ -11,7 +11,7 @@
     border-radius: 2px;
     display: flex;
     background: #c9c9c9 none;
-    padding: 0.5rem;
+    padding: 0.5rem 0.75rem 0.5rem 0.5rem;
     justify-content: space-between;
     font-weight: normal;
     margin: 0.5rem 1rem 0.5rem 0;
@@ -33,7 +33,6 @@
     background-color: #ffd799;
 }
 .veilarbportefoljeflatefs .filtreringlabel__label {
-    padding-right: 0.5rem;
     max-width: 10rem;
     white-space: nowrap;
     overflow: hidden;
@@ -44,11 +43,11 @@
 }
 .veilarbportefoljeflatefs .filtreringlabel__container {
     display: flex;
+    align-items: center;
 }
 .veilarbportefoljeflatefs .filtreringlabel__container .arbeidsliste--ikon {
-    right: 0;
-    height: 0;
-    margin-right: 0.2rem;
+    margin-right: 0.25rem;
+    display: flex;
 }
 .veilarbportefoljeflatefs .filtreringlabel__container .filter-ikon-x-svg {
     margin-left: 0.5rem;
@@ -56,7 +55,7 @@
 .veilarbportefoljeflatefs .slett-alle-filtervalg-knapp {
     background-color: #6a6a6a;
     color: white;
-    padding-right: 0;
+    padding-right: 0.5rem;
 }
 .veilarbportefoljeflatefs .slett-alle-filtervalg-knapp:hover {
     background: #4f4f4f none;

--- a/src/minoversikt/moteplan/moteplan.tsx
+++ b/src/minoversikt/moteplan/moteplan.tsx
@@ -45,8 +45,13 @@ function Moteplan({veileder, enhet}: MoteplanProps) {
 
     return (
         <>
-            <Button className="moteplan_knapp" ref={buttonRef} variant="tertiary" onClick={() => fetchMoteData()}>
-                <Calender title="møteplan" />
+            <Button
+                className="moteplan_knapp"
+                ref={buttonRef}
+                variant="tertiary"
+                onClick={() => fetchMoteData()}
+                icon={<Calender title="møteplan" />}
+            >
                 Møteplan
             </Button>
             <Popover


### PR DESCRIPTION
- Flyttet resten av ikonene til props
- La til ikon på lenke for å vise at det åpnes ny fane
- Justert litt på filteretikettene, midtstilt og lagt på litt padding som DS av en eller annen grunn fjerner ( `--navds-button-icon-adjustment: -4px;` )