### PR TITLE
FS-289482: bugfiks - antall uker AAP-unntak

### DIFF
--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -116,7 +116,7 @@ export function aapVurderingsfrist(
 
 export function aapRettighetsperiode(ytelse, maxtidukerigjen, unntakukerigjen) {
     if (ytelse === 'AAP') {
-        return maxtidukerigjen !== -1 ? maxtidukerigjen : unntakukerigjen;
+        return maxtidukerigjen !== 0 ? maxtidukerigjen : unntakukerigjen;
     } else if (ytelse === 'AAP_MAXTID') {
         return maxtidukerigjen;
     } else if (ytelse === 'AAP_UNNTAK') {


### PR DESCRIPTION
Når man filtrerer på kun AAP, så vises det feil gjenstående rettighet når brukeren er på unntaksperiode. Mulig Arena/veilarbportefolje returnerte -1 før, men det ser ikke ut til å være tilfellet nå. Nå er maxtidukerigjen 0 når brukeren er på unntaksperiode.