### PR TITLE
Beholde kolonnene ved re-render med mindre man endrer filter

### DIFF
--- a/cypress/e2e/diverse_spec.js
+++ b/cypress/e2e/diverse_spec.js
@@ -159,4 +159,36 @@ describe('Diverse', () => {
         cy.klikkTab('MINE_FILTER');
         cy.getByTestId('brukerfeilmelding').should('not.exist');
     });
+
+	it('Sjekk at filter og kolonnevalg blir beholdt mellom oversiktene', () => {
+		cy.gaTilOversikt('enhetens-oversikt');
+		cy.klikkTab('FILTER');
+		cy.getByTestId('filtrering-filter_container').scrollTo('bottom');
+		cy.apneLukkeFilterDropdown('ensligeForsorgere');
+		cy.getByTestId('filter_OVERGANGSSTØNAD').check({force: true});
+		cy.getByTestId('sorteringheader_utlop_overgangsstonad').should('be.visible');
+		cy.getByTestId('dropdown-knapp_velg-kolonner').contains('Velg kolonner').click({ force: true });
+		cy.getByTestId('velg-kolonne-rad_veileder').uncheck({force: true});
+		cy.getByTestId('velg-kolonne-rad_om_barnet').check({force: true});
+		cy.getByTestId('lukk-velg-kolonner-knapp').click({force: true});
+		cy.getByTestId('sorteringheader_veileder').should('not.exist');
+		cy.getByTestId('sorteringheader_utlop_overgangsstonad').should('be.visible');
+		cy.getByTestId('sorteringheader_oppfolging').should('be.visible'); //om barnet kolonne synlig
+
+		cy.gaTilOversikt('min-oversikt');
+		cy.klikkTab('STATUS');
+		cy.getByTestId('filter_checkboks-container_iavtaltAktivitet').check({
+			force: true
+		});
+		cy.getByTestId('sorteringheader_i-avtalt-aktivitet').should('be.visible');
+
+		cy.gaTilOversikt('enhetens-oversikt');
+		cy.getByTestId('sorteringheader_veileder').should('not.exist');
+		cy.getByTestId('sorteringheader_oppfolging').should('be.visible');
+
+		cy.gaTilOversikt('min-oversikt');
+		cy.getByTestId('sorteringheader_i-avtalt-aktivitet').should('be.visible');
+
+	});
+
 });

--- a/src/components/sidebar/sidevelger.tsx
+++ b/src/components/sidebar/sidevelger.tsx
@@ -3,7 +3,7 @@ import {FiltreringStatus, Statustall} from '../../filtrering/filtrering-status/f
 import FilteringVeiledergrupper from '../../filtrering/filtrering-veileder-grupper/filtrering-veiledergrupper';
 import React from 'react';
 import {useDispatch} from 'react-redux';
-import {OversiktType} from '../../ducks/ui/listevisning';
+import {oppdaterKolonneAlternativer, OversiktType} from '../../ducks/ui/listevisning';
 import {skjulSidebar} from '../../ducks/sidebar-tab';
 import {Sidebarelement} from './sidebar';
 import {FiltervalgModell} from '../../model-interfaces';
@@ -26,7 +26,8 @@ function Sidevelger({selectedTabData, oversiktType, filtervalg, enhettiltak, sta
     const dispatch = useDispatch();
     const doEndreFiltervalg = (filterId: string, filterVerdi: React.ReactNode) => {
         dispatch(pagineringSetup({side: 1}));
-        dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType, filtervalg, dispatch));
+        dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType));
+        oppdaterKolonneAlternativer(dispatch, {...filtervalg, [filterId]: filterVerdi}, oversiktType);
     };
 
     if (!selectedTabData) {

--- a/src/components/sidebar/sidevelger.tsx
+++ b/src/components/sidebar/sidevelger.tsx
@@ -26,7 +26,7 @@ function Sidevelger({selectedTabData, oversiktType, filtervalg, enhettiltak, sta
     const dispatch = useDispatch();
     const doEndreFiltervalg = (filterId: string, filterVerdi: React.ReactNode) => {
         dispatch(pagineringSetup({side: 1}));
-        dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType));
+        dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType, filtervalg, dispatch));
     };
 
     if (!selectedTabData) {

--- a/src/components/toolbar/sok-veileder.tsx
+++ b/src/components/toolbar/sok-veileder.tsx
@@ -18,7 +18,7 @@ interface SokVeilederProps {
 }
 
 interface DispatchProps {
-    sokEtterVeileder: (filterId: string, filterverdi: string[]) => void;
+    sokEtterVeileder: (filterId: string, filterverdi: string[], filtervalg: FiltervalgModell) => void;
     veilederSokt: () => void;
 }
 
@@ -40,7 +40,7 @@ function SokVeilederFilter(props: AllProps) {
     const createHandleOnSubmit = (filterverdi: string[]) => {
         props.onClick();
         if (harValg) {
-            props.sokEtterVeileder('veiledere', filterverdi);
+            props.sokEtterVeileder('veiledere', filterverdi, props.filtervalg);
             props.veilederSokt();
             setValgteVeileder([]);
         }
@@ -72,8 +72,8 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = (dispatch, ownProps) =>
     bindActionCreators(
         {
-            sokEtterVeileder(filterId: string, filterverdi: string[]) {
-                return endreFiltervalg(filterId, filterverdi, ownProps.oversiktType);
+            sokEtterVeileder(filterId: string, filterverdi: string[], filterValg: FiltervalgModell) {
+                return endreFiltervalg(filterId, filterverdi, ownProps.oversiktType, filterValg, dispatch);
             },
             veilederSokt() {
                 return veilederSoktFraToolbar();

--- a/src/components/toolbar/sok-veileder.tsx
+++ b/src/components/toolbar/sok-veileder.tsx
@@ -8,7 +8,7 @@ import {VeiledereState} from '../../ducks/veiledere';
 import {useEffect, useState} from 'react';
 import SokVeiledere from '../sok-veiledere/sok-veiledere';
 import './toolbar.css';
-import {OversiktType} from '../../ducks/ui/listevisning';
+import {oppdaterKolonneAlternativer, OversiktType} from '../../ducks/ui/listevisning';
 
 interface SokVeilederProps {
     filtervalg: FiltervalgModell;
@@ -73,7 +73,8 @@ const mapDispatchToProps = (dispatch, ownProps) =>
     bindActionCreators(
         {
             sokEtterVeileder(filterId: string, filterverdi: string[], filterValg: FiltervalgModell) {
-                return endreFiltervalg(filterId, filterverdi, ownProps.oversiktType, filterValg, dispatch);
+                oppdaterKolonneAlternativer(dispatch, {...filterValg, [filterId]: filterverdi}, ownProps.oversiktType);
+                return endreFiltervalg(filterId, filterverdi, ownProps.oversiktType);
             },
             veilederSokt() {
                 return veilederSoktFraToolbar();

--- a/src/components/veileder-checkbox-liste/veileder-checkbox-liste.tsx
+++ b/src/components/veileder-checkbox-liste/veileder-checkbox-liste.tsx
@@ -7,7 +7,7 @@ import './veileder-checkbox-liste.css';
 import {AppState} from '../../reducer';
 import NullstillKnapp from '../nullstill-valg-knapp/nullstill-knapp';
 import {endreFiltervalg} from '../../ducks/filtrering';
-import {OversiktType} from '../../ducks/ui/listevisning';
+import {oppdaterKolonneAlternativer, OversiktType} from '../../ducks/ui/listevisning';
 import {Alert, Checkbox, CheckboxGroup} from '@navikt/ds-react';
 
 interface VeilederCheckboxListeProps {
@@ -40,12 +40,18 @@ function VeilederCheckboxListe({nullstillInputfelt}: VeilederCheckboxListeProps)
 
     const handterValgteVeiledere = (valgteVeiledere: string[]) => {
         setValgteVeiledere(valgteVeiledere);
-        dispatch(endreFiltervalg(formNavn, valgteVeiledere, OversiktType.veilederOversikt, filtervalg, dispatch));
+        dispatch(endreFiltervalg(formNavn, valgteVeiledere, OversiktType.veilederOversikt));
+        oppdaterKolonneAlternativer(
+            dispatch,
+            {...filtervalg, [formNavn]: valgteVeiledere},
+            OversiktType.veilederOversikt
+        );
     };
 
     const nullstillValg = () => {
         nullstillInputfelt();
-        dispatch(endreFiltervalg(formNavn, [], OversiktType.veilederOversikt, filtervalg, dispatch));
+        dispatch(endreFiltervalg(formNavn, [], OversiktType.veilederOversikt));
+        oppdaterKolonneAlternativer(dispatch, {...filtervalg, [formNavn]: []}, OversiktType.veilederOversikt);
     };
 
     const mapToCheckboxList = (veiledere?: VeilederModell[]) => {

--- a/src/components/veileder-checkbox-liste/veileder-checkbox-liste.tsx
+++ b/src/components/veileder-checkbox-liste/veileder-checkbox-liste.tsx
@@ -40,12 +40,12 @@ function VeilederCheckboxListe({nullstillInputfelt}: VeilederCheckboxListeProps)
 
     const handterValgteVeiledere = (valgteVeiledere: string[]) => {
         setValgteVeiledere(valgteVeiledere);
-        dispatch(endreFiltervalg(formNavn, valgteVeiledere, OversiktType.veilederOversikt));
+        dispatch(endreFiltervalg(formNavn, valgteVeiledere, OversiktType.veilederOversikt, filtervalg, dispatch));
     };
 
     const nullstillValg = () => {
         nullstillInputfelt();
-        dispatch(endreFiltervalg(formNavn, [], OversiktType.veilederOversikt));
+        dispatch(endreFiltervalg(formNavn, [], OversiktType.veilederOversikt, filtervalg, dispatch));
     };
 
     const mapToCheckboxList = (veiledere?: VeilederModell[]) => {

--- a/src/ducks/filtrering.ts
+++ b/src/ducks/filtrering.ts
@@ -1,7 +1,8 @@
 import {FiltervalgModell} from '../model-interfaces';
 import {VELG_MINE_FILTER} from './lagret-filter-ui-state';
-import {OversiktType} from './ui/listevisning';
+import {oppdaterAlternativer, OversiktType} from './ui/listevisning';
 import {LagretFilter} from './lagret-filter';
+import {Dispatch} from 'redux';
 // Actions
 export const ENDRE_FILTER = 'filtrering/ENDRE_FILTER';
 export const SETT_FILTERVALG = 'filtrering/SETT_FILTERVALG';
@@ -127,7 +128,8 @@ export default function filtreringReducer(state: FiltervalgModell = initialState
     }
 }
 
-export function velgMineFilter(filterVerdi: LagretFilter, oversiktType: OversiktType) {
+export function velgMineFilter(filterVerdi: LagretFilter, oversiktType: OversiktType, dispatch: Dispatch) {
+    oppdaterAlternativer(dispatch, filterVerdi.filterValg, oversiktType);
     return {
         type: VELG_MINE_FILTER,
         data: filterVerdi,
@@ -138,11 +140,15 @@ export function velgMineFilter(filterVerdi: LagretFilter, oversiktType: Oversikt
 export function endreFiltervalg(
     filterId: string,
     filterVerdi: React.ReactNode,
-    oversiktType: OversiktType = OversiktType.enhetensOversikt
+    oversiktType: OversiktType = OversiktType.enhetensOversikt,
+    filterValg: FiltervalgModell,
+    dispatch: Dispatch
 ) {
     if (Array.isArray(filterVerdi)) {
         filterVerdi.sort();
     }
+    const updatertFiltervalg = {...filterValg, [filterId]: filterVerdi};
+    oppdaterAlternativer(dispatch, updatertFiltervalg, oversiktType);
     return {
         type: ENDRE_FILTER,
         data: {filterId, filterVerdi},
@@ -150,7 +156,15 @@ export function endreFiltervalg(
     };
 }
 
-export function slettEnkeltFilter(filterId, filterVerdi, oversiktType = OversiktType.enhetensOversikt) {
+export function slettEnkeltFilter(
+    filterId,
+    filterVerdi,
+    oversiktType = OversiktType.enhetensOversikt,
+    filterValg: FiltervalgModell,
+    dispatch: Dispatch
+) {
+    const updatertFiltervalg = {...filterValg, [filterId]: fjern(filterId, filterValg[filterId], filterVerdi)};
+    oppdaterAlternativer(dispatch, updatertFiltervalg, oversiktType);
     return {
         type: SLETT_ENKELT_FILTER,
         data: {filterId, filterVerdi},
@@ -158,7 +172,8 @@ export function slettEnkeltFilter(filterId, filterVerdi, oversiktType = Oversikt
     };
 }
 
-export function clearFiltervalg(oversiktType = OversiktType.enhetensOversikt) {
+export function clearFiltervalg(oversiktType = OversiktType.enhetensOversikt, dispatch: Dispatch) {
+    oppdaterAlternativer(dispatch, initialState, oversiktType);
     return {type: CLEAR_FILTER, name: oversiktType};
 }
 

--- a/src/ducks/filtrering.ts
+++ b/src/ducks/filtrering.ts
@@ -1,8 +1,7 @@
 import {FiltervalgModell} from '../model-interfaces';
 import {VELG_MINE_FILTER} from './lagret-filter-ui-state';
-import {oppdaterAlternativer, OversiktType} from './ui/listevisning';
+import {OversiktType} from './ui/listevisning';
 import {LagretFilter} from './lagret-filter';
-import {Dispatch} from 'redux';
 // Actions
 export const ENDRE_FILTER = 'filtrering/ENDRE_FILTER';
 export const SETT_FILTERVALG = 'filtrering/SETT_FILTERVALG';
@@ -79,7 +78,7 @@ export const initialState: FiltervalgModell = {
     ensligeForsorgere: []
 };
 
-function fjern(filterId, verdi, fjernVerdi) {
+export function fjern(filterId, verdi, fjernVerdi) {
     if (typeof verdi === 'boolean') {
         return false;
     } else if (Array.isArray(verdi)) {
@@ -128,8 +127,7 @@ export default function filtreringReducer(state: FiltervalgModell = initialState
     }
 }
 
-export function velgMineFilter(filterVerdi: LagretFilter, oversiktType: OversiktType, dispatch: Dispatch) {
-    oppdaterAlternativer(dispatch, filterVerdi.filterValg, oversiktType);
+export function velgMineFilter(filterVerdi: LagretFilter, oversiktType: OversiktType) {
     return {
         type: VELG_MINE_FILTER,
         data: filterVerdi,
@@ -140,15 +138,11 @@ export function velgMineFilter(filterVerdi: LagretFilter, oversiktType: Oversikt
 export function endreFiltervalg(
     filterId: string,
     filterVerdi: React.ReactNode,
-    oversiktType: OversiktType = OversiktType.enhetensOversikt,
-    filterValg: FiltervalgModell,
-    dispatch: Dispatch
+    oversiktType: OversiktType = OversiktType.enhetensOversikt
 ) {
     if (Array.isArray(filterVerdi)) {
         filterVerdi.sort();
     }
-    const updatertFiltervalg = {...filterValg, [filterId]: filterVerdi};
-    oppdaterAlternativer(dispatch, updatertFiltervalg, oversiktType);
     return {
         type: ENDRE_FILTER,
         data: {filterId, filterVerdi},
@@ -156,15 +150,7 @@ export function endreFiltervalg(
     };
 }
 
-export function slettEnkeltFilter(
-    filterId,
-    filterVerdi,
-    oversiktType = OversiktType.enhetensOversikt,
-    filterValg: FiltervalgModell,
-    dispatch: Dispatch
-) {
-    const updatertFiltervalg = {...filterValg, [filterId]: fjern(filterId, filterValg[filterId], filterVerdi)};
-    oppdaterAlternativer(dispatch, updatertFiltervalg, oversiktType);
+export function slettEnkeltFilter(filterId, filterVerdi, oversiktType = OversiktType.enhetensOversikt) {
     return {
         type: SLETT_ENKELT_FILTER,
         data: {filterId, filterVerdi},
@@ -172,8 +158,7 @@ export function slettEnkeltFilter(
     };
 }
 
-export function clearFiltervalg(oversiktType = OversiktType.enhetensOversikt, dispatch: Dispatch) {
-    oppdaterAlternativer(dispatch, initialState, oversiktType);
+export function clearFiltervalg(oversiktType = OversiktType.enhetensOversikt) {
     return {type: CLEAR_FILTER, name: oversiktType};
 }
 

--- a/src/ducks/ui/listevisning.ts
+++ b/src/ducks/ui/listevisning.ts
@@ -139,7 +139,7 @@ export const lukkInfopanel = (oversiktType: OversiktType) => ({
     name: oversiktType
 });
 
-export const oppdaterAlternativer = (
+export const oppdaterKolonneAlternativer = (
     dispatch: Dispatch<OppdaterListevisningAction>,
     filterValg: FiltervalgModell,
     oversiktType: OversiktType

--- a/src/enhetsportefolje/enhet-side.tsx
+++ b/src/enhetsportefolje/enhet-side.tsx
@@ -9,13 +9,13 @@ import './enhetsportefolje.css';
 import './brukerliste.css';
 import ToppMeny from '../topp-meny/topp-meny';
 import {usePortefoljeSelector} from '../hooks/redux/use-portefolje-selector';
-import {OversiktType} from '../ducks/ui/listevisning';
+import {oppdaterKolonneAlternativer, OversiktType} from '../ducks/ui/listevisning';
 import {useSetStateFromUrl} from '../hooks/portefolje/use-set-state-from-url';
 import {useFetchPortefolje} from '../hooks/portefolje/use-fetch-portefolje';
 import FiltreringLabelContainer from '../filtrering/filtrering-label-container';
 import {lagLablerTilVeiledereMedIdenter} from '../filtrering/utils';
 import {useDispatch, useSelector} from 'react-redux';
-import {endreFiltervalg, slettEnkeltFilter} from '../ducks/filtrering';
+import {endreFiltervalg, fjern, slettEnkeltFilter} from '../ducks/filtrering';
 import {hentPortefoljeForEnhet} from '../ducks/portefolje';
 import {useSyncStateMedUrl} from '../hooks/portefolje/use-sync-state-med-url';
 import {useSetLocalStorageOnUnmount} from '../hooks/portefolje/use-set-local-storage-on-unmount';
@@ -83,7 +83,11 @@ export default function EnhetSide() {
     const harFilter = antallFilter(filtervalg) !== 0;
     const veilederliste = useSelector((state: AppState) => state.veiledere.data.veilederListe);
     const slettVeilederFilter = useCallback(
-        ident => dispatch(slettEnkeltFilter('veiledere', ident, OversiktType.enhetensOversikt, filtervalg, dispatch)),
+        ident => {
+            dispatch(slettEnkeltFilter('veiledere', ident, OversiktType.enhetensOversikt));
+            const oppdatertFiltervalg = {...filtervalg, veiledere: fjern('veiledere', filtervalg['veiledere'], ident)};
+            oppdaterKolonneAlternativer(dispatch, oppdatertFiltervalg, oversiktType);
+        },
         [dispatch, filtervalg]
     );
     const veilederLabel = useMemo(
@@ -107,7 +111,8 @@ export default function EnhetSide() {
 
     const doEndreFiltervalg = (filterId: string, filterVerdi: React.ReactNode) => {
         dispatch(pagineringSetup({side: 1}));
-        dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType, filtervalg, dispatch));
+        dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType));
+        oppdaterKolonneAlternativer(dispatch, {...filtervalg, [filterId]: filterVerdi}, oversiktType);
     };
 
     const [scrolling, setScrolling] = useState(false);

--- a/src/enhetsportefolje/enhet-side.tsx
+++ b/src/enhetsportefolje/enhet-side.tsx
@@ -83,8 +83,8 @@ export default function EnhetSide() {
     const harFilter = antallFilter(filtervalg) !== 0;
     const veilederliste = useSelector((state: AppState) => state.veiledere.data.veilederListe);
     const slettVeilederFilter = useCallback(
-        ident => dispatch(slettEnkeltFilter('veiledere', ident, OversiktType.enhetensOversikt)),
-        [dispatch]
+        ident => dispatch(slettEnkeltFilter('veiledere', ident, OversiktType.enhetensOversikt, filtervalg, dispatch)),
+        [dispatch, filtervalg]
     );
     const veilederLabel = useMemo(
         () => lagLablerTilVeiledereMedIdenter(filtervalg.veiledere, veilederliste, slettVeilederFilter),
@@ -107,7 +107,7 @@ export default function EnhetSide() {
 
     const doEndreFiltervalg = (filterId: string, filterVerdi: React.ReactNode) => {
         dispatch(pagineringSetup({side: 1}));
-        dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType));
+        dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType, filtervalg, dispatch));
     };
 
     const [scrolling, setScrolling] = useState(false);

--- a/src/filtrering/filtrering-label-container.tsx
+++ b/src/filtrering/filtrering-label-container.tsx
@@ -350,14 +350,16 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     actions: {
         slettAlle: () => {
             dispatch(pagineringSetup({side: 1}));
-            dispatch(clearFiltervalg(ownProps.oversiktType));
+            dispatch(clearFiltervalg(ownProps.oversiktType, dispatch));
         },
         slettEnkelt: (filterKey: string, filterValue: boolean | string | null) => {
             dispatch(pagineringSetup({side: 1}));
-            dispatch(slettEnkeltFilter(filterKey, filterValue, ownProps.oversiktType));
+            dispatch(slettEnkeltFilter(filterKey, filterValue, ownProps.oversiktType, ownProps.filtervalg, dispatch));
             dispatch(avmarkerValgtMineFilter(ownProps.oversiktType));
             if (filterValue === 'MIN_ARBEIDSLISTE') {
-                dispatch(endreFiltervalg('arbeidslisteKategori', [], ownProps.oversiktType));
+                dispatch(
+                    endreFiltervalg('arbeidslisteKategori', [], ownProps.oversiktType, ownProps.filtervalg, dispatch)
+                );
             }
         }
     }

--- a/src/filtrering/filtrering-mine-filter/drag-and-drop/drag-and-drop.tsx
+++ b/src/filtrering/filtrering-mine-filter/drag-and-drop/drag-and-drop.tsx
@@ -82,7 +82,7 @@ function DragAndDrop({stateFilterOrder, oversiktType, isDraggable, setisDraggabl
             dispatch(avmarkerValgtMineFilter(oversiktType));
         } else {
             dispatch(markerMineFilter(filter, oversiktType));
-            dispatch(velgMineFilter(filter, oversiktType));
+            dispatch(velgMineFilter(filter, oversiktType, dispatch));
         }
     };
 

--- a/src/filtrering/filtrering-mine-filter/drag-and-drop/drag-and-drop.tsx
+++ b/src/filtrering/filtrering-mine-filter/drag-and-drop/drag-and-drop.tsx
@@ -6,7 +6,7 @@ import MineFilterRad from '../mine-filter-rad';
 import {useDispatch, useSelector} from 'react-redux';
 import {useOnlyOnUnmount} from './use-only-onUnmount-hook';
 import {LagretFilter} from '../../../ducks/lagret-filter';
-import {OversiktType} from '../../../ducks/ui/listevisning';
+import {oppdaterKolonneAlternativer, OversiktType} from '../../../ducks/ui/listevisning';
 import {OrNothing} from '../../../utils/types/types';
 import {Tiltak} from '../../../ducks/enhettiltak';
 import {RadioGroup} from '@navikt/ds-react';
@@ -82,7 +82,8 @@ function DragAndDrop({stateFilterOrder, oversiktType, isDraggable, setisDraggabl
             dispatch(avmarkerValgtMineFilter(oversiktType));
         } else {
             dispatch(markerMineFilter(filter, oversiktType));
-            dispatch(velgMineFilter(filter, oversiktType, dispatch));
+            dispatch(velgMineFilter(filter, oversiktType));
+            oppdaterKolonneAlternativer(dispatch, filter.filterValg, oversiktType);
         }
     };
 

--- a/src/filtrering/filtrering-status/filtrering-status.tsx
+++ b/src/filtrering/filtrering-status/filtrering-status.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import {useDispatch} from 'react-redux';
 import {endreFiltervalg} from '../../ducks/filtrering';
 import {CHECKBOX_FILTER, fjernFerdigfilter, leggTilFerdigFilter} from './filter-utils';
-import {FiltervalgModell} from '../../model-interfaces';
+import {FiltervalgModell, KategoriModell} from '../../model-interfaces';
 import {pagineringSetup} from '../../ducks/paginering';
 import {MIN_ARBEIDSLISTE, NYE_BRUKERE_FOR_VEILEDER, UFORDELTE_BRUKERE} from '../filter-konstanter';
 import FilterStatusMinArbeidsliste from './arbeidsliste';
-import {OversiktType} from '../../ducks/ui/listevisning';
+import {oppdaterKolonneAlternativer, OversiktType} from '../../ducks/ui/listevisning';
 import BarInputCheckbox from '../../components/barinput/barinput-checkbox';
 import {BarInputRadio} from '../../components/barinput/barinput-radio';
 import {tekstAntallBrukere} from '../../utils/tekst-utils';
@@ -63,7 +63,8 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
 
     function dispatchFiltreringStatusChanged(ferdigFilterListe) {
         dispatch(pagineringSetup({side: 1}));
-        dispatch(endreFiltervalg('ferdigfilterListe', ferdigFilterListe, oversiktType, filtervalg, dispatch));
+        dispatch(endreFiltervalg('ferdigfilterListe', ferdigFilterListe, oversiktType));
+        oppdaterKolonneAlternativer(dispatch, {...filtervalg, ferdigfilterListe: ferdigFilterListe}, oversiktType);
     }
 
     function dispatchArbeidslisteKategoriChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -71,7 +72,12 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
         const nyeFerdigfilterListe = e.target.checked
             ? [...kategoriliste, e.target.value]
             : kategoriliste.filter(elem => elem !== e.target.value);
-        dispatch(endreFiltervalg('arbeidslisteKategori', nyeFerdigfilterListe, oversiktType, filtervalg, dispatch));
+        dispatch(endreFiltervalg('arbeidslisteKategori', nyeFerdigfilterListe, oversiktType));
+        oppdaterKolonneAlternativer(
+            dispatch,
+            {...filtervalg, arbeidslisteKategori: nyeFerdigfilterListe as KategoriModell[]},
+            oversiktType
+        );
     }
 
     function handleCheckboxChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -85,16 +91,17 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
         const nyeFerdigfilterListe = leggTilFerdigFilter(ferdigfilterListe!, e.target.value);
         dispatchFiltreringStatusChanged(nyeFerdigfilterListe);
         if (e.target.value !== 'MIN_ARBEIDSLISTE') {
-            dispatch(
-                endreFiltervalg(
-                    'arbeidslisteKategori',
-                    [],
-                    oversiktType,
-                    {...filtervalg, ferdigfilterListe: nyeFerdigfilterListe},
-                    dispatch
-                )
-            );
+            dispatch(endreFiltervalg('arbeidslisteKategori', [], oversiktType));
         }
+        oppdaterKolonneAlternativer(
+            dispatch,
+            {
+                ...filtervalg,
+                ferdigfilterListe: nyeFerdigfilterListe,
+                arbeidslisteKategori: e.target.value !== 'MIN_ARBEIDSLISTE' ? [] : filtervalg.arbeidslisteKategori
+            },
+            oversiktType
+        );
     }
 
     return (

--- a/src/filtrering/filtrering-status/filtrering-status.tsx
+++ b/src/filtrering/filtrering-status/filtrering-status.tsx
@@ -63,7 +63,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
 
     function dispatchFiltreringStatusChanged(ferdigFilterListe) {
         dispatch(pagineringSetup({side: 1}));
-        dispatch(endreFiltervalg('ferdigfilterListe', ferdigFilterListe, oversiktType));
+        dispatch(endreFiltervalg('ferdigfilterListe', ferdigFilterListe, oversiktType, filtervalg, dispatch));
     }
 
     function dispatchArbeidslisteKategoriChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -71,7 +71,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
         const nyeFerdigfilterListe = e.target.checked
             ? [...kategoriliste, e.target.value]
             : kategoriliste.filter(elem => elem !== e.target.value);
-        dispatch(endreFiltervalg('arbeidslisteKategori', nyeFerdigfilterListe, oversiktType));
+        dispatch(endreFiltervalg('arbeidslisteKategori', nyeFerdigfilterListe, oversiktType, filtervalg, dispatch));
     }
 
     function handleCheckboxChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -85,7 +85,15 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
         const nyeFerdigfilterListe = leggTilFerdigFilter(ferdigfilterListe!, e.target.value);
         dispatchFiltreringStatusChanged(nyeFerdigfilterListe);
         if (e.target.value !== 'MIN_ARBEIDSLISTE') {
-            dispatch(endreFiltervalg('arbeidslisteKategori', [], oversiktType));
+            dispatch(
+                endreFiltervalg(
+                    'arbeidslisteKategori',
+                    [],
+                    oversiktType,
+                    {...filtervalg, ferdigfilterListe: nyeFerdigfilterListe},
+                    dispatch
+                )
+            );
         }
     }
 

--- a/src/filtrering/filtrering-veileder-grupper/filtrering-veiledergrupper.tsx
+++ b/src/filtrering/filtrering-veileder-grupper/filtrering-veiledergrupper.tsx
@@ -7,7 +7,7 @@ import {endreFiltervalg, initialState} from '../../ducks/filtrering';
 import {FiltervalgModell} from '../../model-interfaces';
 import {lageNyGruppe} from '../../ducks/veiledergrupper_filter';
 import {useEnhetSelector} from '../../hooks/redux/use-enhet-selector';
-import {OversiktType} from '../../ducks/ui/listevisning';
+import {oppdaterKolonneAlternativer, OversiktType} from '../../ducks/ui/listevisning';
 import {STATUS} from '../../ducks/utils';
 import {ThunkDispatch} from 'redux-thunk';
 import {AnyAction} from 'redux';
@@ -38,17 +38,14 @@ function FilteringVeiledergrupper({oversiktType}: FilteringVeiledergruppeProps) 
                     },
                     enhet
                 )
-            ).then(resp =>
-                dispatch(
-                    endreFiltervalg(
-                        'veiledere',
-                        resp.data.filterValg.veiledere,
-                        oversiktType,
-                        resp.data.filterValg,
-                        dispatch
-                    )
-                )
-            );
+            ).then(resp => {
+                oppdaterKolonneAlternativer(
+                    dispatch,
+                    {...filterValg, veiledere: resp.data.filterValg.veiledere},
+                    oversiktType
+                );
+                return dispatch(endreFiltervalg('veiledere', resp.data.filterValg.veiledere, oversiktType));
+            });
     };
 
     const sortertVeiledergruppe = lagretFilter.sort((a, b) =>

--- a/src/filtrering/filtrering-veileder-grupper/filtrering-veiledergrupper.tsx
+++ b/src/filtrering/filtrering-veileder-grupper/filtrering-veiledergrupper.tsx
@@ -38,7 +38,17 @@ function FilteringVeiledergrupper({oversiktType}: FilteringVeiledergruppeProps) 
                     },
                     enhet
                 )
-            ).then(resp => dispatch(endreFiltervalg('veiledere', resp.data.filterValg.veiledere, oversiktType)));
+            ).then(resp =>
+                dispatch(
+                    endreFiltervalg(
+                        'veiledere',
+                        resp.data.filterValg.veiledere,
+                        oversiktType,
+                        resp.data.filterValg,
+                        dispatch
+                    )
+                )
+            );
     };
 
     const sortertVeiledergruppe = lagretFilter.sort((a, b) =>

--- a/src/filtrering/filtrering-veileder-grupper/veiledergruppe-innhold.tsx
+++ b/src/filtrering/filtrering-veileder-grupper/veiledergruppe-innhold.tsx
@@ -70,7 +70,17 @@ function VeiledergruppeInnhold(props: VeiledergruppeInnholdProps) {
                     },
                     enhet
                 )
-            ).then(resp => dispatch(endreFiltervalg('veiledere', resp.data.filterValg.veiledere, props.oversiktType)));
+            ).then(resp =>
+                dispatch(
+                    endreFiltervalg(
+                        'veiledere',
+                        resp.data.filterValg.veiledere,
+                        props.oversiktType,
+                        filterValg,
+                        dispatch
+                    )
+                )
+            );
         } else {
             dispatch(visIngenEndringerToast());
         }
@@ -80,7 +90,9 @@ function VeiledergruppeInnhold(props: VeiledergruppeInnholdProps) {
         valgtGruppe &&
             enhet &&
             dispatch(slettGruppe(enhet, valgtGruppe.filterId)).then(() => {
-                dispatch(endreFiltervalg('veiledere', [], OversiktType.enhetensOversikt));
+                dispatch(
+                    endreFiltervalg('veiledere', [], OversiktType.enhetensOversikt, valgtGruppe.filterValg, dispatch)
+                );
                 dispatch(hentMineFilterForVeileder());
             });
     };

--- a/src/filtrering/filtrering-veileder-grupper/veiledergruppe-innhold.tsx
+++ b/src/filtrering/filtrering-veileder-grupper/veiledergruppe-innhold.tsx
@@ -13,7 +13,7 @@ import './veiledergruppe.css';
 import '../filtrering-filter/filterform/filterform.css';
 import {ThunkDispatch} from 'redux-thunk';
 import {AnyAction} from 'redux';
-import {OversiktType} from '../../ducks/ui/listevisning';
+import {oppdaterKolonneAlternativer, OversiktType} from '../../ducks/ui/listevisning';
 import {LagretFilter} from '../../ducks/lagret-filter';
 import VeiledergruppeRad from './veiledergruppe_rad';
 import {kebabCase} from '../../utils/utils';
@@ -70,17 +70,14 @@ function VeiledergruppeInnhold(props: VeiledergruppeInnholdProps) {
                     },
                     enhet
                 )
-            ).then(resp =>
-                dispatch(
-                    endreFiltervalg(
-                        'veiledere',
-                        resp.data.filterValg.veiledere,
-                        props.oversiktType,
-                        filterValg,
-                        dispatch
-                    )
-                )
-            );
+            ).then(resp => {
+                oppdaterKolonneAlternativer(
+                    dispatch,
+                    {...filterValg, veiledere: resp.data.filterValg.veiledere},
+                    props.oversiktType
+                );
+                return dispatch(endreFiltervalg('veiledere', resp.data.filterValg.veiledere, props.oversiktType));
+            });
         } else {
             dispatch(visIngenEndringerToast());
         }
@@ -90,10 +87,13 @@ function VeiledergruppeInnhold(props: VeiledergruppeInnholdProps) {
         valgtGruppe &&
             enhet &&
             dispatch(slettGruppe(enhet, valgtGruppe.filterId)).then(() => {
-                dispatch(
-                    endreFiltervalg('veiledere', [], OversiktType.enhetensOversikt, valgtGruppe.filterValg, dispatch)
-                );
+                dispatch(endreFiltervalg('veiledere', [], OversiktType.enhetensOversikt));
                 dispatch(hentMineFilterForVeileder());
+                oppdaterKolonneAlternativer(
+                    dispatch,
+                    {...valgtGruppe.filterValg, veiledere: []},
+                    OversiktType.enhetensOversikt
+                );
             });
     };
 

--- a/src/filtrering/filtrering-veileder-grupper/veiledergruppe_rad.tsx
+++ b/src/filtrering/filtrering-veileder-grupper/veiledergruppe_rad.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {endreFiltervalg} from '../../ducks/filtrering';
 import {useDispatch, useSelector} from 'react-redux';
 import {LagretFilter} from '../../ducks/lagret-filter';
-import {OversiktType} from '../../ducks/ui/listevisning';
+import {oppdaterKolonneAlternativer, OversiktType} from '../../ducks/ui/listevisning';
 import {logEvent} from '../../utils/frontend-logger';
 import {finnSideNavn} from '../../middleware/metrics-middleware';
 import {AppState} from '../../reducer';
@@ -38,16 +38,13 @@ function VeiledergruppeRad({veilederGruppe, onClickRedigerKnapp, oversiktType, e
             {},
             {gruppeId: veilederGruppe.filterId, sideNavn: finnSideNavn()}
         );
-        dispatch(
-            endreFiltervalg(
-                'veiledere',
-                veilederGruppe.filterValg.veiledere,
-                oversiktType,
-                veilederGruppe.filterValg,
-                dispatch
-            )
-        );
+        dispatch(endreFiltervalg('veiledere', veilederGruppe.filterValg.veiledere, oversiktType));
         dispatch(markerValgtVeiledergruppe(veilederGruppe, oversiktType));
+        oppdaterKolonneAlternativer(
+            dispatch,
+            {...veilederGruppe.filterValg, veiledere: veilederGruppe.filterValg.veiledere},
+            oversiktType
+        );
 
         if (veilederGruppe.filterCleanup && erDetLikGruppe() !== undefined) {
             onClickRedigerKnapp();

--- a/src/filtrering/filtrering-veileder-grupper/veiledergruppe_rad.tsx
+++ b/src/filtrering/filtrering-veileder-grupper/veiledergruppe_rad.tsx
@@ -38,7 +38,15 @@ function VeiledergruppeRad({veilederGruppe, onClickRedigerKnapp, oversiktType, e
             {},
             {gruppeId: veilederGruppe.filterId, sideNavn: finnSideNavn()}
         );
-        dispatch(endreFiltervalg('veiledere', veilederGruppe.filterValg.veiledere, oversiktType));
+        dispatch(
+            endreFiltervalg(
+                'veiledere',
+                veilederGruppe.filterValg.veiledere,
+                oversiktType,
+                veilederGruppe.filterValg,
+                dispatch
+            )
+        );
         dispatch(markerValgtVeiledergruppe(veilederGruppe, oversiktType));
 
         if (veilederGruppe.filterCleanup && erDetLikGruppe() !== undefined) {

--- a/src/hooks/portefolje/use-fetch-portefolje.tsx
+++ b/src/hooks/portefolje/use-fetch-portefolje.tsx
@@ -3,7 +3,7 @@ import {hentArbeidslisteforVeileder, hentPortefoljeForEnhet, hentPortefoljeForVe
 import {useDispatch} from 'react-redux';
 import {useEnhetSelector} from '../redux/use-enhet-selector';
 import {usePortefoljeSelector} from '../redux/use-portefolje-selector';
-import {OversiktType, oppdaterAlternativer} from '../../ducks/ui/listevisning';
+import {OversiktType} from '../../ducks/ui/listevisning';
 import {useSelectGjeldendeVeileder} from './use-select-gjeldende-veileder';
 import {antallFilter} from '../../enhetsportefolje/enhet-side';
 import {STATUS} from '../../ducks/utils';
@@ -42,8 +42,4 @@ export function useFetchPortefolje(oversiktType: OversiktType) {
             dispatch(hentArbeidslisteforVeileder(enhet, gjeldendeVeileder));
         }
     }, [dispatch, enhet, gjeldendeVeileder, oversiktType, portefolje.status]);
-
-    useEffect(() => {
-        oppdaterAlternativer(dispatch, filtervalg, oversiktType);
-    }, [dispatch, filtervalg, oversiktType]);
 }

--- a/src/minoversikt/minoversikt-side.tsx
+++ b/src/minoversikt/minoversikt-side.tsx
@@ -82,7 +82,7 @@ export default function MinoversiktSide() {
     const veilederFraUrl = veiledere.find(veileder => veileder.ident === ident) || {fornavn: '', etternavn: ''};
     const doEndreFiltervalg = (filterId: string, filterVerdi: React.ReactNode) => {
         dispatch(pagineringSetup({side: 1}));
-        dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType));
+        dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType, filtervalg, dispatch));
     };
 
     const [scrolling, setScrolling] = useState(false);

--- a/src/minoversikt/minoversikt-side.tsx
+++ b/src/minoversikt/minoversikt-side.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {useEffect, useState} from 'react';
 import Innholdslaster from './../innholdslaster/innholdslaster';
-import {OversiktType} from '../ducks/ui/listevisning';
+import {oppdaterKolonneAlternativer, OversiktType} from '../ducks/ui/listevisning';
 import {useIdentSelector} from '../hooks/redux/use-innlogget-ident';
 import {MinOversiktModalController} from '../components/modal/modal-min-oversikt-controller';
 import MinoversiktTabell from './minoversikt-portefolje-tabell';
@@ -82,7 +82,8 @@ export default function MinoversiktSide() {
     const veilederFraUrl = veiledere.find(veileder => veileder.ident === ident) || {fornavn: '', etternavn: ''};
     const doEndreFiltervalg = (filterId: string, filterVerdi: React.ReactNode) => {
         dispatch(pagineringSetup({side: 1}));
-        dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType, filtervalg, dispatch));
+        dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType));
+        oppdaterKolonneAlternativer(dispatch, {...filtervalg, [filterId]: filterVerdi}, oversiktType);
     };
 
     const [scrolling, setScrolling] = useState(false);

--- a/src/veiledere/veiledere-side.tsx
+++ b/src/veiledere/veiledere-side.tsx
@@ -31,7 +31,8 @@ function VeiledereSide() {
     const filtervalg = useSelector((state: AppState) => state.filtreringVeilederoversikt);
     const oversiktType = OversiktType.veilederOversikt;
     const dispatch = useDispatch();
-    const slettVeilederFilter = ident => dispatch(slettEnkeltFilter('veiledere', ident, oversiktType));
+    const slettVeilederFilter = ident =>
+        dispatch(slettEnkeltFilter('veiledere', ident, oversiktType, filtervalg, dispatch));
     const veiledere = useSelector((state: AppState) => state.veiledere);
     const portefoljestorrelser = useSelector((state: AppState) => state.portefoljestorrelser);
     const id = 'veileder-oversikt';
@@ -55,7 +56,7 @@ function VeiledereSide() {
 
     const doEndreFiltervalg = (filterId: string, filterVerdi: React.ReactNode) => {
         dispatch(pagineringSetup({side: 1}));
-        dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType));
+        dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType, filtervalg, dispatch));
     };
 
     return (

--- a/src/veiledere/veiledere-side.tsx
+++ b/src/veiledere/veiledere-side.tsx
@@ -6,7 +6,7 @@ import Innholdslaster from '../innholdslaster/innholdslaster';
 import FiltreringVeiledere from '../filtrering/filtrering-veiledere';
 import FiltreringLabelContainer from '../filtrering/filtrering-label-container';
 import {lagLablerTilVeiledereMedIdenter} from '../filtrering/utils';
-import {endreFiltervalg, slettEnkeltFilter} from '../ducks/filtrering';
+import {endreFiltervalg, fjern, slettEnkeltFilter} from '../ducks/filtrering';
 import './veiledere.css';
 import ToppMeny from '../topp-meny/topp-meny';
 import {useOnMount} from '../hooks/use-on-mount';
@@ -19,7 +19,7 @@ import {useSetLocalStorageOnUnmount} from '../hooks/portefolje/use-set-local-sto
 import FilteringVeiledergrupper from '../filtrering/filtrering-veileder-grupper/filtrering-veiledergrupper';
 import {useFetchStatustallForVeileder} from '../hooks/portefolje/use-fetch-statustall';
 import MetrikkEkspanderbartpanel from '../components/ekspandertbart-panel/metrikk-ekspanderbartpanel';
-import {OversiktType} from '../ducks/ui/listevisning';
+import {oppdaterKolonneAlternativer, OversiktType} from '../ducks/ui/listevisning';
 import LagredeFilterUIController from '../filtrering/lagrede-filter-controller';
 import {Panel} from '@navikt/ds-react';
 import {Informasjonsmeldinger} from '../components/informasjonsmeldinger/informasjonsmeldinger';
@@ -31,8 +31,11 @@ function VeiledereSide() {
     const filtervalg = useSelector((state: AppState) => state.filtreringVeilederoversikt);
     const oversiktType = OversiktType.veilederOversikt;
     const dispatch = useDispatch();
-    const slettVeilederFilter = ident =>
-        dispatch(slettEnkeltFilter('veiledere', ident, oversiktType, filtervalg, dispatch));
+    const slettVeilederFilter = ident => {
+        const oppdatertFiltervalg = {...filtervalg, veiledere: fjern('veiledere', filtervalg['veiledere'], ident)};
+        oppdaterKolonneAlternativer(dispatch, oppdatertFiltervalg, oversiktType);
+        return dispatch(slettEnkeltFilter('veiledere', ident, oversiktType));
+    };
     const veiledere = useSelector((state: AppState) => state.veiledere);
     const portefoljestorrelser = useSelector((state: AppState) => state.portefoljestorrelser);
     const id = 'veileder-oversikt';
@@ -56,7 +59,8 @@ function VeiledereSide() {
 
     const doEndreFiltervalg = (filterId: string, filterVerdi: React.ReactNode) => {
         dispatch(pagineringSetup({side: 1}));
-        dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType, filtervalg, dispatch));
+        oppdaterKolonneAlternativer(dispatch, {...filtervalg, [filterId]: filterVerdi}, oversiktType);
+        dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType));
     };
 
     return (


### PR DESCRIPTION
Litt usikker på endringen, men går fra å "resette" ved hver render i use-fetch-portefolje.tsx til å heller endre kolonner når man endrer filteret.
Må testes godt før merging