### PR TITLE
TC-320 Gi alle AzureAD-brukere tilgang i prod

### DIFF
--- a/.nais/obo-nais-prod.yaml
+++ b/.nais/obo-nais-prod.yaml
@@ -31,6 +31,7 @@ spec:
     enabled: true
   azure:
     application:
+      allowAllUsers: true
       enabled: true
     sidecar:
       enabled: true


### PR DESCRIPTION
Ref. endring i default brukertilganger for AzureAD, som annonsert i #nais-announcements: https://nav-it.slack.com/archives/C01DE3M9YBV/p1674475818557619