### PR TITLE
TC-254 Vise melding ved utløpt sesjon

### DIFF
--- a/src/application.tsx
+++ b/src/application.tsx
@@ -10,6 +10,7 @@ import {RedirectPortefolje} from './redirect-portefolje';
 import {Modal} from '@navikt/ds-react';
 import {erMock} from './utils/url-utils';
 import {useBrukeraktivitetTokenRefresh} from './hooks/use-brukeraktivitet-token-refresh';
+import {settSesjonStatusGyldig, settSesjonStatusUtlopt} from './ducks/informasjonsmelding';
 
 if (process.env.NODE_ENV !== 'test') {
     Modal.setAppElement && Modal.setAppElement('#applikasjon');
@@ -19,7 +20,10 @@ moment.locale('nb');
 const store = createStore();
 
 function Application() {
-    useBrukeraktivitetTokenRefresh();
+    useBrukeraktivitetTokenRefresh(
+        () => store.dispatch(settSesjonStatusUtlopt()),
+        () => store.dispatch(settSesjonStatusGyldig())
+    );
 
     return (
         <Provider store={store}>

--- a/src/components/informasjonsmeldinger/informasjonsmeldinger.css
+++ b/src/components/informasjonsmeldinger/informasjonsmeldinger.css
@@ -1,0 +1,9 @@
+.veilarbportefoljeflatefs .informasjonsmeldinger > *:not(:last-child) {
+    margin-bottom: var(--navds-spacing-1);
+}
+
+.veilarbportefoljeflatefs .informasjonsmeldinger--sticky {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+}

--- a/src/components/informasjonsmeldinger/informasjonsmeldinger.tsx
+++ b/src/components/informasjonsmeldinger/informasjonsmeldinger.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import {Systemmeldinger} from './systemmeldinger';
+import {SesjonStatusmelding} from './sesjon-statusmelding';
+import './informasjonsmeldinger.css';
+
+export const Informasjonsmeldinger = () => {
+    return (
+        <>
+            <section className="informasjonsmeldinger informasjonsmeldinger--sticky">
+                <SesjonStatusmelding />
+            </section>
+            <section className="informasjonsmeldinger">
+                <Systemmeldinger />
+            </section>
+        </>
+    );
+};

--- a/src/components/informasjonsmeldinger/sesjon-statusmelding.tsx
+++ b/src/components/informasjonsmeldinger/sesjon-statusmelding.tsx
@@ -1,0 +1,22 @@
+import {Alert, Link} from '@navikt/ds-react';
+import * as React from 'react';
+import {useSesjonStatus} from '../../hooks/redux/use-informasjonsmelding';
+import {isDefined} from '../../utils/types/typeguards';
+import {SesjonStatus} from '../../model-interfaces';
+import {loginUrl} from '../../utils/url-utils';
+
+export const SesjonStatusmelding = () => {
+    const sesjonStatus = useSesjonStatus();
+
+    if (!isDefined(sesjonStatus) || sesjonStatus === SesjonStatus.GYLDIG) {
+        return null;
+    }
+
+    const LoginLenke = () => <Link href={loginUrl()}>Logg inn på nytt.</Link>;
+
+    return (
+        <Alert variant="error" size="medium" fullWidth>
+            Økten din er utløpt. <LoginLenke />
+        </Alert>
+    );
+};

--- a/src/components/informasjonsmeldinger/systemmeldinger.tsx
+++ b/src/components/informasjonsmeldinger/systemmeldinger.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import './modal/feilmelding-brukere.css';
+import '../modal/feilmelding-brukere.css';
 import {Alert, Heading} from '@navikt/ds-react';
 import BlockContent from '@sanity/block-content-to-react';
-import {useSystemmeldingerSelector} from '../hooks/redux/use-systemmeldinger';
+import {useSystemmeldingerSelector} from '../../hooks/redux/use-systemmeldinger';
 
 export const Systemmeldinger = () => {
     const systemmeldinger = useSystemmeldingerSelector();
     return (
-        <section className="systemmeldinger">
+        <>
             {systemmeldinger.map(systemmelding => (
                 <Alert key={`tittel_${systemmelding.tittel}`} variant={systemmelding.type} size="medium" fullWidth>
                     <Heading spacing size="small" level="3">
@@ -16,6 +16,6 @@ export const Systemmeldinger = () => {
                     <BlockContent blocks={systemmelding.beskrivelse} />
                 </Alert>
             ))}
-        </section>
+        </>
     );
 };

--- a/src/components/modal/sesjonNotifikasjon.css
+++ b/src/components/modal/sesjonNotifikasjon.css
@@ -1,9 +1,0 @@
-.sesjonNotifikasjonWraper {
-    position: sticky;
-    top: 0;
-    z-index: 100;
-}
-
-.wonderwallLoginLenke {
-    margin-left: 1rem;
-}

--- a/src/ducks/informasjonsmelding.ts
+++ b/src/ducks/informasjonsmelding.ts
@@ -1,0 +1,40 @@
+import {SesjonStatus} from '../model-interfaces';
+import {Action} from 'redux';
+
+type DataAction<T, D> = Action<T> & {data?: D};
+
+type SesjonStatusDataAction = DataAction<SesjonStatusAction, SesjonStatus>;
+
+export interface SesjonStatusState {
+    data?: SesjonStatus | null;
+}
+
+const initalStatusState: SesjonStatusState = {
+    data: null
+};
+
+// Actions
+export enum SesjonStatusAction {
+    OPPDATER_SESJON_STATUS = 'veilarbportefoljeflatefs/informasjonsmelding/SETT_SESJON_STATUS'
+}
+
+// Reducer
+export default function reducer(
+    state: SesjonStatusState = initalStatusState,
+    action: SesjonStatusDataAction
+): SesjonStatusState {
+    switch (action.type) {
+        case SesjonStatusAction.OPPDATER_SESJON_STATUS:
+            return {...state, data: action.data};
+        default:
+            return state;
+    }
+}
+
+// Action Creators
+const oppdaterSesjonStatus = (status: SesjonStatus): SesjonStatusDataAction => {
+    return {type: SesjonStatusAction.OPPDATER_SESJON_STATUS, data: status};
+};
+
+export const settSesjonStatusUtlopt = (): SesjonStatusDataAction => oppdaterSesjonStatus(SesjonStatus.UTLOPT);
+export const settSesjonStatusGyldig = (): SesjonStatusDataAction => oppdaterSesjonStatus(SesjonStatus.GYLDIG);

--- a/src/ducks/utils.ts
+++ b/src/ducks/utils.ts
@@ -18,11 +18,11 @@ class FetchError extends Error {
     }
 }
 
-export function sjekkStatuskode(response) {
+export function sjekkStatuskode(response, redirectOnUnauthorized: Boolean = true) {
     if (response.status >= 200 && response.status < 300 && response.ok) {
         return response;
     }
-    if (response.status === 401) {
+    if (response.status === 401 && redirectOnUnauthorized) {
         window.location.href = loginUrl();
     }
     return Promise.reject(new FetchError(response.statusText, response));
@@ -61,8 +61,10 @@ export function handterFeil(dispatch, action) {
     };
 }
 
-export function fetchToJson(url: string, config: RequestInit = {}) {
-    return fetch(url, config).then(sjekkStatuskode).then(toJson);
+export function fetchToJson(url: string, config: RequestInit = {}, redirectOnUnauthorized: Boolean = true) {
+    return fetch(url, config)
+        .then(res => sjekkStatuskode(res, redirectOnUnauthorized))
+        .then(toJson);
 }
 
 export function doThenDispatch(fn, {OK, FEILET, PENDING}) {

--- a/src/enhetsportefolje/enhet-side.tsx
+++ b/src/enhetsportefolje/enhet-side.tsx
@@ -36,7 +36,7 @@ import LagredeFilterUIController from '../filtrering/lagrede-filter-controller';
 import {FeilTiltakModal} from '../components/modal/mine-filter/feil-tiltak-modal';
 import {lukkFeilTiltakModal} from '../ducks/lagret-filter-ui-state';
 import {Alert} from '@navikt/ds-react';
-import {Systemmeldinger} from '../components/systemmeldinger';
+import {Informasjonsmeldinger} from '../components/informasjonsmeldinger/informasjonsmeldinger';
 
 export function antallFilter(filtervalg) {
     function mapAktivitetFilter(value) {
@@ -134,7 +134,7 @@ export default function EnhetSide() {
     return (
         <div className="side-storrelse" id={`side-storrelse_${id}`} data-testid={`side-storrelse_${id}`}>
             <ToppMeny oversiktType={oversiktType} />
-            <Systemmeldinger />
+            <Informasjonsmeldinger />
             <Innholdslaster avhengigheter={[statustall]}>
                 <div
                     className={classNames('oversikt-sideinnhold', isSidebarHidden && 'oversikt-sideinnhold__hidden')}

--- a/src/hooks/redux/use-informasjonsmelding.tsx
+++ b/src/hooks/redux/use-informasjonsmelding.tsx
@@ -1,0 +1,10 @@
+import {useSelector} from 'react-redux';
+import {AppState} from '../../reducer';
+import {SesjonStatus} from '../../model-interfaces';
+import {Maybe} from '../../utils/types';
+
+const selectSesjonStatus = (state: AppState) => state.sesjonStatus.data;
+
+export function useSesjonStatus() {
+    return useSelector<AppState, Maybe<SesjonStatus>>(state => selectSesjonStatus(state));
+}

--- a/src/middleware/api.ts
+++ b/src/middleware/api.ts
@@ -230,9 +230,9 @@ export function sendEventTilPortefolje(event: FrontendEvent) {
 }
 
 export const refreshAccessTokens = async (): Promise<SessionMeta> => {
-    return fetchToJson('/oauth2/session/refresh').then(data => Promise.resolve(data as SessionMeta));
+    return fetchToJson('/oauth2/session/refresh', {}, false).then(data => Promise.resolve(data as SessionMeta));
 };
 
 export const hentSesjonMetadata = async (): Promise<SessionMeta> => {
-    return fetchToJson('/oauth2/session').then(data => Promise.resolve(data as SessionMeta));
+    return fetchToJson('/oauth2/session', {}, false).then(data => Promise.resolve(data as SessionMeta));
 };

--- a/src/minoversikt/minoversikt-side.tsx
+++ b/src/minoversikt/minoversikt-side.tsx
@@ -41,8 +41,8 @@ import {lukkFeilTiltakModal} from '../ducks/lagret-filter-ui-state';
 import {FeilTiltakModal} from '../components/modal/mine-filter/feil-tiltak-modal';
 import {AppState} from '../reducer';
 import {Alert} from '@navikt/ds-react';
-import {Systemmeldinger} from '../components/systemmeldinger';
 import {IdentParam} from '../model-interfaces';
+import {Informasjonsmeldinger} from '../components/informasjonsmeldinger/informasjonsmeldinger';
 
 const oversiktType = OversiktType.minOversikt;
 const id = 'min-oversikt';
@@ -110,8 +110,7 @@ export default function MinoversiktSide() {
     return (
         <div className="side-storrelse" id={`side-storrelse_${id}`} data-testid={`side-storrelse_${id}`}>
             <ToppMeny erPaloggetVeileder={!visesAnnenVeiledersPortefolje} oversiktType={oversiktType} />
-            <Systemmeldinger />
-
+            <Informasjonsmeldinger />
             <Innholdslaster avhengigheter={[statustall]}>
                 <MinOversiktWrapper
                     className={classNames(

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -9,7 +9,7 @@ import lagPortefoljeStorrelser from './portefoljestorrelser';
 import features from './features';
 import {faker} from '@faker-js/faker/locale/nb_NO';
 import FetchMock, {MiddlewareUtils} from 'yet-another-fetch-mock';
-import {delayed, jsonResponse} from './utils';
+import {delayed, errorResponse, jsonResponse} from './utils';
 import {mineFilter} from './mine-filter';
 import {LagretFilter, SorteringOgId} from '../ducks/lagret-filter';
 import {hentSystemmeldinger} from './systemmeldinger';
@@ -282,7 +282,7 @@ mock.get(
         100,
         (() => {
             session = sessionData(true);
-            return jsonResponse(session);
+            return errorResponse(session, 401);
         })()
     )
 );

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -8,7 +8,7 @@ import {veiledergrupper} from './veiledergrupper';
 import lagPortefoljeStorrelser from './portefoljestorrelser';
 import features from './features';
 import {faker} from '@faker-js/faker/locale/nb_NO';
-import FetchMock, {MiddlewareUtils} from 'yet-another-fetch-mock';
+import FetchMock, {MiddlewareUtils, MockRequest, ResponseData} from 'yet-another-fetch-mock';
 import {delayed, errorResponse, jsonResponse} from './utils';
 import {mineFilter} from './mine-filter';
 import {LagretFilter, SorteringOgId} from '../ducks/lagret-filter';
@@ -16,7 +16,8 @@ import {hentSystemmeldinger} from './systemmeldinger';
 import {endringsloggListe} from './endringslogg';
 import {foedelandListMockData} from './foedeland';
 import {tolkebehovSpraakMockData} from './tolkebehovSpraak';
-import sessionData from './session';
+import getSessionData, {DEFAULT_SESSION_LIFETIME_IN_SECONDS, defaultSessionDataMockConfig} from './session';
+import {SessionMeta} from '../middleware/api';
 
 function lagPortefoljeForVeileder(queryParams, alleBrukere) {
     const enhetportefolje = lagPortefolje(queryParams, innloggetVeileder.enheter[0].enhetId, alleBrukere);
@@ -59,12 +60,35 @@ let customVeiledergrupper = veiledergrupper();
 let customMineFilter = mineFilter();
 let foedeland = foedelandListMockData();
 let tolkebehovSpraak = tolkebehovSpraakMockData();
-let session = sessionData();
+let sessionBaseTimestamp = Date.now();
+let sessionDataMockConfig = defaultSessionDataMockConfig(sessionBaseTimestamp);
+let sessionData: SessionMeta | null = null;
 
 const mock = FetchMock.configure({
     enableFallback: true,
-    middleware: MiddlewareUtils.combine(MiddlewareUtils.delayMiddleware(500), MiddlewareUtils.loggingMiddleware())
+    middleware: MiddlewareUtils.combine(
+        MiddlewareUtils.delayMiddleware(500),
+        MiddlewareUtils.loggingMiddleware(),
+        (request: MockRequest, response: ResponseData) => {
+            if (sesjonUtlopt()) {
+                return {status: 401};
+            } else {
+                return response;
+            }
+        }
+    )
 });
+
+const sesjonUtlopt = () => {
+    return sessionData?.tokens?.expire_at && Date.now() >= new Date(sessionData?.tokens?.expire_at).getTime();
+};
+
+// situasjon-api
+function tildel(body: any) {
+    return {feilendeTilordninger: []}; //uten feilende brukere
+    //return {feilendeTilordninger: [body[0]]}; //noen feilende brukere
+    //return {feilendeTilordninger: body}; //alle feilende brukere
+}
 
 // Azure Ad
 mock.get(
@@ -182,13 +206,6 @@ mock.get('/veilarbportefolje/api/arbeidsliste/:fodselsnummer', (req, res, ctx) =
 
 mock.get('/veilarbportefolje/api/veileder/:veileder/moteplan', jsonResponse(hentMockPlan()));
 
-// situasjon-api
-function tildel(body: any) {
-    return {feilendeTilordninger: []}; //uten feilende brukere
-    //return {feilendeTilordninger: [body[0]]}; //noen feilende brukere
-    //return {feilendeTilordninger: body}; //alle feilende brukere
-}
-
 //veilarbvedtakstøtte
 mock.get('/veilarbvedtaksstotte/api/utrulling/erUtrullet', jsonResponse(true));
 
@@ -275,16 +292,25 @@ mock.get('https://poao-sanity.intern.nav.no/systemmeldinger', jsonResponse(hentS
 mock.get('/veilarbportefolje/api/enhet/:enhetId/foedeland', delayed(500, jsonResponse(foedeland)));
 mock.get('/veilarbportefolje/api/enhet/:enhetId/tolkSpraak', delayed(500, jsonResponse(tolkebehovSpraak)));
 
-mock.get('/oauth2/session', delayed(100, jsonResponse(session)));
+mock.get(
+    '/oauth2/session',
+    delayed(100, (req, res, ctx) => {
+        sessionData = getSessionData(sessionDataMockConfig);
+        return jsonResponse(sessionData)(req, res, ctx);
+    })
+);
+
 mock.get(
     '/oauth2/session/refresh',
-    delayed(
-        100,
-        (() => {
-            session = sessionData(true);
-            return errorResponse(session, 401);
-        })()
-    )
+    delayed(100, (req, res, ctx) => {
+        if (sesjonUtlopt()) {
+            return errorResponse(401)(req, res, ctx);
+        }
+
+        sessionDataMockConfig = defaultSessionDataMockConfig(Date.now(), DEFAULT_SESSION_LIFETIME_IN_SECONDS);
+        sessionData = getSessionData(sessionDataMockConfig);
+        return jsonResponse(sessionData)(req, res, ctx);
+    })
 );
 
 // websocket

--- a/src/mocks/session.ts
+++ b/src/mocks/session.ts
@@ -1,31 +1,68 @@
 import {SessionMeta} from '../middleware/api';
 
-const sessionData = (isRefresh: boolean = false) => {
-    const outdatedAccessToken = isRefresh ? false : Math.random() < 5;
-    const tenHoursInSeconds: number = 10 * 60 * 60;
-    const oneHourInSeconds: number = 60 * 60;
-    const fiveMinutesInSeconds: number = 5 * 60;
-    const now: Date = new Date();
-    const nowIsoString: string = now.toISOString();
-    const nowPlusTenHoursIsoString: string = new Date(now.getTime() + tenHoursInSeconds * 1000).toISOString();
-    const nowPlusOneHourIsoString: string = new Date(now.getTime() + oneHourInSeconds * 1000).toISOString();
-    const nowMinusOneHourIsoString: string = new Date(now.getTime() - oneHourInSeconds * 1000).toISOString();
+type SessionDataMockConfig = {
+    createdAt: string;
+    tokensExpireTimestamp: number;
+    sessionExpireTimestamp: number;
+    tokensRefreshBufferPeriodMs: number;
+    tokensRefreshedAt?: string;
+};
+
+export const DEFAULT_SESSION_LIFETIME_IN_SECONDS = 10 * 60; // 10 minutes
+
+export const sessionData = ({
+    createdAt,
+    tokensExpireTimestamp,
+    sessionExpireTimestamp,
+    tokensRefreshBufferPeriodMs,
+    tokensRefreshedAt
+}: SessionDataMockConfig): SessionMeta => {
+    const nowTimestamp: number = Date.now();
 
     return {
         session: {
-            created_at: nowIsoString,
-            ends_at: nowPlusTenHoursIsoString,
-            ends_in_seconds: tenHoursInSeconds
+            created_at: createdAt,
+            ends_at: new Date(Math.floor(sessionExpireTimestamp)).toISOString(),
+            ends_in_seconds:
+                nowTimestamp >= sessionExpireTimestamp ? 0 : Math.floor((sessionExpireTimestamp - nowTimestamp) / 1000)
         },
         tokens: {
-            refreshed_at: outdatedAccessToken ? nowMinusOneHourIsoString : nowIsoString,
-            expire_at: outdatedAccessToken ? nowIsoString : nowPlusOneHourIsoString,
-            expire_in_seconds: outdatedAccessToken ? 0 : oneHourInSeconds,
-            next_auto_refresh_in_seconds: outdatedAccessToken ? 0 : oneHourInSeconds - fiveMinutesInSeconds,
+            refreshed_at: tokensRefreshedAt ? tokensRefreshedAt : createdAt,
+            expire_at: new Date(Math.floor(tokensExpireTimestamp)).toISOString(),
+            expire_in_seconds:
+                nowTimestamp >= tokensExpireTimestamp ? 0 : Math.floor((tokensExpireTimestamp - nowTimestamp) / 1000),
+            next_auto_refresh_in_seconds:
+                nowTimestamp >= tokensExpireTimestamp - tokensRefreshBufferPeriodMs
+                    ? 0
+                    : Math.floor((tokensExpireTimestamp - tokensRefreshBufferPeriodMs - nowTimestamp) / 1000),
             refresh_cooldown: false,
             refresh_cooldown_seconds: 0
         }
-    } as SessionMeta;
+    };
+};
+
+export const defaultSessionDataMockConfig = (
+    baseTimestamp: number,
+    extendSessionWithSeconds?: number
+): SessionDataMockConfig => {
+    const timeLeftInSessionSeconds = extendSessionWithSeconds
+        ? extendSessionWithSeconds
+        : DEFAULT_SESSION_LIFETIME_IN_SECONDS;
+    const timeLeftInTokensSeconds = timeLeftInSessionSeconds;
+    const sessionLifetimeSeconds = 10 * 60 * 60;
+    const tokensLifetimeSeconds = 60 * 60;
+
+    return {
+        createdAt: new Date(
+            baseTimestamp + timeLeftInSessionSeconds * 1000 - sessionLifetimeSeconds * 1000
+        ).toISOString(),
+        tokensExpireTimestamp: baseTimestamp + timeLeftInTokensSeconds * 1000,
+        sessionExpireTimestamp: baseTimestamp + timeLeftInSessionSeconds * 1000,
+        tokensRefreshBufferPeriodMs: 5 * 60 * 1000,
+        tokensRefreshedAt: new Date(
+            baseTimestamp + timeLeftInTokensSeconds * 1000 - tokensLifetimeSeconds * 1000
+        ).toISOString()
+    };
 };
 
 export default sessionData;

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -34,6 +34,6 @@ export function jsonResponse(json: any): MockHandler {
     return (req: MockRequest, res: MockResponse, ctx: MockContext) => res(ctx.json(json));
 }
 
-export function errorResponse(json: any, status: number): MockHandler {
+export function errorResponse(status: number): MockHandler {
     return (req: MockRequest, res: MockResponse, ctx: MockContext) => res(ctx.status(status));
 }

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -33,3 +33,7 @@ export function delayed(ms: number, handler: MockHandler): MockHandler {
 export function jsonResponse(json: any): MockHandler {
     return (req: MockRequest, res: MockResponse, ctx: MockContext) => res(ctx.json(json));
 }
+
+export function errorResponse(json: any, status: number): MockHandler {
+    return (req: MockRequest, res: MockResponse, ctx: MockContext) => res(ctx.status(status));
+}

--- a/src/model-interfaces.ts
+++ b/src/model-interfaces.ts
@@ -223,3 +223,8 @@ export interface Systemmelding {
 export interface IdentParam {
     ident: string;
 }
+
+export enum SesjonStatus {
+    GYLDIG = 'GYLDIG',
+    UTLOPT = 'UTLØPT'
+}

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -31,6 +31,7 @@ import lagretFilterUIState, {LagretFilterUIState} from './ducks/lagret-filter-ui
 import {LagretFilterState} from './ducks/lagret-filter';
 import foedelandListReducer, {FoedelandListState} from './ducks/foedeland';
 import tolkebehovListReducer, {TolkebehovSpraakListState} from './ducks/tolkebehov';
+import informasjonsmeldingReducer, {SesjonStatusState} from './ducks/informasjonsmelding';
 
 function named(name, reducer) {
     return (state, action) => {
@@ -79,6 +80,7 @@ export interface AppState {
     systemmeldinger: SystemmeldingState;
     foedelandList: FoedelandListState;
     tolkbehovSpraakList: TolkebehovSpraakListState;
+    sesjonStatus: SesjonStatusState;
 }
 
 export default combineReducers<AppState>({
@@ -143,5 +145,6 @@ export default combineReducers<AppState>({
     innloggetVeileder: innloggetVeilederReducer,
     systemmeldinger: systemmeldingerReducer,
     foedelandList: foedelandListReducer,
-    tolkbehovSpraakList: tolkebehovListReducer
+    tolkbehovSpraakList: tolkebehovListReducer,
+    sesjonStatus: informasjonsmeldingReducer
 });

--- a/src/style.css
+++ b/src/style.css
@@ -8,26 +8,32 @@
     border-spacing: 0;
     width: 100%;
 }
+
 .tabell caption {
     padding-top: 8px;
     padding-bottom: 8px;
     color: #7f756c;
     text-align: left;
 }
+
 .tabell td:first-child,
 .tabell th:first-child {
     border-left: 1px solid #6a6a6a;
 }
+
 .tabell td:last-child,
 .tabell th:last-child {
     border-right: 1px solid #6a6a6a;
 }
+
 .tabell th:last-child {
     border-right: none;
 }
+
 .tabell th:first-child {
     border-left: none;
 }
+
 .tabell thead th {
     background-color: #f4f4f4;
     border-bottom: 1px solid #6a6a6a;
@@ -35,13 +41,16 @@
     top: 2.5rem;
     -webkit-backface-visibility: hidden;
 }
+
 .tabell .tabellheader__lenke {
     display: flex;
 }
+
 .tabell .tabellheader__tekst {
     width: max-content;
     padding: 0.2rem;
 }
+
 .tabell .tabellheader__pil {
     width: 1rem;
     height: 1rem;
@@ -49,9 +58,11 @@
     float: left;
     margin-top: 2px;
 }
+
 .tabell th {
     text-align: left;
 }
+
 .tabell th,
 .tabell td {
     padding: 8px;
@@ -59,55 +70,67 @@
     vertical-align: top;
     border-top: 1px solid #a0a0a0;
 }
+
 .tabell thead tr:first-child th,
 .tabell thead tr:first-child td {
     border-top: none;
     font-weight: 100;
 }
+
 .tabell tbody tr:first-child th,
 .tabell tbody tr:first-child td {
     border-top-width: 2px;
 }
+
 .tabell tbody tr:last-child th,
 .tabell tbody tr:last-child td {
     border-bottom: none;
 }
+
 .tabell tbody tr:nth-child(odd) {
     background-color: #fff;
 }
+
 .tabell tbody th,
 .tabell tbody td {
     border-bottom: 1px solid #a0a0a0;
     border-top: none;
     font-weight: normal;
 }
+
 .tabell tbody th:first-child,
 .tabell tbody td:first-child {
     width: 30%;
     white-space: pre-wrap;
 }
+
 .tabell tbody th:nth-child(2),
 .tabell tbody td:nth-child(2) {
     width: 20%;
     white-space: pre-wrap;
 }
+
 .tabell tbody th:nth-child(3),
 .tabell tbody td:nth-child(3) {
     width: 7rem;
     white-space: pre-wrap;
 }
+
 .tabell-kompakt th,
 .tabell-kompakt td {
     padding: 5px;
 }
+
 table .tabell-element-center {
     text-align: center;
 }
+
 table col[class*='col-'] {
     position: static;
     float: none;
     display: table-column;
 }
+
 body {
     height: 100%;
     width: 100%;
@@ -118,11 +141,13 @@ body {
     background-color: #f4f4f4;
     filter: none;
 }
+
 @media print {
     body a[href]:after {
         content: none !important;
     }
 }
+
 body #mainapp {
     background-color: #fff;
     margin: 0 auto;
@@ -130,25 +155,31 @@ body #mainapp {
     max-height: 8rem;
     box-shadow: 0 2px 4px 0 rgba(183, 177, 169, 0.5);
 }
+
 @media (max-width: 870px) {
     body #mainapp {
         max-height: 10rem;
     }
 }
+
 @media (max-width: 782px) {
     body #mainapp {
         max-height: 11rem;
     }
 }
+
 html.darkmode {
     filter: invert(90%);
 }
+
 body.annen-veileder {
     background-color: #85d5f0;
 }
+
 html {
     height: 100%;
 }
+
 /*!
  * Bootstrap v3.3.7 (http://getbootstrap.com)
  * Copyright 2011-2016 Twitter, Inc.
@@ -176,6 +207,7 @@ html {
     font-family: sans-serif;
     /* 3 */
 }
+
 /* Sections
    ========================================================================== */
 /**
@@ -184,12 +216,14 @@ html {
 body {
     margin: 0;
 }
+
 /**
  * Render the `main` element consistently in IE.
  */
 main {
     display: block;
 }
+
 /**
  * Correct the font size and margin on `h1` elements within `section` and
  * `article` contexts in Chrome, Firefox, and Safari.
@@ -198,6 +232,7 @@ h1 {
     font-size: 2em;
     margin: 0.67em 0;
 }
+
 /* Grouping content
    ========================================================================== */
 /**
@@ -212,6 +247,7 @@ hr {
     overflow: visible;
     /* 2 */
 }
+
 /**
  * 1. Correct the inheritance and scaling of font size in all browsers.
  * 2. Correct the odd `em` font sizing in all browsers.
@@ -222,6 +258,7 @@ pre {
     font-size: 1em;
     /* 2 */
 }
+
 /* Text-level semantics
    ========================================================================== */
 /**
@@ -230,6 +267,7 @@ pre {
 a {
     background-color: transparent;
 }
+
 /**
  * 1. Remove the bottom border in Chrome 57-
  * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
@@ -242,6 +280,7 @@ abbr[title] {
     text-decoration: underline dotted;
     /* 2 */
 }
+
 /**
  * Add the correct font weight in Chrome, Edge, and Safari.
  */
@@ -249,6 +288,7 @@ b,
 strong {
     font-weight: bolder;
 }
+
 /**
  * 1. Correct the inheritance and scaling of font size in all browsers.
  * 2. Correct the odd `em` font sizing in all browsers.
@@ -261,12 +301,14 @@ samp {
     font-size: 1em;
     /* 2 */
 }
+
 /**
  * Add the correct font size in all browsers.
  */
 small {
     font-size: 80%;
 }
+
 /**
  * Prevent `sub` and `sup` elements from affecting the line height in
  * all browsers.
@@ -278,12 +320,15 @@ sup {
     position: relative;
     vertical-align: baseline;
 }
+
 sub {
     bottom: -0.25em;
 }
+
 sup {
     top: -0.5em;
 }
+
 /* Embedded content
    ========================================================================== */
 /**
@@ -292,6 +337,7 @@ sup {
 img {
     border-style: none;
 }
+
 /* Forms
    ========================================================================== */
 /**
@@ -312,6 +358,7 @@ textarea {
     margin: 0;
     /* 2 */
 }
+
 /**
  * Show the overflow in IE.
  * 1. Show the overflow in Edge.
@@ -321,6 +368,7 @@ input {
     /* 1 */
     overflow: visible;
 }
+
 /**
  * Remove the inheritance of text transform in Edge, Firefox, and IE.
  * 1. Remove the inheritance of text transform in Firefox.
@@ -330,6 +378,7 @@ select {
     /* 1 */
     text-transform: none;
 }
+
 /**
  * Correct the inability to style clickable types in iOS and Safari.
  */
@@ -339,6 +388,7 @@ button,
 [type='submit'] {
     -webkit-appearance: button;
 }
+
 /**
  * Remove the inner border and padding in Firefox.
  */
@@ -349,6 +399,7 @@ button::-moz-focus-inner,
     border-style: none;
     padding: 0;
 }
+
 /**
  * Restore the focus styles unset by the previous rule.
  */
@@ -358,12 +409,14 @@ button:-moz-focusring,
 [type='submit']:-moz-focusring {
     outline: 1px dotted ButtonText;
 }
+
 /**
  * Correct the padding in Firefox.
  */
 fieldset {
     padding: 0.35em 0.75em 0.625em;
 }
+
 /**
  * 1. Correct the text wrapping in Edge and IE.
  * 2. Correct the color inheritance from `fieldset` elements in IE.
@@ -384,18 +437,21 @@ legend {
     white-space: normal;
     /* 1 */
 }
+
 /**
  * Add the correct vertical alignment in Chrome, Firefox, and Opera.
  */
 progress {
     vertical-align: baseline;
 }
+
 /**
  * Remove the default vertical scrollbar in IE 10+.
  */
 textarea {
     overflow: auto;
 }
+
 /**
  * 1. Add the correct box sizing in IE 10.
  * 2. Remove the padding in IE 10.
@@ -407,6 +463,7 @@ textarea {
     padding: 0;
     /* 2 */
 }
+
 /**
  * Correct the cursor style of increment and decrement buttons in Chrome.
  */
@@ -414,6 +471,7 @@ textarea {
 [type='number']::-webkit-outer-spin-button {
     height: auto;
 }
+
 /**
  * 1. Correct the odd appearance in Chrome and Safari.
  * 2. Correct the outline style in Safari.
@@ -424,12 +482,14 @@ textarea {
     outline-offset: -2px;
     /* 2 */
 }
+
 /**
  * Remove the inner padding in Chrome and Safari on macOS.
  */
 [type='search']::-webkit-search-decoration {
     -webkit-appearance: none;
 }
+
 /**
  * 1. Correct the inability to style clickable types in iOS and Safari.
  * 2. Change font properties to `inherit` in Safari.
@@ -440,6 +500,7 @@ textarea {
     font: inherit;
     /* 2 */
 }
+
 /* Interactive
    ========================================================================== */
 /*
@@ -448,12 +509,14 @@ textarea {
 details {
     display: block;
 }
+
 /*
  * Add the correct display in all browsers.
  */
 summary {
     display: list-item;
 }
+
 /* Misc
    ========================================================================== */
 /**
@@ -462,12 +525,14 @@ summary {
 template {
     display: none;
 }
+
 /**
  * Add the correct display in IE 10.
  */
 [hidden] {
     display: none;
 }
+
 /*! Source: https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css */
 @media print {
     *,
@@ -478,62 +543,76 @@ template {
         box-shadow: none !important;
         text-shadow: none !important;
     }
+
     a,
     a:visited {
         text-decoration: underline;
     }
+
     a[href]::after {
         content: ' (' attr(href) ')';
     }
+
     abbr[title]::after {
         content: ' (' attr(title) ')';
     }
+
     a[href^='#']::after,
     a[href^='javascript:']::after {
         content: '';
     }
+
     pre,
     blockquote {
         border: 1px solid #999;
         page-break-inside: avoid;
     }
+
     thead {
         display: table-header-group;
     }
+
     tr,
     img {
         page-break-inside: avoid;
     }
+
     img {
         max-width: 100% !important;
     }
+
     p,
     h2,
     h3 {
         orphans: 3;
         widows: 3;
     }
+
     h2,
     h3 {
         page-break-after: avoid;
     }
 }
+
 * {
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
 }
+
 *::before,
 *::after {
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
 }
+
 html {
     font-size: 100%;
     font-family: sans-serif;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
+
 input,
 button,
 select,
@@ -542,23 +621,29 @@ textarea {
     font-size: inherit;
     line-height: inherit;
 }
+
 figure {
     margin: 0;
 }
+
 img {
     vertical-align: middle;
 }
+
 .img-responsive {
     display: block;
     max-width: 100%;
     height: auto;
 }
+
 .img-rounded {
     border-radius: 6px;
 }
+
 .img-circle {
     border-radius: 50%;
 }
+
 .sr-only {
     position: absolute;
     width: 1px;
@@ -570,6 +655,7 @@ img {
     border: 0;
     white-space: nowrap;
 }
+
 .sr-only-focusable:active,
 .sr-only-focusable:focus {
     position: static;
@@ -579,40 +665,51 @@ img {
     overflow: visible;
     clip: auto;
 }
+
 [role='button'] {
     cursor: pointer;
 }
+
 body .clearfix::before,
 body .clearfix::after {
     content: ' ';
     display: table;
 }
+
 body .clearfix::after {
     clear: both;
 }
+
 body .center-block {
     display: block;
     margin-left: auto;
     margin-right: auto;
 }
+
 body .pull-right {
     float: right !important;
 }
+
 body .pull-left {
     float: left !important;
 }
+
 body .hide {
     display: none !important;
 }
+
 body .show {
     display: block !important;
 }
+
 body .hidden {
     display: none !important;
 }
+
 body .invisible {
     visibility: hidden;
 }
+
 body .text-hide {
     font: 0px/0 a;
     color: transparent;
@@ -621,61 +718,77 @@ body .text-hide {
     border: 0;
     position: absolute;
 }
+
 body .ustilet {
     margin: 0;
     padding: 0;
     list-style: none;
 }
+
 body .blokk {
     margin-bottom: 2rem;
 }
+
 body .blokk-null {
     margin-bottom: 0;
 }
+
 body .blokk-xxxs {
     margin-bottom: 4px;
 }
+
 body .blokk-xxs {
     margin-bottom: 0.5rem;
 }
+
 body .blokk-xs {
     margin-bottom: 1rem;
 }
+
 body .blokk-s {
     margin-bottom: 20px;
 }
+
 body .blokk-m {
     margin-bottom: 2rem;
 }
+
 body .blokk-l {
     margin-bottom: 2.5rem;
 }
+
 body .blokk-xl {
     margin-bottom: 4rem;
 }
+
 @-ms-viewport {
     width: device-width;
 }
+
 @media (max-width: 767px) {
     .hidden-xs {
         display: none !important;
     }
 }
+
 @media (min-width: 768px) and (max-width: 991px) {
     .hidden-sm {
         display: none !important;
     }
 }
+
 @media (min-width: 992px) and (max-width: 1199px) {
     .hidden-md {
         display: none !important;
     }
 }
+
 @media (min-width: 1200px) {
     .hidden-lg {
         display: none !important;
     }
 }
+
 /*
 ------------
  GRID FROM GRID-FRAMEWORK
@@ -697,29 +810,35 @@ GRID
     -moz-box-sizing: border-box;
     box-sizing: border-box;
 }
+
 .container::before,
 .container::after {
     content: ' ';
     display: table;
 }
+
 .container::after {
     clear: both;
 }
+
 @media (min-width: 768px) {
     .container {
         width: 736px;
     }
 }
+
 @media (min-width: 992px) {
     .container {
         width: 956px;
     }
 }
+
 @media (min-width: 1200px) {
     .container {
         width: 1156px;
     }
 }
+
 .container-fluid {
     margin-right: auto;
     margin-left: auto;
@@ -729,14 +848,17 @@ GRID
     -moz-box-sizing: border-box;
     box-sizing: border-box;
 }
+
 .container-fluid::before,
 .container-fluid::after {
     content: ' ';
     display: table;
 }
+
 .container-fluid::after {
     clear: both;
 }
+
 .row {
     margin-left: -8px;
     margin-right: -8px;
@@ -744,14 +866,17 @@ GRID
     -moz-box-sizing: border-box;
     box-sizing: border-box;
 }
+
 .row::before,
 .row::after {
     content: ' ';
     display: table;
 }
+
 .row::after {
     clear: both;
 }
+
 .col-xs-1,
 .col-sm-1,
 .col-md-1,
@@ -806,6 +931,7 @@ GRID
     padding-left: 8px;
     padding-right: 8px;
 }
+
 .col-xs-1,
 .col-xs-2,
 .col-xs-2-5,
@@ -821,162 +947,215 @@ GRID
 .col-xs-12 {
     float: left;
 }
+
 .col-xs-12 {
     width: 100%;
 }
+
 .col-xs-11 {
     width: 91.66666667%;
 }
+
 .col-xs-10 {
     width: 83.33333333%;
 }
+
 .col-xs-9 {
     width: 75%;
 }
+
 .col-xs-8 {
     width: 66.66666667%;
 }
+
 .col-xs-7 {
     width: 58.33333333%;
 }
+
 .col-xs-6 {
     width: 50%;
 }
+
 .col-xs-5 {
     width: 41.66666667%;
 }
+
 .col-xs-4 {
     width: 33.33333333%;
 }
+
 .col-xs-3 {
     width: 25%;
 }
+
 .col-xs-2-5 {
     width: 20%;
 }
+
 .col-xs-2 {
     width: 16.66666667%;
 }
+
 .col-xs-1 {
     width: 8.33333333%;
 }
+
 .col-xs-pull-12 {
     right: 100%;
 }
+
 .col-xs-pull-11 {
     right: 91.66666667%;
 }
+
 .col-xs-pull-10 {
     right: 83.33333333%;
 }
+
 .col-xs-pull-9 {
     right: 75%;
 }
+
 .col-xs-pull-8 {
     right: 66.66666667%;
 }
+
 .col-xs-pull-7 {
     right: 58.33333333%;
 }
+
 .col-xs-pull-6 {
     right: 50%;
 }
+
 .col-xs-pull-5 {
     right: 41.66666667%;
 }
+
 .col-xs-pull-4 {
     right: 33.33333333%;
 }
+
 .col-xs-pull-3 {
     right: 25%;
 }
+
 .col-xs-pull-2 {
     right: 16.66666667%;
 }
+
 .col-xs-pull-1 {
     right: 8.33333333%;
 }
+
 .col-xs-pull-0 {
     right: auto;
 }
+
 .col-xs-push-12 {
     left: 100%;
 }
+
 .col-xs-push-11 {
     left: 91.66666667%;
 }
+
 .col-xs-push-10 {
     left: 83.33333333%;
 }
+
 .col-xs-push-9 {
     left: 75%;
 }
+
 .col-xs-push-8 {
     left: 66.66666667%;
 }
+
 .col-xs-push-7 {
     left: 58.33333333%;
 }
+
 .col-xs-push-6 {
     left: 50%;
 }
+
 .col-xs-push-5 {
     left: 41.66666667%;
 }
+
 .col-xs-push-4 {
     left: 33.33333333%;
 }
+
 .col-xs-push-3 {
     left: 25%;
 }
+
 .col-xs-push-2 {
     left: 16.66666667%;
 }
+
 .col-xs-push-1 {
     left: 8.33333333%;
 }
+
 .col-xs-push-0 {
     left: auto;
 }
+
 .col-xs-offset-12 {
     margin-left: 100%;
 }
+
 .col-xs-offset-11 {
     margin-left: 91.66666667%;
 }
+
 .col-xs-offset-10 {
     margin-left: 83.33333333%;
 }
+
 .col-xs-offset-9 {
     margin-left: 75%;
 }
+
 .col-xs-offset-8 {
     margin-left: 66.66666667%;
 }
+
 .col-xs-offset-7 {
     margin-left: 58.33333333%;
 }
+
 .col-xs-offset-6 {
     margin-left: 50%;
 }
+
 .col-xs-offset-5 {
     margin-left: 41.66666667%;
 }
+
 .col-xs-offset-4 {
     margin-left: 33.33333333%;
 }
+
 .col-xs-offset-3 {
     margin-left: 25%;
 }
+
 .col-xs-offset-2 {
     margin-left: 16.66666667%;
 }
+
 .col-xs-offset-1 {
     margin-left: 8.33333333%;
 }
+
 .col-xs-offset-0 {
     margin-left: 0%;
 }
+
 @media (min-width: 768px) {
     .col-sm-1,
     .col-sm-2,
@@ -992,160 +1171,212 @@ GRID
     .col-sm-12 {
         float: left;
     }
+
     .col-sm-12 {
         width: 100%;
     }
+
     .col-sm-11 {
         width: 91.66666667%;
     }
+
     .col-sm-10 {
         width: 83.33333333%;
     }
+
     .col-sm-9 {
         width: 75%;
     }
+
     .col-sm-8 {
         width: 66.66666667%;
     }
+
     .col-sm-7 {
         width: 58.33333333%;
     }
+
     .col-sm-6 {
         width: 50%;
     }
+
     .col-sm-5 {
         width: 41.66666667%;
     }
+
     .col-sm-4 {
         width: 33.33333333%;
     }
+
     .col-sm-3 {
         width: 25%;
     }
+
     .col-sm-2 {
         width: 16.66666667%;
     }
+
     .col-sm-1 {
         width: 8.33333333%;
     }
+
     .col-sm-pull-12 {
         right: 100%;
     }
+
     .col-sm-pull-11 {
         right: 91.66666667%;
     }
+
     .col-sm-pull-10 {
         right: 83.33333333%;
     }
+
     .col-sm-pull-9 {
         right: 75%;
     }
+
     .col-sm-pull-8 {
         right: 66.66666667%;
     }
+
     .col-sm-pull-7 {
         right: 58.33333333%;
     }
+
     .col-sm-pull-6 {
         right: 50%;
     }
+
     .col-sm-pull-5 {
         right: 41.66666667%;
     }
+
     .col-sm-pull-4 {
         right: 33.33333333%;
     }
+
     .col-sm-pull-3 {
         right: 25%;
     }
+
     .col-sm-pull-2 {
         right: 16.66666667%;
     }
+
     .col-sm-pull-1 {
         right: 8.33333333%;
     }
+
     .col-sm-pull-0 {
         right: auto;
     }
+
     .col-sm-push-12 {
         left: 100%;
     }
+
     .col-sm-push-11 {
         left: 91.66666667%;
     }
+
     .col-sm-push-10 {
         left: 83.33333333%;
     }
+
     .col-sm-push-9 {
         left: 75%;
     }
+
     .col-sm-push-8 {
         left: 66.66666667%;
     }
+
     .col-sm-push-7 {
         left: 58.33333333%;
     }
+
     .col-sm-push-6 {
         left: 50%;
     }
+
     .col-sm-push-5 {
         left: 41.66666667%;
     }
+
     .col-sm-push-4 {
         left: 33.33333333%;
     }
+
     .col-sm-push-3 {
         left: 25%;
     }
+
     .col-sm-push-2 {
         left: 16.66666667%;
     }
+
     .col-sm-push-1 {
         left: 8.33333333%;
     }
+
     .col-sm-push-0 {
         left: auto;
     }
+
     .col-sm-offset-12 {
         margin-left: 100%;
     }
+
     .col-sm-offset-11 {
         margin-left: 91.66666667%;
     }
+
     .col-sm-offset-10 {
         margin-left: 83.33333333%;
     }
+
     .col-sm-offset-9 {
         margin-left: 75%;
     }
+
     .col-sm-offset-8 {
         margin-left: 66.66666667%;
     }
+
     .col-sm-offset-7 {
         margin-left: 58.33333333%;
     }
+
     .col-sm-offset-6 {
         margin-left: 50%;
     }
+
     .col-sm-offset-5 {
         margin-left: 41.66666667%;
     }
+
     .col-sm-offset-4 {
         margin-left: 33.33333333%;
     }
+
     .col-sm-offset-3 {
         margin-left: 25%;
     }
+
     .col-sm-offset-2 {
         margin-left: 16.66666667%;
     }
+
     .col-sm-offset-1 {
         margin-left: 8.33333333%;
     }
+
     .col-sm-offset-0 {
         margin-left: 0%;
     }
 }
+
 @media (min-width: 992px) {
     .col-md-1,
     .col-md-2,
@@ -1161,160 +1392,212 @@ GRID
     .col-md-12 {
         float: left;
     }
+
     .col-md-12 {
         width: 100%;
     }
+
     .col-md-11 {
         width: 91.66666667%;
     }
+
     .col-md-10 {
         width: 83.33333333%;
     }
+
     .col-md-9 {
         width: 75%;
     }
+
     .col-md-8 {
         width: 66.66666667%;
     }
+
     .col-md-7 {
         width: 58.33333333%;
     }
+
     .col-md-6 {
         width: 50%;
     }
+
     .col-md-5 {
         width: 41.66666667%;
     }
+
     .col-md-4 {
         width: 33.33333333%;
     }
+
     .col-md-3 {
         width: 25%;
     }
+
     .col-md-2 {
         width: 16.66666667%;
     }
+
     .col-md-1 {
         width: 8.33333333%;
     }
+
     .col-md-pull-12 {
         right: 100%;
     }
+
     .col-md-pull-11 {
         right: 91.66666667%;
     }
+
     .col-md-pull-10 {
         right: 83.33333333%;
     }
+
     .col-md-pull-9 {
         right: 75%;
     }
+
     .col-md-pull-8 {
         right: 66.66666667%;
     }
+
     .col-md-pull-7 {
         right: 58.33333333%;
     }
+
     .col-md-pull-6 {
         right: 50%;
     }
+
     .col-md-pull-5 {
         right: 41.66666667%;
     }
+
     .col-md-pull-4 {
         right: 33.33333333%;
     }
+
     .col-md-pull-3 {
         right: 25%;
     }
+
     .col-md-pull-2 {
         right: 16.66666667%;
     }
+
     .col-md-pull-1 {
         right: 8.33333333%;
     }
+
     .col-md-pull-0 {
         right: auto;
     }
+
     .col-md-push-12 {
         left: 100%;
     }
+
     .col-md-push-11 {
         left: 91.66666667%;
     }
+
     .col-md-push-10 {
         left: 83.33333333%;
     }
+
     .col-md-push-9 {
         left: 75%;
     }
+
     .col-md-push-8 {
         left: 66.66666667%;
     }
+
     .col-md-push-7 {
         left: 58.33333333%;
     }
+
     .col-md-push-6 {
         left: 50%;
     }
+
     .col-md-push-5 {
         left: 41.66666667%;
     }
+
     .col-md-push-4 {
         left: 33.33333333%;
     }
+
     .col-md-push-3 {
         left: 25%;
     }
+
     .col-md-push-2 {
         left: 16.66666667%;
     }
+
     .col-md-push-1 {
         left: 8.33333333%;
     }
+
     .col-md-push-0 {
         left: auto;
     }
+
     .col-md-offset-12 {
         margin-left: 100%;
     }
+
     .col-md-offset-11 {
         margin-left: 91.66666667%;
     }
+
     .col-md-offset-10 {
         margin-left: 83.33333333%;
     }
+
     .col-md-offset-9 {
         margin-left: 75%;
     }
+
     .col-md-offset-8 {
         margin-left: 66.66666667%;
     }
+
     .col-md-offset-7 {
         margin-left: 58.33333333%;
     }
+
     .col-md-offset-6 {
         margin-left: 50%;
     }
+
     .col-md-offset-5 {
         margin-left: 41.66666667%;
     }
+
     .col-md-offset-4 {
         margin-left: 33.33333333%;
     }
+
     .col-md-offset-3 {
         margin-left: 25%;
     }
+
     .col-md-offset-2 {
         margin-left: 16.66666667%;
     }
+
     .col-md-offset-1 {
         margin-left: 8.33333333%;
     }
+
     .col-md-offset-0 {
         margin-left: 0%;
     }
 }
+
 @media (min-width: 1200px) {
     .col-lg-1,
     .col-lg-2,
@@ -1330,160 +1613,212 @@ GRID
     .col-lg-12 {
         float: left;
     }
+
     .col-lg-12 {
         width: 100%;
     }
+
     .col-lg-11 {
         width: 91.66666667%;
     }
+
     .col-lg-10 {
         width: 83.33333333%;
     }
+
     .col-lg-9 {
         width: 75%;
     }
+
     .col-lg-8 {
         width: 66.66666667%;
     }
+
     .col-lg-7 {
         width: 58.33333333%;
     }
+
     .col-lg-6 {
         width: 50%;
     }
+
     .col-lg-5 {
         width: 41.66666667%;
     }
+
     .col-lg-4 {
         width: 33.33333333%;
     }
+
     .col-lg-3 {
         width: 25%;
     }
+
     .col-lg-2 {
         width: 16.66666667%;
     }
+
     .col-lg-1 {
         width: 8.33333333%;
     }
+
     .col-lg-pull-12 {
         right: 100%;
     }
+
     .col-lg-pull-11 {
         right: 91.66666667%;
     }
+
     .col-lg-pull-10 {
         right: 83.33333333%;
     }
+
     .col-lg-pull-9 {
         right: 75%;
     }
+
     .col-lg-pull-8 {
         right: 66.66666667%;
     }
+
     .col-lg-pull-7 {
         right: 58.33333333%;
     }
+
     .col-lg-pull-6 {
         right: 50%;
     }
+
     .col-lg-pull-5 {
         right: 41.66666667%;
     }
+
     .col-lg-pull-4 {
         right: 33.33333333%;
     }
+
     .col-lg-pull-3 {
         right: 25%;
     }
+
     .col-lg-pull-2 {
         right: 16.66666667%;
     }
+
     .col-lg-pull-1 {
         right: 8.33333333%;
     }
+
     .col-lg-pull-0 {
         right: auto;
     }
+
     .col-lg-push-12 {
         left: 100%;
     }
+
     .col-lg-push-11 {
         left: 91.66666667%;
     }
+
     .col-lg-push-10 {
         left: 83.33333333%;
     }
+
     .col-lg-push-9 {
         left: 75%;
     }
+
     .col-lg-push-8 {
         left: 66.66666667%;
     }
+
     .col-lg-push-7 {
         left: 58.33333333%;
     }
+
     .col-lg-push-6 {
         left: 50%;
     }
+
     .col-lg-push-5 {
         left: 41.66666667%;
     }
+
     .col-lg-push-4 {
         left: 33.33333333%;
     }
+
     .col-lg-push-3 {
         left: 25%;
     }
+
     .col-lg-push-2 {
         left: 16.66666667%;
     }
+
     .col-lg-push-1 {
         left: 8.33333333%;
     }
+
     .col-lg-push-0 {
         left: auto;
     }
+
     .col-lg-offset-12 {
         margin-left: 100%;
     }
+
     .col-lg-offset-11 {
         margin-left: 91.66666667%;
     }
+
     .col-lg-offset-10 {
         margin-left: 83.33333333%;
     }
+
     .col-lg-offset-9 {
         margin-left: 75%;
     }
+
     .col-lg-offset-8 {
         margin-left: 66.66666667%;
     }
+
     .col-lg-offset-7 {
         margin-left: 58.33333333%;
     }
+
     .col-lg-offset-6 {
         margin-left: 50%;
     }
+
     .col-lg-offset-5 {
         margin-left: 41.66666667%;
     }
+
     .col-lg-offset-4 {
         margin-left: 33.33333333%;
     }
+
     .col-lg-offset-3 {
         margin-left: 25%;
     }
+
     .col-lg-offset-2 {
         margin-left: 16.66666667%;
     }
+
     .col-lg-offset-1 {
         margin-left: 8.33333333%;
     }
+
     .col-lg-offset-0 {
         margin-left: 0%;
     }
 }
+
 .col,
 .row,
 .container,
@@ -1492,23 +1827,28 @@ GRID
     -moz-box-sizing: border-box;
     box-sizing: border-box;
 }
+
 .ReactCollapse--collapse {
     transition: height 250ms cubic-bezier(0.4, 0, 0.2, 1);
 }
+
 .ekspanderbartPanel {
     position: relative;
     background: white;
     border-radius: 0.25rem;
 }
+
 .ekspanderbartPanel:hover,
 .ekspanderbartPanel--hover {
     box-shadow: #a0a0a0 0 2px 1px 0;
 }
+
 .ekspanderbartPanel:focus,
 .ekspanderbartPanel--focus {
     box-shadow: 0 0 0 3px #00347d;
     outline: none;
 }
+
 .ekspanderbartPanel__hode {
     background-color: #fff;
     display: block;
@@ -1520,6 +1860,7 @@ GRID
     width: 100%;
     margin-bottom: 0;
 }
+
 .ekspanderbartPanel__hode .ekspanderbartPanel__tittel {
     font-family: 'Source Sans Pro', Arial, sans-serif;
     font-size: 1.25rem;
@@ -1527,29 +1868,35 @@ GRID
     font-weight: 600;
     color: #262626;
 }
+
 .ekspanderbartPanel__hode:hover,
 .ekspanderbartPanel__hode--hover {
     cursor: pointer;
 }
+
 .ekspanderbartPanel__hode:hover .ekspanderbartPanel__tittel,
 .ekspanderbartPanel__hode--hover .ekspanderbartPanel__tittel {
     text-decoration: underline;
     color: #0067c5;
 }
+
 .ekspanderbartPanel__hode:focus,
 .ekspanderbartPanel__hode--focus {
     box-shadow: 0 0 0 3px #00347d;
     outline: none;
 }
+
 .ekspanderbartPanel__flex-wrapper {
     display: flex;
     align-items: center;
     justify-content: space-between;
 }
+
 .ekspanderbartPanel__innhold {
     padding: 1rem;
     padding-top: 0.5rem;
 }
+
 .ekspanderbartPanel--lukket .ekspanderbartPanel__indikator {
     display: inline-block;
     flex-shrink: 0;
@@ -1561,11 +1908,13 @@ GRID
     transition: 200ms transform;
     vertical-align: middle;
 }
+
 .ekspanderbartPanel--lukket .ekspanderbartPanel__indikator::before,
 .ekspanderbartPanel--lukket .ekspanderbartPanel__indikator::after {
     transition: 200ms transform;
     border-radius: 10px;
 }
+
 .ekspanderbartPanel--lukket .ekspanderbartPanel__indikator::before {
     content: '';
     position: absolute;
@@ -1575,6 +1924,7 @@ GRID
     width: 50%;
     background: currentColor;
 }
+
 .ekspanderbartPanel--lukket .ekspanderbartPanel__indikator::after {
     content: '';
     position: absolute;
@@ -1584,30 +1934,38 @@ GRID
     width: 50%;
     background: currentColor;
 }
+
 .ekspanderbartPanel--lukket .ekspanderbartPanel__indikator::before {
     transform: translateX(2px) rotate(45deg);
 }
+
 .ekspanderbartPanel--lukket .ekspanderbartPanel__indikator::after {
     transform: translateX(-2px) rotate(-45deg);
 }
+
 .ekspanderbartPanel--border {
     border: 1px solid #6a6a6a;
 }
+
 .ekspanderbartPanel--border:hover,
 .ekspanderbartPanel--border.panel-interaktiv-mixin--hover {
     border: 1px solid #0067c5;
 }
+
 .ekspanderbartPanel--border.ekspanderbartPanel--apen {
     border: 1px solid #6a6a6a;
 }
+
 .ekspanderbartPanel--apen > .ekspanderbartPanel__hode {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
 }
+
 .ekspanderbartPanel--apen .ekspanderbartPanel__innhold {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
 }
+
 .ekspanderbartPanel--apen > .ekspanderbartPanel__hode .ekspanderbartPanel__indikator {
     display: inline-block;
     flex-shrink: 0;
@@ -1619,11 +1977,13 @@ GRID
     transition: 200ms transform;
     vertical-align: middle;
 }
+
 .ekspanderbartPanel--apen > .ekspanderbartPanel__hode .ekspanderbartPanel__indikator::before,
 .ekspanderbartPanel--apen > .ekspanderbartPanel__hode .ekspanderbartPanel__indikator::after {
     transition: 200ms transform;
     border-radius: 10px;
 }
+
 .ekspanderbartPanel--apen > .ekspanderbartPanel__hode .ekspanderbartPanel__indikator::before {
     content: '';
     position: absolute;
@@ -1633,6 +1993,7 @@ GRID
     width: 50%;
     background: currentColor;
 }
+
 .ekspanderbartPanel--apen > .ekspanderbartPanel__hode .ekspanderbartPanel__indikator::after {
     content: '';
     position: absolute;
@@ -1642,65 +2003,82 @@ GRID
     width: 50%;
     background: currentColor;
 }
+
 .ekspanderbartPanel--apen > .ekspanderbartPanel__hode .ekspanderbartPanel__indikator::before {
     transform: translateX(2px) rotate(-45deg);
 }
+
 .ekspanderbartPanel--apen > .ekspanderbartPanel__hode .ekspanderbartPanel__indikator::after {
     transform: translateX(-2px) rotate(45deg);
 }
+
 .begrensetbredde {
     max-width: 35rem;
 }
+
 .text-hide {
     position: absolute;
 }
+
 .decorator-context-modal {
     padding: 1rem;
 }
+
 .modal__overlay {
     z-index: 2000;
 }
+
 .flex {
     display: flex;
 }
+
 .flex--center {
     align-items: center;
 }
+
 .flex--grow {
     flex-grow: 1;
 }
+
 .mr1 {
     margin-right: 1rem;
 }
+
 .text--left {
     text-align: left !important;
 }
+
 .sticky-container {
     z-index: 5;
     background-color: #f4f4f4;
 }
+
 .ikke-sticky__skygge {
     height: 16px;
     top: -16px;
 }
+
 .ikke-sticky__toolbar-container {
     position: sticky;
     top: 0;
     border-bottom: 1px solid #6a6a6a;
     z-index: 3;
 }
+
 .ikke-sticky__container {
     position: inherit;
     top: 0;
     z-index: 1;
     background-color: #f4f4f4;
 }
+
 .sticky-skygge {
     z-index: 1;
     -webkit-backface-visibility: hidden;
     height: 16px;
     top: -16px;
 }
+
 .toolbar-container {
     position: sticky;
     top: 0;
@@ -1713,6 +2091,7 @@ GRID
     grid-template-columns: 21.8rem auto;
     grid-template-rows: auto auto auto;
 }
+
 .toolbar-container .tabellinfo {
     grid-row: 1;
     grid-column-start: 1;
@@ -1720,24 +2099,29 @@ GRID
     display: grid;
     grid-template-columns: 40% 60%;
 }
+
 .toolbar-container .tabellinfo__hidden {
     grid-column-start: 2;
 }
+
 .toolbar-container .tabellinfo .tabelloverskrift {
     background-color: #f4f4f4;
     grid-column: 1;
 }
+
 .toolbar-container .toolbar {
     grid-column-start: 1;
     grid-column-end: 3;
     grid-row: 2;
     margin-top: 0.5rem;
 }
+
 .toolbar-container .brukerliste__header {
     grid-column-start: 1;
     grid-column-end: 3;
     grid-row: 3;
 }
+
 .sticky-skygge::before,
 .sticky-skygge::after {
     content: '';
@@ -1745,11 +2129,13 @@ GRID
     height: 16px;
     position: sticky;
 }
+
 .sticky-skygge::before {
     top: 142px;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
     margin: 0 4px;
 }
+
 .sticky-skygge::after {
     background: linear-gradient(white, rgba(255, 255, 255, 0.3));
     top: 0;
@@ -1757,30 +2143,36 @@ GRID
     height: 0;
     width: auto;
 }
+
 .skjemaelement {
     margin-bottom: 0.5rem;
 }
+
 .veilarbportefoljeflatefs .barinput-checkbox,
 .veilarbportefoljeflatefs .barinput-radio {
     display: flex;
     justify-content: space-between;
     margin-bottom: 5px;
 }
+
 .veilarbportefoljeflatefs .barinput-checkbox__input,
 .veilarbportefoljeflatefs .barinput-radio__input {
     margin-right: 1rem;
     align-self: center;
     transform: scale(1.5);
 }
+
 .veilarbportefoljeflatefs .barinput-checkbox .arbeidslisteikon__svg,
 .veilarbportefoljeflatefs .barinput-radio .arbeidslisteikon__svg {
     margin-right: 0.5rem;
 }
+
 .veilarbportefoljeflatefs .barlabel {
     display: flex;
     justify-content: space-between;
     margin-top: 2px;
 }
+
 .veilarbportefoljeflatefs .barlabel__labeltext {
     width: 100%;
     padding-right: 0.5rem;
@@ -1788,9 +2180,11 @@ GRID
     display: inline-flex;
     align-items: center;
 }
+
 .veilarbportefoljeflatefs .barlabel__labeltext:hover {
     color: #0067c5;
 }
+
 .veilarbportefoljeflatefs .barlabel__barwrapper {
     display: flex;
     justify-content: flex-start;
@@ -1799,11 +2193,13 @@ GRID
     flex-shrink: 0;
     flex-grow: 0;
 }
+
 .veilarbportefoljeflatefs .barlabel__barwrapper .arbeidsliste {
     flex-basis: 3rem;
     display: inline-flex;
     height: 2rem;
 }
+
 .veilarbportefoljeflatefs .barlabel__antall {
     flex-basis: 3rem;
     text-align: right;
@@ -1812,11 +2208,13 @@ GRID
     font-weight: 800;
     margin-top: -0.3rem;
 }
+
 .veilarbportefoljeflatefs .barlabel__bar {
     position: relative;
     height: 1rem;
     flex-grow: 1;
 }
+
 .veilarbportefoljeflatefs .barlabel__bartrack {
     display: block;
     background-color: #f1f1f1;
@@ -1824,6 +2222,7 @@ GRID
     border-radius: 1rem;
     width: 100%;
 }
+
 .veilarbportefoljeflatefs .barlabel__barface {
     position: absolute;
     display: block;
@@ -1834,47 +2233,61 @@ GRID
     left: 0;
     top: 0;
 }
+
 .veilarbportefoljeflatefs .barlabel.ufordeltebrukere .barlabel__barface {
     background-color: #8269a2;
 }
+
 .veilarbportefoljeflatefs .barlabel.venterPaSvarFraNAV .barlabel__barface {
     background-color: #8269a2;
 }
+
 .veilarbportefoljeflatefs .barlabel.venterPaSvarFraBruker .barlabel__barface {
     background-color: #c1cb33;
 }
+
 .veilarbportefoljeflatefs .barlabel.avtaltMoteMedNav .barlabel__barface {
     background-color: #00243a;
 }
+
 .veilarbportefoljeflatefs .barlabel.utlopteAktiviteter .barlabel__barface {
     background-color: #6a6a6a;
 }
+
 .veilarbportefoljeflatefs .barlabel.ikkeIAvtaltAktivitet .barlabel__barface {
     background-color: #6a6a6a;
 }
+
 .veilarbportefoljeflatefs .barlabel.iAvtaltAktivitet .barlabel__barface {
     background-color: #3380a5;
 }
+
 .veilarbportefoljeflatefs .barlabel.inaktiveBrukere .barlabel__barface {
     background-color: #6a6a6a;
 }
+
 .veilarbportefoljeflatefs .barlabel.minArbeidsliste .barlabel__barface {
     background-color: #6a6a6a;
 }
+
 .veilarbportefoljeflatefs .forsteBarlabelIGruppe {
     padding-top: 1rem;
     border-top: 1px solid #6a6a6a;
     margin-top: 1rem;
 }
+
 .veilarbportefoljeflatefs .barlabel__barwrapper {
     flex: none;
 }
+
 .veilarbportefoljeflatefs .ekspanderbartPanel__innhold {
     padding: 0.5rem 1rem 1rem;
 }
+
 .veilarbportefoljeflatefs .ekspanderbartPanel--apen .ReactCollapse--collapse {
     overflow: initial !important;
 }
+
 .veilarbportefoljeflatefs .side-storrelse {
     margin: 0 auto;
     padding: 0 3rem;
@@ -1882,12 +2295,18 @@ GRID
     display: grid;
     grid-template-rows: auto 1fr;
 }
+
+.veilarbportefoljeflatefs .side-storrelse > .informasjonsmeldinger:not(:last-child) {
+    margin-bottom: var(--navds-spacing-1);
+}
+
 .veilarbportefoljeflatefs .oversikt-sideinnhold {
     display: grid;
     column-gap: 1%;
     grid-template-columns: 21rem auto;
     grid-template-rows: auto auto auto;
 }
+
 .veilarbportefoljeflatefs .oversikt-sideinnhold .annen-veileder-varsel {
     grid-column: 2;
     grid-row: 1;
@@ -1896,6 +2315,7 @@ GRID
     font-weight: bolder;
     padding-right: 1rem;
 }
+
 .veilarbportefoljeflatefs .oversikt-sideinnhold .alertstripe__annen-veileder-varsel {
     align-self: center;
     grid-row: 1;
@@ -1904,6 +2324,7 @@ GRID
     width: 80%;
     justify-self: flex-end;
 }
+
 .veilarbportefoljeflatefs .oversikt-sideinnhold .sokefelt-knapp__container {
     grid-row: 1;
     grid-column: 2;
@@ -1912,10 +2333,12 @@ GRID
     justify-content: space-between;
     z-index: 10;
 }
+
 .veilarbportefoljeflatefs .oversikt-sideinnhold .sidebar {
     grid-row-start: 1;
     grid-column: 1;
 }
+
 .veilarbportefoljeflatefs .oversikt-sideinnhold .filtrering-label-container,
 .veilarbportefoljeflatefs .oversikt-sideinnhold .filtrering-label-container__annen-veileder {
     grid-row: 2;
@@ -1924,50 +2347,63 @@ GRID
     display: flex;
     flex-wrap: wrap;
 }
+
 .veilarbportefoljeflatefs .oversikt-sideinnhold .filtrering-label-container__feature,
 .veilarbportefoljeflatefs .oversikt-sideinnhold .filtrering-label-container__annen-veileder__feature {
     background-color: #85d5f0;
 }
+
 .veilarbportefoljeflatefs .oversikt-sideinnhold .oversikt__container {
     grid-row: 3;
     grid-column-start: 2;
     grid-column-end: 3;
     margin: 0.5rem 0 2rem;
 }
+
 .veilarbportefoljeflatefs .oversikt-sideinnhold .alertstripe__filtrering {
     grid-row: 2;
     grid-column-start: 2;
     grid-column-end: 3;
 }
+
 .veilarbportefoljeflatefs .oversikt-sideinnhold__hidden .oversikt__container {
     grid-column-start: 1;
 }
+
 .veilarbportefoljeflatefs .oversikt-sideinnhold__hidden .filtrering-label-container {
     grid-column-start: 1;
 }
+
 .veilarbportefoljeflatefs .oversikt-sideinnhold__hidden .alertstripe__filtrering {
     grid-column-start: 1;
     grid-column-end: 3;
 }
+
 .veilarbportefoljeflatefs .registrering-alert {
     margin: 4px 8px 4px 12px;
 }
+
 .veilarbportefoljeflatefs .navds-alert__wrapper {
     font-size: 14px !important;
 }
+
 .veilarbportefoljeflatefs .navds-body-short {
     font-size: 14px !important;
 }
+
 .veilarbportefoljeflatefs .skjemaelement__label {
     font-size: 14px !important;
 }
+
 .veilarbportefoljeflatefs .navds-label {
     font-size: 14px !important;
 }
+
 @media (max-width: 1200px) {
     .veilarbportefoljeflatefs .oversikt-sideinnhold .oversikt__container {
         grid-column-start: 1;
     }
+
     .veilarbportefoljeflatefs .oversikt-sideinnhold .sidebar {
         z-index: 1200;
     }

--- a/src/veiledere/veiledere-side.tsx
+++ b/src/veiledere/veiledere-side.tsx
@@ -21,8 +21,8 @@ import {useFetchStatusTall} from '../hooks/portefolje/use-fetch-statustall';
 import MetrikkEkspanderbartpanel from '../components/ekspandertbart-panel/metrikk-ekspanderbartpanel';
 import {OversiktType} from '../ducks/ui/listevisning';
 import LagredeFilterUIController from '../filtrering/lagrede-filter-controller';
-import {Systemmeldinger} from '../components/systemmeldinger';
 import {Panel} from '@navikt/ds-react';
+import {Informasjonsmeldinger} from '../components/informasjonsmeldinger/informasjonsmeldinger';
 
 function VeiledereSide() {
     const statustall = useFetchStatusTall();
@@ -63,7 +63,7 @@ function VeiledereSide() {
             data-testid={`side-storrelse_${id}`}
         >
             <ToppMeny oversiktType={oversiktType} />
-            <Systemmeldinger />
+            <Informasjonsmeldinger />
             <Innholdslaster avhengigheter={[statustall]}>
                 <div className="oversikt-sideinnhold-veilederside" role="tabpanel" id={`oversikt-sideinnhold_${id}`}>
                     <div className="status-filter-kolonne">


### PR DESCRIPTION
I stedet for å automatisk redirecte brukeren til innloggingssiden når sesjonen er utløpt, så viser vi nå heller en statusmelding med lenke til innloggingssiden. Dersom brukeren derimot velger å overse meldingen og trykker utløser et nettverkskall (feks. trykker på et filter) så vil vi derimot redirecte til innloggingssiden siden brukeren i dette tilfellet eksplisitt har utført en handling.

Dette er først og fremst for å unngå å forvirre brukeren, da den forrige implementasjonen ville ha redirected brukeren ved første input-event (dvs. "mousemove") som potensielt er forvirrende samt at det heller ikke gir brukeren mulighet til å eventuelt lagre unna arbeidet sitt. 