### PR TITLE
Legg til mulighet til å skippe tester når vi deployer manuelt til dev

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yaml
+++ b/.github/workflows/deploy-dev-gcp.yaml
@@ -1,6 +1,11 @@
 name: Deploy to dev
 on:
     workflow_dispatch:
+      inputs:
+        skip_tests:
+          description: "Ignorer tester?"
+          required: false
+          type: boolean
 env:
     CI: true
     TZ: Europe/Amsterdam
@@ -20,6 +25,7 @@ jobs:
             - name: Install dependencies
               run: npm ci
             - name: Run tests
+              if: inputs.skip_tests == false
               run: npm run test
             - name: Build application
               run: npm run build:dev


### PR DESCRIPTION
Av og til ønsker man å deploye en branch i dev for testing. Da hadde det vært nice å kunne slippe å vente på at tester man vet kjører skal kjøre først. Det vil kun være mulig å ignorere testene ved manuell run av workflow-en - ved å sette default til `false` så sikrer vi at testene alltid kjører i forbindelse med PR/merge.