### PR TITLE
Endre sesjons-statusmelding til warning

### DIFF
--- a/src/components/informasjonsmeldinger/sesjon-statusmelding.tsx
+++ b/src/components/informasjonsmeldinger/sesjon-statusmelding.tsx
@@ -15,7 +15,7 @@ export const SesjonStatusmelding = () => {
     const LoginLenke = () => <Link href={loginUrl()}>Logg inn på nytt.</Link>;
 
     return (
-        <Alert variant="error" size="medium" fullWidth>
+        <Alert variant="warning" size="medium" fullWidth>
             Økten din er utløpt. <LoginLenke />
         </Alert>
     );


### PR DESCRIPTION
I følge Aksel/Designsystemet gir det mer mening med warning, da utløpt sesjon streng tatt ikke er en feil (error).