### PR TITLE
Sette opp Amplitude og målinger på arbeidslista

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,10 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "veilarbportefoljeflatefs",
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
+                "@amplitude/analytics-browser": "^2.3.2",
                 "@grafana/faro-web-sdk": "1.1.2",
                 "@navikt/aksel-icons": "2.9.8",
                 "@navikt/ds-css": "2.9.8",
@@ -93,6 +93,95 @@
                 "prettier": "2.8.8",
                 "yet-another-fetch-mock": "4.2.1"
             }
+        },
+        "node_modules/@amplitude/analytics-browser": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.3.2.tgz",
+            "integrity": "sha512-Zjk/PeCc0PZuzWlsGaf/i6qkkofqJvToh41tPhkOIFvLJlv/3cHtB2WXEod9vj20m+XcNoBATbcFAQgl2ubTeA==",
+            "dependencies": {
+                "@amplitude/analytics-client-common": "^2.0.6",
+                "@amplitude/analytics-core": "^2.0.5",
+                "@amplitude/analytics-types": "^2.2.0",
+                "@amplitude/plugin-page-view-tracking-browser": "^2.0.12",
+                "@amplitude/plugin-web-attribution-browser": "^2.0.12",
+                "tslib": "^2.4.1"
+            }
+        },
+        "node_modules/@amplitude/analytics-browser/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@amplitude/analytics-client-common": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@amplitude/analytics-client-common/-/analytics-client-common-2.0.6.tgz",
+            "integrity": "sha512-jnDh0uJXztVisAOUATCOmS+tlocqJgKbaPsA0PfUmhpsjipTlp8hqrQh20wopp/A5PT0vZ91Cw4CJqkLuEAwvw==",
+            "dependencies": {
+                "@amplitude/analytics-connector": "^1.4.8",
+                "@amplitude/analytics-core": "^2.0.5",
+                "@amplitude/analytics-types": "^2.2.0",
+                "tslib": "^2.4.1"
+            }
+        },
+        "node_modules/@amplitude/analytics-client-common/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@amplitude/analytics-connector": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.5.0.tgz",
+            "integrity": "sha512-T8mOYzB9RRxckzhL0NTHwdge9xuFxXEOplC8B1Y3UX3NHa3BLh7DlBUZlCOwQgMc2nxDfnSweDL5S3bhC+W90g=="
+        },
+        "node_modules/@amplitude/analytics-core": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.0.5.tgz",
+            "integrity": "sha512-ke937QKOHFeUuQxwu5fQ5X9x9KUJoe+5XnJ589Fuz0VStWwqQZl7AkgSe85cX45z0bMUdbG7q8u9y/9uaqf2SQ==",
+            "dependencies": {
+                "@amplitude/analytics-types": "^2.2.0",
+                "tslib": "^2.4.1"
+            }
+        },
+        "node_modules/@amplitude/analytics-core/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@amplitude/analytics-types": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-2.2.0.tgz",
+            "integrity": "sha512-HThPlsX5KnxCorQnPVNQR8WZy0/PdgAzlT5n8bubjSmzPEWQgvn8bQzD48wYXoAkEZxlfYlaSnx7IxD5j3N1Dw=="
+        },
+        "node_modules/@amplitude/plugin-page-view-tracking-browser": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.0.12.tgz",
+            "integrity": "sha512-0QJJZocqQ+MltQcI4BkshQJcUOM9mIOiud0BnDPcwAbUjlzGVG+xm4KuOA3bjfGGcSF7I6mpnOnG3nPkX5k47A==",
+            "dependencies": {
+                "@amplitude/analytics-client-common": "^2.0.6",
+                "@amplitude/analytics-types": "^2.2.0",
+                "tslib": "^2.4.1"
+            }
+        },
+        "node_modules/@amplitude/plugin-page-view-tracking-browser/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@amplitude/plugin-web-attribution-browser": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/@amplitude/plugin-web-attribution-browser/-/plugin-web-attribution-browser-2.0.12.tgz",
+            "integrity": "sha512-Ii5lzsixf+2E9f+K2Knk3q/O9tYkoFDm0E9KfPhvkNM27mRLtJ1/YTfvmW4otaYrnPwcvl2Y5E9tzATVrmIelw==",
+            "dependencies": {
+                "@amplitude/analytics-client-common": "^2.0.6",
+                "@amplitude/analytics-core": "^2.0.5",
+                "@amplitude/analytics-types": "^2.2.0",
+                "tslib": "^2.4.1"
+            }
+        },
+        "node_modules/@amplitude/plugin-web-attribution-browser/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@ampproject/remapping": {
             "version": "2.2.0",
@@ -4949,6 +5038,8 @@
             "version": "8.11.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
             "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -4963,7 +5054,9 @@
         "node_modules/ajv-formats/node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "optional": true,
+            "peer": true
         },
         "node_modules/ajv-keywords": {
             "version": "3.5.2",
@@ -18654,6 +18747,105 @@
         }
     },
     "dependencies": {
+        "@amplitude/analytics-browser": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.3.2.tgz",
+            "integrity": "sha512-Zjk/PeCc0PZuzWlsGaf/i6qkkofqJvToh41tPhkOIFvLJlv/3cHtB2WXEod9vj20m+XcNoBATbcFAQgl2ubTeA==",
+            "requires": {
+                "@amplitude/analytics-client-common": "^2.0.6",
+                "@amplitude/analytics-core": "^2.0.5",
+                "@amplitude/analytics-types": "^2.2.0",
+                "@amplitude/plugin-page-view-tracking-browser": "^2.0.12",
+                "@amplitude/plugin-web-attribution-browser": "^2.0.12",
+                "tslib": "^2.4.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+                    "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+                }
+            }
+        },
+        "@amplitude/analytics-client-common": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@amplitude/analytics-client-common/-/analytics-client-common-2.0.6.tgz",
+            "integrity": "sha512-jnDh0uJXztVisAOUATCOmS+tlocqJgKbaPsA0PfUmhpsjipTlp8hqrQh20wopp/A5PT0vZ91Cw4CJqkLuEAwvw==",
+            "requires": {
+                "@amplitude/analytics-connector": "^1.4.8",
+                "@amplitude/analytics-core": "^2.0.5",
+                "@amplitude/analytics-types": "^2.2.0",
+                "tslib": "^2.4.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+                    "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+                }
+            }
+        },
+        "@amplitude/analytics-connector": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.5.0.tgz",
+            "integrity": "sha512-T8mOYzB9RRxckzhL0NTHwdge9xuFxXEOplC8B1Y3UX3NHa3BLh7DlBUZlCOwQgMc2nxDfnSweDL5S3bhC+W90g=="
+        },
+        "@amplitude/analytics-core": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.0.5.tgz",
+            "integrity": "sha512-ke937QKOHFeUuQxwu5fQ5X9x9KUJoe+5XnJ589Fuz0VStWwqQZl7AkgSe85cX45z0bMUdbG7q8u9y/9uaqf2SQ==",
+            "requires": {
+                "@amplitude/analytics-types": "^2.2.0",
+                "tslib": "^2.4.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+                    "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+                }
+            }
+        },
+        "@amplitude/analytics-types": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-2.2.0.tgz",
+            "integrity": "sha512-HThPlsX5KnxCorQnPVNQR8WZy0/PdgAzlT5n8bubjSmzPEWQgvn8bQzD48wYXoAkEZxlfYlaSnx7IxD5j3N1Dw=="
+        },
+        "@amplitude/plugin-page-view-tracking-browser": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.0.12.tgz",
+            "integrity": "sha512-0QJJZocqQ+MltQcI4BkshQJcUOM9mIOiud0BnDPcwAbUjlzGVG+xm4KuOA3bjfGGcSF7I6mpnOnG3nPkX5k47A==",
+            "requires": {
+                "@amplitude/analytics-client-common": "^2.0.6",
+                "@amplitude/analytics-types": "^2.2.0",
+                "tslib": "^2.4.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+                    "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+                }
+            }
+        },
+        "@amplitude/plugin-web-attribution-browser": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/@amplitude/plugin-web-attribution-browser/-/plugin-web-attribution-browser-2.0.12.tgz",
+            "integrity": "sha512-Ii5lzsixf+2E9f+K2Knk3q/O9tYkoFDm0E9KfPhvkNM27mRLtJ1/YTfvmW4otaYrnPwcvl2Y5E9tzATVrmIelw==",
+            "requires": {
+                "@amplitude/analytics-client-common": "^2.0.6",
+                "@amplitude/analytics-core": "^2.0.5",
+                "@amplitude/analytics-types": "^2.2.0",
+                "tslib": "^2.4.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+                    "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+                }
+            }
+        },
         "@ampproject/remapping": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -22135,14 +22327,13 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
             "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-            "requires": {
-                "ajv": "^8.0.0"
-            },
+            "requires": {},
             "dependencies": {
                 "ajv": {
-                    "version": "8.11.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+                    "version": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
                     "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -22153,7 +22344,9 @@
                 "json-schema-traverse": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+                    "optional": true,
+                    "peer": true
                 }
             }
         },
@@ -28032,9 +28225,7 @@
             "version": "1.0.20",
             "resolved": "https://registry.npmjs.org/nav-frontend-js-utils/-/nav-frontend-js-utils-1.0.20.tgz",
             "integrity": "sha512-rCEbgtLmk/95TJeke3Njgm0lBJuBa0N8p8h5Oqhxjov529UjTT2Vx4XJzjQd7/ApgeCkdc5DB9GW5jGTEFoYTA==",
-            "requires": {
-                "lodash.throttle": "^4.1.1"
-            }
+            "requires": {}
         },
         "nav-frontend-knapper-style": {
             "version": "2.1.2",
@@ -30830,7 +31021,6 @@
                 "normalize-path": "^3.0.0",
                 "object-hash": "^3.0.0",
                 "picocolors": "^1.0.0",
-                "postcss": "^8.4.14",
                 "postcss-import": "^14.1.0",
                 "postcss-js": "^4.0.0",
                 "postcss-load-config": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "yet-another-fetch-mock": "4.2.1"
     },
     "dependencies": {
+        "@amplitude/analytics-browser": "2.3.2",
         "@grafana/faro-web-sdk": "1.1.2",
         "@navikt/aksel-icons": "2.9.8",
         "@navikt/ds-css": "2.9.8",

--- a/src/amplitude/amplitude.ts
+++ b/src/amplitude/amplitude.ts
@@ -1,0 +1,62 @@
+import * as amplitude from '@amplitude/analytics-browser';
+import {track} from '@amplitude/analytics-browser';
+import {erProd} from '../utils/url-utils';
+import {AmplitudeEvent} from './taxonomy-events';
+
+export function initAmplitude() {
+    const projectId = erProd() ? '691963e61d2b11465aa96acfcaa8959b' : 'faf28eb5445abfe75c7ac28ae7a8d050';
+
+    amplitude.init(projectId, undefined, {
+        serverUrl: 'https://amplitude.nav.no/collect',
+        ingestionMetadata: {
+            sourceName: window.location.origin
+        },
+        defaultTracking: false
+    });
+}
+
+const maskereFodselsnummer = (data?: Record<string, unknown>) => {
+    const maskertObjekt = JSON.stringify(data).replace(/\d{11}/g, (_, indexOfMatch, fullString) =>
+        fullString.charAt(indexOfMatch - 1) === '"' ? '***********' : '"***********"'
+    );
+
+    try {
+        return JSON.parse(maskertObjekt);
+    } catch (e) {
+        console.error('kunne ikke maskere data korrekt før sending til amplitude');
+    }
+    return {};
+};
+
+async function logAmplitudeEvent(
+    eventName: string,
+    eventData?: Record<string, unknown>,
+    origin = 'veilarbportefoljeflatefs'
+): Promise<void> {
+    try {
+        await track(eventName, {...eventData, app: origin});
+    } catch (e) {
+        return Promise.reject(`Unexpected Amplitude error: ${e}`);
+    }
+}
+
+export const trackAmplitude = (event: AmplitudeEvent, ekstraData?: Record<string, unknown>): Promise<void> => {
+    if (!event || event.constructor !== Object) {
+        return Promise.reject(
+            'Argument must be an object of type {eventName: string, eventData?: Record<string, unknown>}'
+        );
+    }
+
+    const {name: eventName, data: eventData = {}} = event;
+    if (!eventName || typeof eventName !== 'string') {
+        return Promise.reject('Parameter "eventName" must be a string');
+    }
+    if (!eventData || eventData.constructor !== Object) {
+        return Promise.reject('Parameter "eventData" must be a plain object');
+    }
+    if (!!ekstraData && ekstraData?.constructor !== Object) {
+        return Promise.reject('Parameter "ekstraData" must be a plain object');
+    }
+
+    return logAmplitudeEvent(eventName, maskereFodselsnummer({...eventData, ...ekstraData}));
+};

--- a/src/amplitude/taxonomy-events.ts
+++ b/src/amplitude/taxonomy-events.ts
@@ -1,0 +1,6 @@
+//Før du lager en ny eventType -> sjekk https://github.com/navikt/analytics-taxonomy/tree/main/events
+export type AmplitudeEvent =
+    | {name: 'skjema fullført'; data: {skjemanavn: string; skjemaId: string}}
+    | {name: 'navigere'; data: {lenketekst: string; destinasjon: string}}
+    | {name: 'knapp klikket'; data: {knapptekst: string; effekt: string}}
+    | {name: string; data: Record<string, unknown>};

--- a/src/components/modal/arbeidsliste/arbeidsliste-informasjonsmelding.tsx
+++ b/src/components/modal/arbeidsliste/arbeidsliste-informasjonsmelding.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {Alert, Link} from '@navikt/ds-react';
 import {ExternalLink} from '@navikt/ds-icons';
+import {trackAmplitude} from '../../../amplitude/amplitude';
 
 const ArbeidslisteInformasjonsmelding = () => (
     <Alert variant="info" className="arbeidsliste-alert" size="small">
@@ -12,6 +13,12 @@ const ArbeidslisteInformasjonsmelding = () => (
             <Link
                 href="https://navno.sharepoint.com/sites/fag-og-ytelser-arbeid-arbeidsrettet-brukeroppfolging/SitePages/Arbeidslisten-i-Oversikten-i-Modia.aspx"
                 target="_blank"
+                onClick={() => {
+                    trackAmplitude({
+                        name: 'navigere',
+                        data: {lenketekst: 'Les mer om hvordan bruke arbeidslisten på Navet', destinasjon: 'navet'}
+                    });
+                }}
             >
                 Les mer om hvordan bruke arbeidslisten på Navet <ExternalLink />
             </Link>

--- a/src/components/modal/arbeidsliste/arbeidsliste-modal-rediger.tsx
+++ b/src/components/modal/arbeidsliste/arbeidsliste-modal-rediger.tsx
@@ -18,6 +18,7 @@ import {AppState} from '../../../reducer';
 import FjernArbeidslisteModal from './fjern-fra-arbeidsliste-modal';
 import {Button, Modal} from '@navikt/ds-react';
 import LasterModal from '../lastermodal/laster-modal';
+import {trackAmplitude} from '../../../amplitude/amplitude';
 
 interface ArbeidslisteModalRedigerProps {
     bruker: BrukerModell;
@@ -95,6 +96,21 @@ function ArbeidslisteModalRediger({bruker, sistEndretAv, sistEndretDato, settMar
                         setIsOpen(false);
                         dispatch(
                             redigerArbeidslisteAction(values, {bruker, sistEndretAv, sistEndretDato, settMarkert})
+                        );
+                        trackAmplitude(
+                            {
+                                name: 'skjema fullført',
+                                data: {
+                                    skjemanavn: 'Rediger arbeidsliste',
+                                    skjemaId: 'veilarbportefoljeflatefs-arbeidsliste'
+                                }
+                            },
+                            {
+                                kategori: values.kategori,
+                                overskriftslengde: values.overskrift.length,
+                                kommentarlengde: values.kommentar.length,
+                                fristSatt: !!values.frist.length
+                            }
                         );
                     }}
                 >

--- a/src/components/modal/arbeidsliste/fjern-fra-arbeidsliste-form.tsx
+++ b/src/components/modal/arbeidsliste/fjern-fra-arbeidsliste-form.tsx
@@ -9,6 +9,7 @@ import {ArbeidslisteDataModell, BrukerModell, KategoriModell} from '../../../mod
 import './arbeidsliste.css';
 import {logEvent} from '../../../utils/frontend-logger';
 import {Button, Label} from '@navikt/ds-react';
+import {trackAmplitude} from '../../../amplitude/amplitude';
 
 function brukerLabel(bruker) {
     return (
@@ -33,6 +34,10 @@ function FjernFraArbeidslisteForm({lukkModal, valgteBrukere, onSubmit, visBruker
             onSubmit={e => {
                 e.preventDefault();
                 logEvent('portefolje.metrikker.fjern_arbeidsliste');
+                trackAmplitude({
+                    name: 'knapp klikket',
+                    data: {knapptekst: 'Fjern arbeidsliste', effekt: 'Fjern bruker fra arbeidslista'}
+                });
                 onSubmit(valgteBrukere, lukkModal);
             }}
         >

--- a/src/components/modal/arbeidsliste/legg-til-arbeidslisteform.tsx
+++ b/src/components/modal/arbeidsliste/legg-til-arbeidslisteform.tsx
@@ -15,6 +15,7 @@ import './arbeidsliste.css';
 import {logEvent} from '../../../utils/frontend-logger';
 import {BodyShort, Button} from '@navikt/ds-react';
 import ArbeidslisteInformasjonsmelding from './arbeidsliste-informasjonsmelding';
+import {trackAmplitude} from '../../../amplitude/amplitude';
 
 interface OwnProps {
     valgteBrukere: BrukerModell[];
@@ -60,12 +61,27 @@ function LeggTilArbeidslisteForm({
         <Formik
             initialValues={{arbeidsliste: initialValues}}
             onSubmit={values => {
-                values.arbeidsliste.map(value =>
+                values.arbeidsliste.forEach(value => {
                     logEvent('teamvoff.metrikker.arbeidslistekategori', {
                         kategori: value.kategori,
                         applikasjon: 'oversikt'
-                    })
-                );
+                    });
+                    trackAmplitude(
+                        {
+                            name: 'skjema fullført',
+                            data: {
+                                skjemanavn: 'Legg til arbeidsliste',
+                                skjemaId: 'veilarbportefoljeflatefs-arbeidsliste'
+                            }
+                        },
+                        {
+                            kategori: value.kategori,
+                            overskriftslengde: value.overskrift.length,
+                            kommentarlengde: value.kommentar.length,
+                            fristSatt: !!value.frist.length
+                        }
+                    );
+                });
 
                 onSubmit(values.arbeidsliste);
             }}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ import '@navikt/ds-css';
 import './style.css';
 import {initializeFaro, WebVitalsInstrumentation} from '@grafana/faro-web-sdk';
 import {DeploymentEnvironment, erMock} from './utils/url-utils';
+import {initAmplitude} from './amplitude/amplitude';
 
 if (!(window as any)._babelPolyfill) {
     require('babel-polyfill');
@@ -32,6 +33,8 @@ if (erMock()) {
     // eslint-disable-next-line no-console
     console.log('==========================');
     require('./mocks');
+} else {
+    initAmplitude();
 }
 
 function hentMetrikkEndepunkt(env: DeploymentEnvironment) {

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -61,7 +61,7 @@ export function updateLastPath() {
 }
 
 export const erDev = () => (process.env.REACT_APP_DEPLOYMENT_ENV as DeploymentEnvironment) === 'development';
-
+export const erProd = () => (process.env.REACT_APP_DEPLOYMENT_ENV as DeploymentEnvironment) === 'production';
 export const erMock = () => process.env.REACT_APP_MOCK === 'true';
 
 export const getEndringsloggUrl = () => `https://poao-endringslogg.intern${erDev() ? '.dev' : ''}.nav.no`;


### PR DESCRIPTION
Jeg har satt default tracking til false, det vil si at vi ikke automatisk får med pageViewed osv. Dersom det er sånne ting vi vil ha med tenker jeg vi kan sette opp det på sikt. Ved å ikke ha det så har vi i alle fall mer kontroll på hva som trackes. Av det vi sender nå er det kun origin som sendes av url (https://veilarbportefoljeflate.intern.dev.nav.no/) ikke paths osv. Og så er det kun ikke identifiserbare data vi spesifikt tracker ved handling. 
Eksempel på tracking:
![Screenshot 2023-09-29 at 12 04 09](https://github.com/navikt/veilarbportefoljeflatefs/assets/3892999/c2443bbf-f3ba-4615-b23e-c9b94e47ce44)
