### PR TITLE
Fikse 404 feil

### DIFF
--- a/src/components/modal/arbeidsliste/arbeidsliste-modal-rediger.tsx
+++ b/src/components/modal/arbeidsliste/arbeidsliste-modal-rediger.tsx
@@ -7,7 +7,7 @@ import {Formik, FormikProps} from 'formik';
 import {STATUS} from '../../../ducks/utils';
 import {visServerfeilModal} from '../../../ducks/modal-serverfeil';
 import {markerAlleBrukere, oppdaterArbeidslisteForBruker} from '../../../ducks/portefolje';
-import {redigerArbeidsliste} from '../../../ducks/arbeidsliste';
+import {redigerArbeidslisteAction} from '../../../ducks/arbeidsliste';
 import moment from 'moment';
 import {OrNothing} from '../../../utils/types/types';
 import './arbeidsliste.css';
@@ -93,7 +93,9 @@ function ArbeidslisteModalRediger({bruker, sistEndretAv, sistEndretDato, settMar
                     enableReinitialize={true}
                     onSubmit={values => {
                         setIsOpen(false);
-                        dispatch(redigerArbeidsliste(values, {bruker, sistEndretAv, sistEndretDato, settMarkert}));
+                        dispatch(
+                            redigerArbeidslisteAction(values, {bruker, sistEndretAv, sistEndretDato, settMarkert})
+                        );
                     }}
                 >
                     {formikProps => (

--- a/src/components/modal/arbeidsliste/fjern-fra-arbeidsliste-form.tsx
+++ b/src/components/modal/arbeidsliste/fjern-fra-arbeidsliste-form.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {connect} from 'react-redux';
-import {slettArbeidsliste} from '../../../ducks/arbeidsliste';
+import {slettArbeidslisteAction} from '../../../ducks/arbeidsliste';
 import {oppdaterArbeidslisteForBruker} from '../../../ducks/portefolje';
 import {leggTilStatustall} from '../../../ducks/statustall-veileder';
 import {FJERN_FRA_ARBEIDSLISTE_FEILET, visFeiletModal} from '../../../ducks/modal-feilmelding-brukere';
@@ -116,7 +116,9 @@ const mapDispatchToProps = dispatch => ({
             frist: bruker.arbeidsliste.frist,
             kategori: bruker.arbeidsliste.kategori
         }));
-        slettArbeidsliste(arbeidsliste)(dispatch).then(res => oppdaterState(res, lukkModal, arbeidsliste, dispatch));
+        slettArbeidslisteAction(arbeidsliste)(dispatch).then(res =>
+            oppdaterState(res, lukkModal, arbeidsliste, dispatch)
+        );
     }
 });
 

--- a/src/components/modal/arbeidsliste/legg-til-arbeidslisteform.tsx
+++ b/src/components/modal/arbeidsliste/legg-til-arbeidslisteform.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {ArbeidslisteDataModell, BrukerModell, KategoriModell, Status, VeilederModell} from '../../../model-interfaces';
-import {postArbeidsliste} from '../../../ducks/arbeidsliste';
+import {lagreArbeidslisteAction} from '../../../ducks/arbeidsliste';
 import {markerAlleBrukere, oppdaterArbeidslisteForBruker} from '../../../ducks/portefolje';
 import {visServerfeilModal} from '../../../ducks/modal-serverfeil';
 import {LEGG_TIL_ARBEIDSLISTE_FEILET, visFeiletModal} from '../../../ducks/modal-feilmelding-brukere';
@@ -182,7 +182,7 @@ const mapDispatchToProps = (dispatch, props) => ({
             frist: elem.frist ? dateToISODate(elem.frist) : null,
             kategori: elem.kategori
         }));
-        return postArbeidsliste(liste)(dispatch)
+        return lagreArbeidslisteAction(liste)(dispatch)
             .then(data => {
                 oppdaterState(data, liste, props, dispatch);
             })

--- a/src/ducks/arbeidsliste.ts
+++ b/src/ducks/arbeidsliste.ts
@@ -1,5 +1,5 @@
 import {doThenDispatch, STATUS} from './utils';
-import {_lagreArbeidsliste, _oppdaterArbeidsliste, _slettArbeidsliste} from '../middleware/api';
+import {lagreArbeidsliste, oppdaterArbeidsliste, slettArbeidsliste} from '../middleware/api';
 import {skjulModal} from './modal';
 import {oppdaterArbeidsListeState} from '../components/modal/arbeidsliste/arbeidsliste-modal-rediger';
 import {dateToISODate} from '../utils/dato-utils';
@@ -48,7 +48,7 @@ export default function arbeidslisteReducer(state = initialState, action) {
 }
 
 // Action Creators
-export function redigerArbeidsliste(formData, props) {
+export function redigerArbeidslisteAction(formData, props) {
     const arbeidsliste = {
         kommentar: formData.kommentar,
         overskrift: formData.overskrift,
@@ -57,7 +57,7 @@ export function redigerArbeidsliste(formData, props) {
     };
 
     return dispatch =>
-        putArbeidsliste(
+        oppdaterArbeidslisteAction(
             arbeidsliste,
             props.bruker.fnr
         )(dispatch)
@@ -67,24 +67,24 @@ export function redigerArbeidsliste(formData, props) {
             .then(() => dispatch(skjulModal()));
 }
 
-export function postArbeidsliste(arbeidsliste) {
-    return doThenDispatch(() => _lagreArbeidsliste(arbeidsliste), {
+export function lagreArbeidslisteAction(arbeidsliste) {
+    return doThenDispatch(() => lagreArbeidsliste(arbeidsliste), {
         OK: ARBEIDSLISTE_LAGRE_OK,
         FEILET: ARBEIDSLISTE_LAGRE_FEILET,
         PENDING: ARBEIDSLISTE_LAGRE_PENDING
     });
 }
 
-export function slettArbeidsliste(arbeidsliste) {
-    return doThenDispatch(() => _slettArbeidsliste(arbeidsliste), {
+export function slettArbeidslisteAction(arbeidsliste) {
+    return doThenDispatch(() => slettArbeidsliste(arbeidsliste), {
         OK: ARBEIDSLISTE_SLETT_OK,
         FEILET: ARBEIDSLISTE_SLETT_FEILET,
         PENDING: ARBEIDSLISTE_SLETT_PENDING
     });
 }
 
-export function putArbeidsliste(arbeidsliste, fnr) {
-    return doThenDispatch(() => _oppdaterArbeidsliste(arbeidsliste, fnr), {
+export function oppdaterArbeidslisteAction(arbeidsliste, fnr) {
+    return doThenDispatch(() => oppdaterArbeidsliste(arbeidsliste, fnr), {
         OK: ARBEIDSLISTE_REDIGER_OK,
         FEILET: ARBEIDSLISTE_REDIGER_FEILET,
         PENDING: ARBEIDSLISTE_REDIGER_PENDING

--- a/src/ducks/arbeidsliste.ts
+++ b/src/ducks/arbeidsliste.ts
@@ -1,8 +1,6 @@
 import {doThenDispatch, STATUS} from './utils';
 import {_lagreArbeidsliste, _oppdaterArbeidsliste, _slettArbeidsliste} from '../middleware/api';
 import {skjulModal} from './modal';
-import {markerAlleBrukere} from './portefolje';
-import {oppdaterState} from '../components/modal/arbeidsliste/legg-til-arbeidslisteform';
 import {oppdaterArbeidsListeState} from '../components/modal/arbeidsliste/arbeidsliste-modal-rediger';
 import {dateToISODate} from '../utils/dato-utils';
 
@@ -50,24 +48,6 @@ export default function arbeidslisteReducer(state = initialState, action) {
 }
 
 // Action Creators
-export function lagreArbeidsliste(arbeidsliste, props) {
-    const {valgteBrukere} = props;
-    const liste = arbeidsliste.map((elem, index) => ({
-        fnr: valgteBrukere[index].fnr,
-        overskrift: elem.overskrift,
-        kommentar: elem.kommentar,
-        frist: elem.frist,
-        kategori: elem.kategori
-    }));
-    return dispatch =>
-        postArbeidsliste(liste)(dispatch)
-            .then(res => oppdaterState(res, liste, props, dispatch))
-            .then(() => {
-                dispatch(skjulModal());
-                dispatch(markerAlleBrukere(false));
-            });
-}
-
 export function redigerArbeidsliste(formData, props) {
     const arbeidsliste = {
         kommentar: formData.kommentar,

--- a/src/ducks/arbeidsliste.ts
+++ b/src/ducks/arbeidsliste.ts
@@ -1,5 +1,5 @@
-import {STATUS, doThenDispatch} from './utils';
-import {httpArbeidsliste} from '../middleware/api';
+import {doThenDispatch, STATUS} from './utils';
+import {_lagreArbeidsliste, _oppdaterArbeidsliste, _slettArbeidsliste} from '../middleware/api';
 import {skjulModal} from './modal';
 import {markerAlleBrukere} from './portefolje';
 import {oppdaterState} from '../components/modal/arbeidsliste/legg-til-arbeidslisteform';
@@ -88,7 +88,7 @@ export function redigerArbeidsliste(formData, props) {
 }
 
 export function postArbeidsliste(arbeidsliste) {
-    return doThenDispatch(() => httpArbeidsliste(arbeidsliste, 'post'), {
+    return doThenDispatch(() => _lagreArbeidsliste(arbeidsliste), {
         OK: ARBEIDSLISTE_LAGRE_OK,
         FEILET: ARBEIDSLISTE_LAGRE_FEILET,
         PENDING: ARBEIDSLISTE_LAGRE_PENDING
@@ -96,7 +96,7 @@ export function postArbeidsliste(arbeidsliste) {
 }
 
 export function slettArbeidsliste(arbeidsliste) {
-    return doThenDispatch(() => httpArbeidsliste(arbeidsliste, 'post', 'delete'), {
+    return doThenDispatch(() => _slettArbeidsliste(arbeidsliste), {
         OK: ARBEIDSLISTE_SLETT_OK,
         FEILET: ARBEIDSLISTE_SLETT_FEILET,
         PENDING: ARBEIDSLISTE_SLETT_PENDING
@@ -104,7 +104,7 @@ export function slettArbeidsliste(arbeidsliste) {
 }
 
 export function putArbeidsliste(arbeidsliste, fnr) {
-    return doThenDispatch(() => httpArbeidsliste(arbeidsliste, 'put', fnr), {
+    return doThenDispatch(() => _oppdaterArbeidsliste(arbeidsliste, fnr), {
         OK: ARBEIDSLISTE_REDIGER_OK,
         FEILET: ARBEIDSLISTE_REDIGER_FEILET,
         PENDING: ARBEIDSLISTE_REDIGER_PENDING

--- a/src/middleware/api.ts
+++ b/src/middleware/api.ts
@@ -178,9 +178,21 @@ export function hentStatusTallForVeileder(enhetId, veilederId) {
     return fetchToJson(url, MED_CREDENTIALS);
 }
 
-export function httpArbeidsliste(arbeidsliste, method, additionalPath = '') {
-    const url = `${VEILARBPORTEFOLJE_URL}/arbeidsliste/${additionalPath}`;
-    const config = {...MED_CREDENTIALS, method, body: JSON.stringify(arbeidsliste)};
+export function _lagreArbeidsliste(arbeidsliste) {
+    const url = `${VEILARBPORTEFOLJE_URL}/arbeidsliste`;
+    const config = {...MED_CREDENTIALS, method: 'post', body: JSON.stringify(arbeidsliste)};
+    return fetchToJson(url, config);
+}
+
+export function _oppdaterArbeidsliste(arbeidsliste, fnr) {
+    const url = `${VEILARBPORTEFOLJE_URL}/arbeidsliste/${fnr}`;
+    const config = {...MED_CREDENTIALS, method: 'put', body: JSON.stringify(arbeidsliste)};
+    return fetchToJson(url, config);
+}
+
+export function _slettArbeidsliste(arbeidsliste) {
+    const url = `${VEILARBPORTEFOLJE_URL}/arbeidsliste/delete`;
+    const config = {...MED_CREDENTIALS, method: 'post', body: JSON.stringify(arbeidsliste)};
     return fetchToJson(url, config);
 }
 
@@ -228,7 +240,7 @@ export function hentSystemmeldinger() {
 }
 
 export function hentMoteplan(veileder: string, enhet: string) {
-    const url = `${VEILARBPORTEFOLJE_URL}/veileder/${veileder}/moteplan/?enhet=${enhet}`;
+    const url = `${VEILARBPORTEFOLJE_URL}/veileder/${veileder}/moteplan?enhet=${enhet}`;
     return fetchToJson(url, MED_CREDENTIALS);
 }
 

--- a/src/middleware/api.ts
+++ b/src/middleware/api.ts
@@ -178,19 +178,19 @@ export function hentStatusTallForVeileder(enhetId, veilederId) {
     return fetchToJson(url, MED_CREDENTIALS);
 }
 
-export function _lagreArbeidsliste(arbeidsliste) {
+export function lagreArbeidsliste(arbeidsliste) {
     const url = `${VEILARBPORTEFOLJE_URL}/arbeidsliste`;
     const config = {...MED_CREDENTIALS, method: 'post', body: JSON.stringify(arbeidsliste)};
     return fetchToJson(url, config);
 }
 
-export function _oppdaterArbeidsliste(arbeidsliste, fnr) {
+export function oppdaterArbeidsliste(arbeidsliste, fnr) {
     const url = `${VEILARBPORTEFOLJE_URL}/arbeidsliste/${fnr}`;
     const config = {...MED_CREDENTIALS, method: 'put', body: JSON.stringify(arbeidsliste)};
     return fetchToJson(url, config);
 }
 
-export function _slettArbeidsliste(arbeidsliste) {
+export function slettArbeidsliste(arbeidsliste) {
     const url = `${VEILARBPORTEFOLJE_URL}/arbeidsliste/delete`;
     const config = {...MED_CREDENTIALS, method: 'post', body: JSON.stringify(arbeidsliste)};
     return fetchToJson(url, config);

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -220,7 +220,7 @@ mock.get('/veilarbvedtaksstotte/api/utrulling/erUtrullet', jsonResponse(true));
 mock.post('/veilarboppfolging/api/tilordneveileder', ({body}, res, ctx) => res(ctx.json(tildel(body))));
 
 // arbeidsliste-api
-mock.post('/veilarbportefolje/api/arbeidsliste/', (req, res, ctx) =>
+mock.post('/veilarbportefolje/api/arbeidsliste', (req, res, ctx) =>
     res(ctx.json({error: [], data: req.body.map(arbeidsliste => arbeidsliste.fnr)}))
 );
 


### PR DESCRIPTION
Feilen oppstår fordi Spring Boot 3 ikke tillater trailing-slash by-default lengre. Det var noen slike i veilarbportefoljeflatefs som gikk "under radaren". Denne PR-en fikser de jeg fant.

I stedet for å rote inne i den gamle `httpArbeidsliste`-funksjonen så lager jeg heller nye funksjoner med semantiske navn for de ulike operasjonene (lagre, oppdatere, slette).

Renamer litt for å unngå navnekollisjon.