### PR TITLE
Oppgrader til node 18

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yaml
+++ b/.github/workflows/deploy-dev-gcp.yaml
@@ -17,11 +17,11 @@ jobs:
       if: github.event_name == 'pull_request'
       steps:
         - name: Checkout
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
         - name: Setup node
           uses: actions/setup-node@v3
           with:
-            node-version: 16
+            node-version: 18
             cache: npm
         - name: Install dependencies
           run: npm ci
@@ -36,11 +36,11 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Setup node
               uses: actions/setup-node@v3
               with:
-                  node-version: 16
+                  node-version: 18
                   cache: npm
             - name: Install dependencies
               run: npm ci
@@ -50,10 +50,10 @@ jobs:
             - name: Build application
               run: npm run build:dev
             - name: Authenticate to Google Cloud
-              uses: google-github-actions/auth@v0
+              uses: google-github-actions/auth@v1
               with:
                   credentials_json: ${{ secrets.GCS_SA_KEY_DEV }}
             - name: Set up Cloud SDK
-              uses: google-github-actions/setup-gcloud@v0
+              uses: google-github-actions/setup-gcloud@v1
             - name: Upload files to GCS
               run: gsutil -m rsync -r build gs://obo-veilarbportefoljeflatefs-dev

--- a/.github/workflows/deploy-prod-gcp.yaml
+++ b/.github/workflows/deploy-prod-gcp.yaml
@@ -14,11 +14,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Setup node
               uses: actions/setup-node@v3
               with:
-                  node-version: 16
+                  node-version: 18
                   cache: npm
             - name: Install dependencies
               run: npm ci
@@ -27,10 +27,10 @@ jobs:
             - name: Build application
               run: npm run build:prod
             - name: Authenticate to Google Cloud
-              uses: google-github-actions/auth@v0
+              uses: google-github-actions/auth@v1
               with:
                   credentials_json: ${{ secrets.GCS_SA_KEY_PROD }}
             - name: Set up Cloud SDK
-              uses: google-github-actions/setup-gcloud@v0
+              uses: google-github-actions/setup-gcloud@v1
             - name: Upload files to GCS
               run: gsutil -m rsync -r build gs://obo-veilarbportefoljeflatefs-prod

--- a/.github/workflows/poao-frontend-container-dev.yaml
+++ b/.github/workflows/poao-frontend-container-dev.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: deploy gcp dev
         uses: nais/deploy/actions/deploy@v1
         env:

--- a/.github/workflows/poao-frontend-container-prod.yaml
+++ b/.github/workflows/poao-frontend-container-prod.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: deploy gcp prod
         uses: nais/deploy/actions/deploy@v1
         env:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,9 +8,9 @@ jobs:
         timeout-minutes: 15
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Cypress run
-              uses: cypress-io/github-action@v5
+              uses: cypress-io/github-action@v6
               with:
                   browser: chrome
                   start: npm start cypress:run

--- a/.github/workflows/update-github-pages.yaml
+++ b/.github/workflows/update-github-pages.yaml
@@ -13,11 +13,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Setup node
               uses: actions/setup-node@v3
               with:
-                  node-version: '16'
+                  node-version: '18'
                   cache: 'npm'
             - name: Install dependencies
               run: npm ci


### PR DESCRIPTION
actions/checkout fra v3 til v4
actions/setup-node ingen endring, v3
google-github-actions/auth fra v0 til v1
google-github-actions/setup-gcloud fra v0 til v1
cypress-io/github-action fra v5 til v6