### PR TITLE
Advarsel for sletting arbeidslista

### DIFF
--- a/src/amplitude/taxonomy-events.ts
+++ b/src/amplitude/taxonomy-events.ts
@@ -2,5 +2,6 @@
 export type AmplitudeEvent =
     | {name: 'skjema fullført'; data: {skjemanavn: string; skjemaId: string}}
     | {name: 'navigere'; data: {lenketekst: string; destinasjon: string}}
+    | {name: 'modal åpnet'; data: {tekst: string}}
     | {name: 'knapp klikket'; data: {knapptekst: string; effekt: string}}
     | {name: string; data: Record<string, unknown>};

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -9,8 +9,9 @@ import SokFilter from '../../sok-veiledere/sok-filter';
 import classNames from 'classnames';
 import {nameToStateSliceMap} from '../../../ducks/utils';
 import {useSelectGjeldendeVeileder} from '../../../hooks/portefolje/use-select-gjeldende-veileder';
-import {Button, Radio, RadioGroup} from '@navikt/ds-react';
+import {BodyShort, Button, Radio, RadioGroup, TextField} from '@navikt/ds-react';
 import {useIdentSelector} from '../../../hooks/redux/use-innlogget-ident';
+import {ErrorModalType, MineFilterVarselModal} from '../mine-filter/varsel-modal';
 
 interface TildelVeilederProps {
     oversiktType?: string;
@@ -36,6 +37,22 @@ function TildelVeileder({oversiktType, btnOnClick}: TildelVeilederProps) {
         return dispatch(tildelVeileder(tilordninger, tilVeileder, oversiktType, gjeldendeVeileder));
     };
 
+    const visAdvarselSletteArbeidslista = (brukereFraNyEnhet, tilordninger, tilVeileder) => {
+        return (
+            <>
+                <form onSubmit={e => doTildelTilVeileder(tilordninger, tilVeileder)}>
+                    <BodyShort size="small">Advarsel.</BodyShort>
+                    <TextField label="Navn:" />
+                    <div className="lagret-filter-knapp-wrapper">
+                        <Button size="small" type="submit">
+                            Lagre
+                        </Button>
+                    </div>
+                </form>
+            </>
+        );
+    };
+
     const valgteBrukere = brukere.filter(bruker => bruker.markert === true);
 
     const onSubmit = () => {
@@ -46,7 +63,12 @@ function TildelVeileder({oversiktType, btnOnClick}: TildelVeilederProps) {
                 tilVeilederId: ident,
                 brukerFnr: bruker.fnr
             }));
-            doTildelTilVeileder(tilordninger, ident);
+            const brukereFraNyEnhet = valgteBrukere.filter(bruker => bruker.nyForEnhet);
+            if (brukereFraNyEnhet.length > 0) {
+                return visAdvarselSletteArbeidslista(brukereFraNyEnhet, tilordninger, ident);
+            } else {
+                doTildelTilVeileder(tilordninger, ident);
+            }
         }
     };
 

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -67,36 +67,39 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 brukerFnr: bruker.fnr
             }));
 
-            const ikkeSlettetTilordninger = valgteBrukere
-                .filter(bruker => bruker.nyForEnhet && bruker.arbeidsliste.arbeidslisteAktiv)
-                .filter(bruker => bruker.veilederId !== ident)
-                .map(bruker => ({
-                    fraVeilederId: bruker.veilederId,
-                    tilVeilederId: ident,
-                    brukerFnr: bruker.fnr
-                }));
+            const brukereArbeidslisteBlirIkkeSlettet = valgteBrukere.filter(
+                bruker => !bruker.nyForEnhet || !bruker.arbeidsliste.arbeidslisteAktiv || bruker.veilederId === ident
+            );
+
+            const tilordningerBrukereArbeidslisteBlirIkkeSlettet = brukereArbeidslisteBlirIkkeSlettet.map(bruker => ({
+                fraVeilederId: bruker.veilederId,
+                tilVeilederId: ident,
+                brukerFnr: bruker.fnr
+            }));
 
             setTilordningerAlle(alleTilordninger);
 
-            setTilordningerIkkeSlettingArbeidslista(ikkeSlettetTilordninger);
+            setTilordningerIkkeSlettingArbeidslista(tilordningerBrukereArbeidslisteBlirIkkeSlettet);
 
-            const brukereArbeidslisteVilBliSlettet = valgteBrukere
+            const fnrBrukereArbeidslisteVilBliSlettet = valgteBrukere
                 .filter(bruker => bruker.nyForEnhet && bruker.arbeidsliste.arbeidslisteAktiv)
                 .filter(bruker => bruker.veilederId !== ident);
 
             setFnrArbeidslisteBlirSlettet(
-                brukereArbeidslisteVilBliSlettet.map(bruker => ({
+                fnrBrukereArbeidslisteVilBliSlettet.map(bruker => ({
                     brukerFnr: bruker.fnr
                 }))
             );
 
             const a = true;
 
-            if (brukereArbeidslisteVilBliSlettet.length > 0 || a) {
+            if (fnrBrukereArbeidslisteVilBliSlettet.length > 0 || a) {
                 // eslint-disable-next-line
-                console.log('Noen arbeidslister vil bli sletta', brukereArbeidslisteVilBliSlettet);
+                console.log('Noen arbeidslister vil bli sletta', fnrBrukereArbeidslisteVilBliSlettet);
                 // eslint-disable-next-line
-                console.log('Noen arbeidslister vil bli sletta', fnrArbeidslisteBlirSlettet);
+                console.log('Alle', alleTilordninger);
+                // eslint-disable-next-line
+                console.log('IkkeSlettes', tilordningerBrukereArbeidslisteBlirIkkeSlettet);
                 setVisAdvarselOmSletting(true);
                 // eslint-disable-next-line
                 console.log(visAdvarselOmSletting);
@@ -104,7 +107,10 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 // eslint-disable-next-line
                 console.log('Ingen arbeidslister vil bli sletta, tilordAlle', alleTilordninger);
                 // eslint-disable-next-line
-                console.log('Ingen arbeidslister vil bli sletta, tilordnIkkeSl', ikkeSlettetTilordninger);
+                console.log(
+                    'Ingen arbeidslister vil bli sletta, tilordnIkkeSl',
+                    tilordningerBrukereArbeidslisteBlirIkkeSlettet
+                );
                 doTildelTilVeileder(alleTilordninger, ident);
                 closeInput();
             }

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -55,6 +55,9 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
     const onSubmit = () => {
         // eslint-disable-next-line
         console.log('Klikket submit');
+        // eslint-disable-next-line
+        console.log('Valgte brukere', valgteBrukere);
+
         if (ident) {
             setTilordningerAlle(
                 valgteBrukere.map(bruker => ({

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -98,9 +98,6 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 valgteBrukere.map(bruker => bruker.arbeidsliste.navkontorForArbeidsliste !== enhet)
             );
 
-            // eslint-disable-next-line
-            console.log('Og');
-
             setFnrArbeidslisteBlirSlettet(
                 fnrBrukereArbeidslisteVilBliSlettet.map(bruker => ({
                     brukerFnr: bruker.fnr

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -83,8 +83,14 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
             );
 
             if (brukereArbeidslisteVilBliSlettet.length > 0) {
+                // eslint-disable-next-line
+                console.log('Noen arbeidslister vil bli sletta', brukereArbeidslisteVilBliSlettet);
                 setVisAdvarselOmSletting(true);
             } else {
+                // eslint-disable-next-line
+                console.log('Ingen arbeidslister vil bli sletta, tilordAlle', tilordningerAlle);
+                // eslint-disable-next-line
+                console.log('Ingen arbeidslister vil bli sletta, tilordnIkkeSl', tilordningerIkkeSlettingArbeidslista);
                 doTildelTilVeileder(tilordningerAlle, ident);
                 closeInput();
             }
@@ -115,6 +121,8 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                             variant="tertiary"
                             className="knapp-avbryt-tildeling"
                             onClick={() => {
+                                // eslint-disable-next-line
+                                console.log('Klikket avbryt, tilordnIkkeSl', tilordningerIkkeSlettingArbeidslista);
                                 doTildelTilVeileder(tilordningerIkkeSlettingArbeidslista, ident);
                                 lukkFjernModal();
                             }}
@@ -127,6 +135,8 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                             className="knapp"
                             size="medium"
                             onClick={() => {
+                                // eslint-disable-next-line
+                                console.log('Klikket bekreft, tilordnAlle', tilordningerAlle);
                                 doTildelTilVeileder(tilordningerAlle, ident);
                                 lukkFjernModal();
                             }}

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -116,11 +116,6 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                             variant="tertiary"
                             className="knapp-avbryt-tildeling"
                             onClick={() => {
-                                // eslint-disable-next-line
-                                console.log(
-                                    'Klikket avbryt, tilordnIkkeSl',
-                                    tilordningerBrukereArbeidslisteBlirIkkeSlettet
-                                );
                                 doTildelTilVeileder(tilordningerBrukereArbeidslisteBlirIkkeSlettet, ident);
                                 lukkFjernModal();
                             }}
@@ -133,8 +128,6 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                             className="knapp"
                             size="medium"
                             onClick={() => {
-                                // eslint-disable-next-line
-                                console.log('Klikket bekreft, tilordnAlle', tilordningerAlle);
                                 doTildelTilVeileder(tilordningerAlle, ident);
                                 lukkFjernModal();
                             }}

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -99,9 +99,9 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 console.log(visAdvarselOmSletting);
             } else {
                 // eslint-disable-next-line
-                console.log('Ingen arbeidslister vil bli sletta, tilordAlle', tilordningerAlle);
+                console.log('Ingen arbeidslister vil bli sletta, tilordAlle', alleTilordninger);
                 // eslint-disable-next-line
-                console.log('Ingen arbeidslister vil bli sletta, tilordnIkkeSl', tilordningerIkkeSlettingArbeidslista);
+                console.log('Ingen arbeidslister vil bli sletta, tilordnIkkeSl', ikkeSlettetTilordninger);
                 doTildelTilVeileder(alleTilordninger, ident);
                 closeInput();
             }

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -95,7 +95,11 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
             // eslint-disable-next-line
             console.log(
                 'Navkontor for arbeidsliste !== enhet',
-                valgteBrukere.map(bruker => bruker.arbeidsliste.navkontorForArbeidsliste !== enhet)
+                valgteBrukere.map(
+                    bruker =>
+                        bruker.arbeidsliste.navkontorForArbeidsliste !== null &&
+                        bruker.arbeidsliste.navkontorForArbeidsliste !== enhet
+                )
             );
 
             setFnrArbeidslisteBlirSlettet(

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -26,7 +26,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
     const [tilordningerAlle, setTilordningerAlle] = useState<
         {fraVeilederId: string | undefined; tilVeilederId: string; brukerFnr: string}[]
     >([]);
-    const [tilordningerIkkeNyEnhet, setTilordningerIkkeNyEnhet] = useState<
+    const [tilordningerIkkeSlettingArbeidslista, setTilordningerIkkeSlettingArbeidslista] = useState<
         {fraVeilederId: string | undefined; tilVeilederId: string; brukerFnr: string}[]
     >([]);
     const [fnrArbeidslisteBlirSlettet, setFnrArbeidslisteBlirSlettet] = useState<Fnr[]>([]);
@@ -62,7 +62,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 }))
             );
 
-            setTilordningerIkkeNyEnhet(
+            setTilordningerIkkeSlettingArbeidslista(
                 valgteBrukere
                     .filter(bruker => !bruker.nyForEnhet)
                     .map(bruker => ({
@@ -115,7 +115,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                             variant="tertiary"
                             className="knapp-avbryt-tildeling"
                             onClick={() => {
-                                doTildelTilVeileder(tilordningerIkkeNyEnhet, ident);
+                                doTildelTilVeileder(tilordningerIkkeSlettingArbeidslista, ident);
                                 lukkFjernModal();
                             }}
                             size="medium"

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -15,15 +15,15 @@ import {Fnr, FnrList} from '../../fnr-list';
 
 interface TildelVeilederProps {
     oversiktType?: string;
-    btnOnClick: () => void;
+    closeInput: () => void;
 }
 
-function TildelVeileder({oversiktType, btnOnClick}: TildelVeilederProps) {
+function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
     const [ident, setIdent] = useState<string | null>(null);
     const [visAdvarselOmSletting, setVisAdvarselOmSletting] = useState<boolean>(false);
     const brukere = useSelector((state: AppState) => state.portefolje.data.brukere);
     const veiledere = useSelector((state: AppState) => state.veiledere.data.veilederListe);
-    const [tilordninger2, setTilordninger] = useState<
+    const [tilordninger, setTilordninger] = useState<
         {fraVeilederId: string | undefined; tilVeilederId: string; brukerFnr: string}[]
     >([]);
     const [fnrArbeidslisteBlirSlettet, setFnrArbeidslisteBlirSlettet] = useState<Fnr[]>([]);
@@ -44,18 +44,13 @@ function TildelVeileder({oversiktType, btnOnClick}: TildelVeilederProps) {
 
     const lukkFjernModal = () => {
         setVisAdvarselOmSletting(false);
-        btnOnClick();
+        closeInput();
     };
 
     const valgteBrukere = brukere.filter(bruker => bruker.markert === true);
 
     const onSubmit = () => {
         if (ident) {
-            const tilordninger = valgteBrukere.map(bruker => ({
-                fraVeilederId: bruker.veilederId,
-                tilVeilederId: ident,
-                brukerFnr: bruker.fnr
-            }));
             setTilordninger(
                 valgteBrukere.map(bruker => ({
                     fraVeilederId: bruker.veilederId,
@@ -76,44 +71,47 @@ function TildelVeileder({oversiktType, btnOnClick}: TildelVeilederProps) {
                 setVisAdvarselOmSletting(true);
             } else {
                 doTildelTilVeileder(tilordninger, ident);
-                btnOnClick();
+                closeInput();
             }
         } else {
-            btnOnClick();
+            closeInput();
         }
     };
 
     return (
         <>
-            <Modal open={visAdvarselOmSletting} onClose={lukkFjernModal}>
+            <Modal open={visAdvarselOmSletting} onClose={lukkFjernModal} className="advarsel-sletting-arbeidslista">
                 <Modal.Content>
-                    <div className="modal-innhold">
-                        <div className="advarsel-modal">
-                            <Heading size="medium" level="1">
-                                Arbeidslistenotat blir slettet
-                            </Heading>
-                            <BodyShort size="small">
-                                {`Arbeidslistenotat for følgende brukere ble opprettet på en annen enhet, og vil bli slettet ved tildeling av ny veileder:`}
-                            </BodyShort>
-                            <FnrList listeMedFnr={fnrArbeidslisteBlirSlettet} />
-                            <BodyShort size="small">{`Ønsker du likevel å tildele veilederen?`}</BodyShort>
-                        </div>
-                        <div className="knapper">
-                            <Button variant="secondary" className="knapp" onClick={lukkFjernModal} size="small">
-                                Avbryt tildeling
-                            </Button>
-                            <Button
-                                type={'submit'}
-                                className="knapp knapp--hoved"
-                                size="small"
-                                onClick={() => {
-                                    doTildelTilVeileder(tilordninger2, ident);
-                                    lukkFjernModal();
-                                }}
-                            >
-                                Ja, tildel veilederen
-                            </Button>
-                        </div>
+                    <div className="advarsel-modal">
+                        <Heading size="medium" level="1">
+                            Arbeidslistenotat blir slettet
+                        </Heading>
+                        <BodyShort size="small">
+                            {`Arbeidslistenotat for følgende brukere ble opprettet på en annen enhet, og vil bli slettet ved tildeling av ny veileder:`}
+                        </BodyShort>
+                        <FnrList listeMedFnr={fnrArbeidslisteBlirSlettet} />
+                        <BodyShort size="small">{`Ønsker du likevel å tildele veilederen?`}</BodyShort>
+                    </div>
+                    <div>
+                        <Button
+                            variant="secondary"
+                            className="knapp-avbryt-tildeling"
+                            onClick={lukkFjernModal}
+                            size="small"
+                        >
+                            Avbryt tildeling
+                        </Button>
+                        <Button
+                            type={'submit'}
+                            className="knapp"
+                            size="small"
+                            onClick={() => {
+                                doTildelTilVeileder(tilordninger, ident);
+                                lukkFjernModal();
+                            }}
+                        >
+                            Ja, tildel veilederen
+                        </Button>
                     </div>
                 </Modal.Content>
             </Modal>

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -11,8 +11,7 @@ import {nameToStateSliceMap} from '../../../ducks/utils';
 import {useSelectGjeldendeVeileder} from '../../../hooks/portefolje/use-select-gjeldende-veileder';
 import {BodyShort, Button, Heading, Modal, Radio, RadioGroup} from '@navikt/ds-react';
 import {useIdentSelector} from '../../../hooks/redux/use-innlogget-ident';
-import {VarselModal, VarselModalType} from '../varselmodal/varselmodal';
-import ModalHeader from '../modal-header';
+import {Fnr, FnrList} from '../../fnr-list';
 
 interface TildelVeilederProps {
     oversiktType?: string;
@@ -27,6 +26,7 @@ function TildelVeileder({oversiktType, btnOnClick}: TildelVeilederProps) {
     const [tilordninger2, setTilordninger] = useState<
         {fraVeilederId: string | undefined; tilVeilederId: string; brukerFnr: string}[]
     >([]);
+    const [fnrArbeidslisteBlirSlettet, setFnrArbeidslisteBlirSlettet] = useState<Fnr[]>([]);
     const dispatch = useDispatch();
     const gjeldendeVeileder = useSelectGjeldendeVeileder();
     const innloggetVeileder = useIdentSelector()?.ident;
@@ -44,6 +44,7 @@ function TildelVeileder({oversiktType, btnOnClick}: TildelVeilederProps) {
 
     const lukkFjernModal = () => {
         setVisAdvarselOmSletting(false);
+        btnOnClick();
     };
 
     const valgteBrukere = brukere.filter(bruker => bruker.markert === true);
@@ -62,7 +63,15 @@ function TildelVeileder({oversiktType, btnOnClick}: TildelVeilederProps) {
                     brukerFnr: bruker.fnr
                 }))
             );
+
             const brukereFraNyEnhet = valgteBrukere.filter(bruker => bruker.nyForEnhet);
+
+            setFnrArbeidslisteBlirSlettet(
+                brukereFraNyEnhet.map(bruker => ({
+                    brukerFnr: bruker.fnr
+                }))
+            );
+
             if (brukereFraNyEnhet.length > 0) {
                 setVisAdvarselOmSletting(true);
             } else {
@@ -86,6 +95,7 @@ function TildelVeileder({oversiktType, btnOnClick}: TildelVeilederProps) {
                             <BodyShort size="small">
                                 {`Arbeidslistenotat for følgende brukere ble opprettet på en annen enhet, og vil bli slettet ved tildeling av ny veileder:`}
                             </BodyShort>
+                            <FnrList listeMedFnr={fnrArbeidslisteBlirSlettet} />
                             <BodyShort size="small">{`Ønsker du likevel å tildele veilederen?`}</BodyShort>
                         </div>
                         <div className="knapper">

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -72,7 +72,9 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                     }))
             );
 
-            const brukereFraNyEnhet = valgteBrukere.filter(bruker => bruker.nyForEnhet);
+            const brukereFraNyEnhet = valgteBrukere
+                .filter(bruker => bruker.nyForEnhet && bruker.arbeidsliste.arbeidslisteAktiv)
+                .filter(bruker => bruker.veilederId !== ident);
 
             setFnrArbeidslisteBlirSlettet(
                 brukereFraNyEnhet.map(bruker => ({

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -68,7 +68,8 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
             }));
 
             const ikkeSlettetTilordninger = valgteBrukere
-                .filter(bruker => !bruker.nyForEnhet)
+                .filter(bruker => bruker.nyForEnhet && bruker.arbeidsliste.arbeidslisteAktiv)
+                .filter(bruker => bruker.veilederId !== ident)
                 .map(bruker => ({
                     fraVeilederId: bruker.veilederId,
                     tilVeilederId: ident,

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -98,6 +98,9 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 valgteBrukere.map(bruker => bruker.arbeidsliste.navkontorForArbeidsliste !== enhet)
             );
 
+            // eslint-disable-next-line
+            console.log('Og');
+
             setFnrArbeidslisteBlirSlettet(
                 fnrBrukereArbeidslisteVilBliSlettet.map(bruker => ({
                     brukerFnr: bruker.fnr

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -92,6 +92,12 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
             // eslint-disable-next-line
             console.log('enhetId', enhet);
 
+            // eslint-disable-next-line
+            console.log(
+                'Navkontor for arbeidsliste !== enhet',
+                valgteBrukere.map(bruker => bruker.arbeidsliste.navkontorForArbeidsliste !== enhet)
+            );
+
             setFnrArbeidslisteBlirSlettet(
                 fnrBrukereArbeidslisteVilBliSlettet.map(bruker => ({
                     brukerFnr: bruker.fnr

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -12,6 +12,7 @@ import {useSelectGjeldendeVeileder} from '../../../hooks/portefolje/use-select-g
 import {BodyShort, Button, Heading, Modal, Radio, RadioGroup} from '@navikt/ds-react';
 import {useIdentSelector} from '../../../hooks/redux/use-innlogget-ident';
 import {Fnr, FnrList} from '../../fnr-list';
+import {useEnhetSelector} from '../../../hooks/redux/use-enhet-selector';
 
 interface TildelVeilederProps {
     oversiktType?: string;
@@ -32,6 +33,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
     const dispatch = useDispatch();
     const gjeldendeVeileder = useSelectGjeldendeVeileder();
     const innloggetVeileder = useIdentSelector()?.ident;
+    const enhet = useEnhetSelector();
 
     const sorterVeiledere = veiledere.sort((a, b) => {
         if (a.ident === b.ident) return 0;
@@ -77,8 +79,18 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 bruker =>
                     bruker.nyForEnhet &&
                     bruker.arbeidsliste.arbeidslisteAktiv &&
-                    (bruker.veilederId !== ident || bruker.veilederId === null)
+                    (bruker.veilederId !== ident || bruker.veilederId === null) &&
+                    bruker.arbeidsliste.navkontorForArbeidsliste !== null &&
+                    bruker.arbeidsliste.navkontorForArbeidsliste !== enhet
             );
+
+            // eslint-disable-next-line
+            console.log(
+                'Navkontor for arbeidsliste',
+                valgteBrukere.map(bruker => bruker.arbeidsliste.navkontorForArbeidsliste)
+            );
+            // eslint-disable-next-line
+            console.log('enhetId', enhet);
 
             setFnrArbeidslisteBlirSlettet(
                 fnrBrukereArbeidslisteVilBliSlettet.map(bruker => ({

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -72,17 +72,17 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                     }))
             );
 
-            const brukereFraNyEnhet = valgteBrukere
+            const brukereArbeidslisteVilBliSlettet = valgteBrukere
                 .filter(bruker => bruker.nyForEnhet && bruker.arbeidsliste.arbeidslisteAktiv)
                 .filter(bruker => bruker.veilederId !== ident);
 
             setFnrArbeidslisteBlirSlettet(
-                brukereFraNyEnhet.map(bruker => ({
+                brukereArbeidslisteVilBliSlettet.map(bruker => ({
                     brukerFnr: bruker.fnr
                 }))
             );
 
-            if (brukereFraNyEnhet.length > 0) {
+            if (brukereArbeidslisteVilBliSlettet.length > 0) {
                 setVisAdvarselOmSletting(true);
             } else {
                 doTildelTilVeileder(tilordningerAlle, ident);

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -13,6 +13,7 @@ import {BodyShort, Button, Heading, Modal, Radio, RadioGroup} from '@navikt/ds-r
 import {useIdentSelector} from '../../../hooks/redux/use-innlogget-ident';
 import {Fnr, FnrList} from '../../fnr-list';
 import {useEnhetSelector} from '../../../hooks/redux/use-enhet-selector';
+import {trackAmplitude} from '../../../amplitude/amplitude';
 
 interface TildelVeilederProps {
     oversiktType?: string;
@@ -77,29 +78,10 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
 
             const fnrBrukereArbeidslisteVilBliSlettet = valgteBrukere.filter(
                 bruker =>
-                    bruker.nyForEnhet &&
                     bruker.arbeidsliste.arbeidslisteAktiv &&
                     (bruker.veilederId !== ident || bruker.veilederId === null) &&
                     bruker.arbeidsliste.navkontorForArbeidsliste !== null &&
                     bruker.arbeidsliste.navkontorForArbeidsliste !== enhet
-            );
-
-            // eslint-disable-next-line
-            console.log(
-                'Navkontor for arbeidsliste',
-                valgteBrukere.map(bruker => bruker.arbeidsliste.navkontorForArbeidsliste)
-            );
-            // eslint-disable-next-line
-            console.log('enhetId', enhet);
-
-            // eslint-disable-next-line
-            console.log(
-                'Navkontor for arbeidsliste !== enhet',
-                valgteBrukere.map(
-                    bruker =>
-                        bruker.arbeidsliste.navkontorForArbeidsliste !== null &&
-                        bruker.arbeidsliste.navkontorForArbeidsliste !== enhet
-                )
             );
 
             setFnrArbeidslisteBlirSlettet(
@@ -109,6 +91,10 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
             );
 
             if (fnrBrukereArbeidslisteVilBliSlettet.length > 0) {
+                trackAmplitude(
+                    {name: 'modal åpnet', data: {tekst: 'Fikk advarsel om sletting av arbeidsliste'}},
+                    {modalId: 'veilarbportefoljeflatefs-advarselOmSlettingAvArbeidsliste'}
+                );
                 setVisAdvarselOmSletting(true);
             } else {
                 doTildelTilVeileder(alleTilordninger, ident);
@@ -141,6 +127,16 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                             variant="tertiary"
                             className="knapp-avbryt-tildeling"
                             onClick={() => {
+                                trackAmplitude(
+                                    {
+                                        name: 'knapp klikket',
+                                        data: {
+                                            knapptekst: 'Avbryt tildeling for de aktuelle brukerne',
+                                            effekt: 'Avbryter tildeling'
+                                        }
+                                    },
+                                    {modalId: 'veilarbportefoljeflatefs-advarselOmSlettingAvArbeidsliste'}
+                                );
                                 doTildelTilVeileder(tilordningerBrukereArbeidslisteBlirIkkeSlettet, ident);
                                 lukkFjernModal();
                             }}
@@ -153,6 +149,16 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                             className="knapp"
                             size="medium"
                             onClick={() => {
+                                trackAmplitude(
+                                    {
+                                        name: 'knapp klikket',
+                                        data: {
+                                            knapptekst: 'Ja, tildel veilederen',
+                                            effekt: 'Fortsetter tildeling'
+                                        }
+                                    },
+                                    {modalId: 'veilarbportefoljeflatefs-advarselOmSlettingAvArbeidsliste'}
+                                );
                                 doTildelTilVeileder(tilordningerAlle, ident);
                                 lukkFjernModal();
                             }}

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -74,7 +74,10 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
             setTilordningerBrukereArbeidslisteBlirIkkeSlettet(tilordningerBrukereArbeidslisteBlirIkkeSlettet);
 
             const fnrBrukereArbeidslisteVilBliSlettet = valgteBrukere.filter(
-                bruker => bruker.nyForEnhet && bruker.arbeidsliste.arbeidslisteAktiv && bruker.veilederId !== ident
+                bruker =>
+                    bruker.nyForEnhet &&
+                    bruker.arbeidsliste.arbeidslisteAktiv &&
+                    (bruker.veilederId !== ident || bruker.veilederId === null)
             );
 
             setFnrArbeidslisteBlirSlettet(

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -26,9 +26,8 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
     const [tilordningerAlle, setTilordningerAlle] = useState<
         {fraVeilederId: string | undefined; tilVeilederId: string; brukerFnr: string}[]
     >([]);
-    const [tilordningerIkkeSlettingArbeidslista, setTilordningerIkkeSlettingArbeidslista] = useState<
-        {fraVeilederId: string | undefined; tilVeilederId: string; brukerFnr: string}[]
-    >([]);
+    const [tilordningerBrukereArbeidslisteBlirIkkeSlettet, setTilordningerBrukereArbeidslisteBlirIkkeSlettet] =
+        useState<{fraVeilederId: string | undefined; tilVeilederId: string; brukerFnr: string}[]>([]);
     const [fnrArbeidslisteBlirSlettet, setFnrArbeidslisteBlirSlettet] = useState<Fnr[]>([]);
     const dispatch = useDispatch();
     const gjeldendeVeileder = useSelectGjeldendeVeileder();
@@ -53,13 +52,6 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
     const valgteBrukere = brukere.filter(bruker => bruker.markert === true);
 
     const onSubmit = () => {
-        // eslint-disable-next-line
-        console.log('Klikket submit');
-        // eslint-disable-next-line
-        console.log('Valgte brukere', valgteBrukere);
-        // eslint-disable-next-line
-        console.log('ident', ident);
-
         if (ident) {
             const alleTilordninger = valgteBrukere.map(bruker => ({
                 fraVeilederId: bruker.veilederId,
@@ -79,11 +71,11 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
 
             setTilordningerAlle(alleTilordninger);
 
-            setTilordningerIkkeSlettingArbeidslista(tilordningerBrukereArbeidslisteBlirIkkeSlettet);
+            setTilordningerBrukereArbeidslisteBlirIkkeSlettet(tilordningerBrukereArbeidslisteBlirIkkeSlettet);
 
-            const fnrBrukereArbeidslisteVilBliSlettet = valgteBrukere
-                .filter(bruker => bruker.nyForEnhet && bruker.arbeidsliste.arbeidslisteAktiv)
-                .filter(bruker => bruker.veilederId !== ident);
+            const fnrBrukereArbeidslisteVilBliSlettet = valgteBrukere.filter(
+                bruker => bruker.nyForEnhet && bruker.arbeidsliste.arbeidslisteAktiv && bruker.veilederId !== ident
+            );
 
             setFnrArbeidslisteBlirSlettet(
                 fnrBrukereArbeidslisteVilBliSlettet.map(bruker => ({
@@ -91,32 +83,13 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 }))
             );
 
-            const a = true;
-
-            if (fnrBrukereArbeidslisteVilBliSlettet.length > 0 || a) {
-                // eslint-disable-next-line
-                console.log('Noen arbeidslister vil bli sletta', fnrBrukereArbeidslisteVilBliSlettet);
-                // eslint-disable-next-line
-                console.log('Alle', alleTilordninger);
-                // eslint-disable-next-line
-                console.log('IkkeSlettes', tilordningerBrukereArbeidslisteBlirIkkeSlettet);
+            if (fnrBrukereArbeidslisteVilBliSlettet.length > 0) {
                 setVisAdvarselOmSletting(true);
-                // eslint-disable-next-line
-                console.log(visAdvarselOmSletting);
             } else {
-                // eslint-disable-next-line
-                console.log('Ingen arbeidslister vil bli sletta, tilordAlle', alleTilordninger);
-                // eslint-disable-next-line
-                console.log(
-                    'Ingen arbeidslister vil bli sletta, tilordnIkkeSl',
-                    tilordningerBrukereArbeidslisteBlirIkkeSlettet
-                );
                 doTildelTilVeileder(alleTilordninger, ident);
                 closeInput();
             }
         } else {
-            // eslint-disable-next-line
-            console.log('closeInput()');
             closeInput();
         }
     };
@@ -144,8 +117,11 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                             className="knapp-avbryt-tildeling"
                             onClick={() => {
                                 // eslint-disable-next-line
-                                console.log('Klikket avbryt, tilordnIkkeSl', tilordningerIkkeSlettingArbeidslista);
-                                doTildelTilVeileder(tilordningerIkkeSlettingArbeidslista, ident);
+                                console.log(
+                                    'Klikket avbryt, tilordnIkkeSl',
+                                    tilordningerBrukereArbeidslisteBlirIkkeSlettet
+                                );
+                                doTildelTilVeileder(tilordningerBrukereArbeidslisteBlirIkkeSlettet, ident);
                                 lukkFjernModal();
                             }}
                             size="medium"

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -53,6 +53,8 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
     const valgteBrukere = brukere.filter(bruker => bruker.markert === true);
 
     const onSubmit = () => {
+        // eslint-disable-next-line
+        console.log('Klikket submit');
         if (ident) {
             setTilordningerAlle(
                 valgteBrukere.map(bruker => ({
@@ -95,6 +97,8 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 closeInput();
             }
         } else {
+            // eslint-disable-next-line
+            console.log('closeInput()');
             closeInput();
         }
     };

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -57,25 +57,27 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
         console.log('Klikket submit');
         // eslint-disable-next-line
         console.log('Valgte brukere', valgteBrukere);
+        // eslint-disable-next-line
+        console.log('ident', ident);
 
         if (ident) {
-            setTilordningerAlle(
-                valgteBrukere.map(bruker => ({
+            const alleTilordninger = valgteBrukere.map(bruker => ({
+                fraVeilederId: bruker.veilederId,
+                tilVeilederId: ident,
+                brukerFnr: bruker.fnr
+            }));
+
+            const ikkeSlettetTilordninger = valgteBrukere
+                .filter(bruker => !bruker.nyForEnhet)
+                .map(bruker => ({
                     fraVeilederId: bruker.veilederId,
                     tilVeilederId: ident,
                     brukerFnr: bruker.fnr
-                }))
-            );
+                }));
 
-            setTilordningerIkkeSlettingArbeidslista(
-                valgteBrukere
-                    .filter(bruker => !bruker.nyForEnhet)
-                    .map(bruker => ({
-                        fraVeilederId: bruker.veilederId,
-                        tilVeilederId: ident,
-                        brukerFnr: bruker.fnr
-                    }))
-            );
+            setTilordningerAlle(alleTilordninger);
+
+            setTilordningerIkkeSlettingArbeidslista(ikkeSlettetTilordninger);
 
             const brukereArbeidslisteVilBliSlettet = valgteBrukere
                 .filter(bruker => bruker.nyForEnhet && bruker.arbeidsliste.arbeidslisteAktiv)
@@ -90,13 +92,17 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
             if (brukereArbeidslisteVilBliSlettet.length > 0) {
                 // eslint-disable-next-line
                 console.log('Noen arbeidslister vil bli sletta', brukereArbeidslisteVilBliSlettet);
+                // eslint-disable-next-line
+                console.log('Noen arbeidslister vil bli sletta', fnrArbeidslisteBlirSlettet);
                 setVisAdvarselOmSletting(true);
+                // eslint-disable-next-line
+                console.log(visAdvarselOmSletting);
             } else {
                 // eslint-disable-next-line
                 console.log('Ingen arbeidslister vil bli sletta, tilordAlle', tilordningerAlle);
                 // eslint-disable-next-line
                 console.log('Ingen arbeidslister vil bli sletta, tilordnIkkeSl', tilordningerIkkeSlettingArbeidslista);
-                doTildelTilVeileder(tilordningerAlle, ident);
+                doTildelTilVeileder(alleTilordninger, ident);
                 closeInput();
             }
         } else {

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -89,7 +89,9 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 }))
             );
 
-            if (brukereArbeidslisteVilBliSlettet.length > 0) {
+            const a = true;
+
+            if (brukereArbeidslisteVilBliSlettet.length > 0 || a) {
                 // eslint-disable-next-line
                 console.log('Noen arbeidslister vil bli sletta', brukereArbeidslisteVilBliSlettet);
                 // eslint-disable-next-line

--- a/src/components/toolbar/toolbar-knapp.tsx
+++ b/src/components/toolbar/toolbar-knapp.tsx
@@ -67,7 +67,7 @@ export default function ToolbarKnapp(props: ToolbarKnappProps) {
         if (props.tildelveileder) {
             return (
                 <TildelVeileder
-                    btnOnClick={() => setBtnClicked(true)}
+                    closeInput={() => setBtnClicked(true)}
                     skalVises={props.skalVises}
                     oversiktType={props.oversiktType}
                 />

--- a/src/components/toolbar/toolbar-knapp.tsx
+++ b/src/components/toolbar/toolbar-knapp.tsx
@@ -21,7 +21,6 @@ interface ToolbarKnappProps {
 export default function ToolbarKnapp(props: ToolbarKnappProps) {
     const [isInputOpen, setInputOpen] = useState(false);
     const [isBtnClicked, setBtnClicked] = useState(false);
-    const [visAdvarselOmSletting, setVisAdvarselOmSletting] = useState<boolean>(false);
     const loggNode = useRef<HTMLDivElement>(null); // Referanse til omsluttende div rundt loggen
     const dispatch = useDispatch();
     const requestSetOpenStatus = (setOpenTo: boolean) => {

--- a/src/components/toolbar/toolbar-knapp.tsx
+++ b/src/components/toolbar/toolbar-knapp.tsx
@@ -21,6 +21,7 @@ interface ToolbarKnappProps {
 export default function ToolbarKnapp(props: ToolbarKnappProps) {
     const [isInputOpen, setInputOpen] = useState(false);
     const [isBtnClicked, setBtnClicked] = useState(false);
+    const [visAdvarselOmSletting, setVisAdvarselOmSletting] = useState<boolean>(false);
     const loggNode = useRef<HTMLDivElement>(null); // Referanse til omsluttende div rundt loggen
     const dispatch = useDispatch();
     const requestSetOpenStatus = (setOpenTo: boolean) => {

--- a/src/components/toolbar/toolbar.css
+++ b/src/components/toolbar/toolbar.css
@@ -365,3 +365,7 @@
     width: fit-content;
     align-self: end;
 }
+
+.advarsel-sletting-arbeidslista .knapp-avbryt-tildeling {
+    margin-right: 1rem;
+}

--- a/src/components/toolbar/toolbar.css
+++ b/src/components/toolbar/toolbar.css
@@ -369,3 +369,14 @@
 .advarsel-sletting-arbeidslista .knapp-avbryt-tildeling {
     margin-right: 1rem;
 }
+
+.advarsel-sletting-arbeidslista .sletting-arbeidslista-knapp-wrapper {
+    display: flex;
+    justify-content: flex-end;
+    border-top: 1px;
+    margin-top: 1rem;
+}
+
+.advarsel-sletting-arbeidslista .sporsmal-likevel-tidele {
+    font-weight: bold;
+}

--- a/src/components/toolbar/toolbar.tsx
+++ b/src/components/toolbar/toolbar.tsx
@@ -92,7 +92,7 @@ function Toolbar(props: ToolbarProps) {
                     {oversiktType !== OversiktType.veilederOversikt && (
                         <div className="tildel-veileder-wrapper">
                             <ToolbarKnapp
-                                tittel="Tildel veiledern"
+                                tittel="Tildel veileder"
                                 skalVises={oversiktType in OversiktType}
                                 aktiv={aktiv}
                                 tildelveileder

--- a/src/components/toolbar/toolbar.tsx
+++ b/src/components/toolbar/toolbar.tsx
@@ -92,7 +92,7 @@ function Toolbar(props: ToolbarProps) {
                     {oversiktType !== OversiktType.veilederOversikt && (
                         <div className="tildel-veileder-wrapper">
                             <ToolbarKnapp
-                                tittel="Tildel veileder"
+                                tittel="Tildel veiledern"
                                 skalVises={oversiktType in OversiktType}
                                 aktiv={aktiv}
                                 tildelveileder

--- a/src/ducks/portefolje.ts
+++ b/src/ducks/portefolje.ts
@@ -12,7 +12,7 @@ import {OrNothing} from '../utils/types/types';
 import {OversiktType} from './ui/listevisning';
 import {capitalize} from '../utils/utils';
 import {hentStatustallForEnhet} from './statustall-enhet';
-import {toJson} from './../middleware/api';
+import {toJson} from '../middleware/api';
 
 // Actions
 const OK = 'veilarbportefolje/portefolje/OK';
@@ -326,8 +326,8 @@ export function tildelVeileder(tilordninger, tilVeileder, oversiktType, veileder
                     const feiledeFnr = feilendeTilordninger.map(f => f.brukerFnr);
 
                     const vellykkedeTilordninger = tilordninger
-                        .filter(tillordning => !feiledeFnr.includes(tillordning.brukerFnr))
-                        .map(tillordning => ({brukerFnr: tillordning.brukerFnr}));
+                        .filter(tilordning => !feiledeFnr.includes(tilordning.brukerFnr))
+                        .map(tilordning => ({brukerFnr: tilordning.brukerFnr}));
 
                     visFeiletModal({
                         aarsak: TILDELING_FEILET,
@@ -335,9 +335,7 @@ export function tildelVeileder(tilordninger, tilVeileder, oversiktType, veileder
                         brukereOk: vellykkedeTilordninger
                     })(dispatch);
                 } else {
-                    dispatch(
-                        visTilordningOkModal(tilordninger.map(tillordning => ({brukerFnr: tillordning.brukerFnr})))
-                    );
+                    dispatch(visTilordningOkModal(tilordninger.map(tilordning => ({brukerFnr: tilordning.brukerFnr}))));
                     dispatch(pagineringSetup({side: 1}));
                 }
                 if (oversiktType === OversiktType.minOversikt) {

--- a/src/model-interfaces.ts
+++ b/src/model-interfaces.ts
@@ -249,6 +249,7 @@ export interface ArbeidslisteModell {
     sistEndretAv: {veilederId: string};
     kategori: KategoriModell;
     hentetKommentarOgTittel: boolean;
+    navkontorForArbeidsliste: string;
 }
 
 export enum Status {

--- a/src/model-interfaces.ts
+++ b/src/model-interfaces.ts
@@ -213,6 +213,7 @@ interface EnsligeForsorgereOvergangsstonad {
 export interface BarnUnder18Aar {
     alder: number;
 }
+
 interface Statsborgerskap {
     statsborgerskap: string;
     gyldigFra?: string;
@@ -249,7 +250,7 @@ export interface ArbeidslisteModell {
     sistEndretAv: {veilederId: string};
     kategori: KategoriModell;
     hentetKommentarOgTittel: boolean;
-    navkontorForArbeidsliste: string;
+    navkontorForArbeidsliste?: string;
 }
 
 export enum Status {


### PR DESCRIPTION
Hva var ønsket? At det skal komme en pop-up boks etter man har trykket på "velg" her: 
![image](https://github.com/navikt/veilarbportefoljeflatefs/assets/34374522/07c3bb9b-5cb7-4837-8dd9-63ac24f1939d)
Som advarer mot at arbeidslista blir slettet dersom noen av brukerne som er valgt:
- er fra en annen enhet OG  har innhold i arbeidslista OG at veileder man vil tildele er ny for bruker
![image](https://github.com/navikt/veilarbportefoljeflatefs/assets/34374522/5b31071a-4d94-4c8f-852b-32b8c3d41104)

Funksjonaliteten er sånn: Når man trykker på Avbryt, vil man kun avbryte tildelingen til de som vil få sletta arb.lista, resten blir da tildelt. 


Flere forklaringer i PR