### PR TITLE
Fiksar bug med møteplan

### DIFF
--- a/src/minoversikt/moteplan/moteplan.css
+++ b/src/minoversikt/moteplan/moteplan.css
@@ -13,6 +13,11 @@
 .veilarbportefoljeflatefs .moteplan_content div:first-child h3 {
     margin-top: 0;
 }
+.veilarbportefoljeflatefs .moteplan_content > div:last-child {
+    /* Om eit møte er siste elementet i lista legg vi til litt luft under det
+     * så det er tydeleg for brukaren at dei kan sjå alle elementa. */
+    margin-bottom: 2rem;
+}
 .veilarbportefoljeflatefs .moteplan_tittel {
     margin-top: 0.5rem;
     margin-bottom: 0;
@@ -43,7 +48,6 @@
 }
 #seFlereMoterKnapp {
     float: right;
-    margin-top: 0.3rem;
     margin-right: 0.3rem;
     margin-top: 1rem;
 }

--- a/src/minoversikt/moteplan/moteplan.css
+++ b/src/minoversikt/moteplan/moteplan.css
@@ -11,17 +11,22 @@
     max-height: max(50vh, 25rem); /* Minst 400px-rem høg, max halve skjermhøgda. Relativt vilkårlege verdiar. */
     overflow-y: auto;
 }
-.veilarbportefoljeflatefs .moteplan_content div:first-child h3 {
-    margin-top: 0;
+.veilarbportefoljeflatefs .moteplan_content ol {
+    /* Nullstillar nettleser-styling av liste */
+    margin: 0;
+    padding: 0;
 }
-.veilarbportefoljeflatefs .moteplan_content > div:last-child {
-    /* Om eit møte er siste elementet i lista legg vi til litt luft under det
-     * så det er tydeleg for brukaren at dei kan sjå alle elementa. */
+.veilarbportefoljeflatefs .moteplan_content li {
+    list-style-type: none; /* Nullstillar nettleserstyling av listeelement */
+    margin-bottom: 0.5rem;
+}
+.veilarbportefoljeflatefs .moteplan_content li:last-child {
+    margin-bottom: 0;
+}
+.veilarbportefoljeflatefs .moteplan_content ol:last-child {
     margin-bottom: 2rem;
 }
 .veilarbportefoljeflatefs .moteplan_tittel {
-    margin-top: 0.5rem;
-    margin-bottom: 0;
     margin-left: 0.75rem;
 }
 .veilarbportefoljeflatefs .moteplan_tabell_tittelrad th {

--- a/src/minoversikt/moteplan/moteplan.css
+++ b/src/minoversikt/moteplan/moteplan.css
@@ -6,6 +6,10 @@
 .veilarbportefoljeflatefs .moteplan_popover {
     z-index: 1201 !important;
 }
+.veilarbportefoljeflatefs .moteplan_content {
+    max-height: max(50vh, 25rem); /* Minst 400px-rem høg, max halve skjermhøgda. Relativt vilkårlege verdiar. */
+    overflow-y: auto;
+}
 .veilarbportefoljeflatefs .moteplan_content div:first-child h3 {
     margin-top: 0;
 }
@@ -41,4 +45,5 @@
     float: right;
     margin-top: 0.3rem;
     margin-right: 0.3rem;
+    margin-top: 1rem;
 }

--- a/src/minoversikt/moteplan/moteplan.css
+++ b/src/minoversikt/moteplan/moteplan.css
@@ -5,6 +5,7 @@
 }
 .veilarbportefoljeflatefs .moteplan_popover {
     z-index: 1201 !important;
+    padding: 2px; /* Unngår at eventuell scrollbar legg seg over border på popover */
 }
 .veilarbportefoljeflatefs .moteplan_content {
     max-height: max(50vh, 25rem); /* Minst 400px-rem høg, max halve skjermhøgda. Relativt vilkårlege verdiar. */

--- a/src/minoversikt/moteplan/moteplan.tsx
+++ b/src/minoversikt/moteplan/moteplan.tsx
@@ -60,7 +60,7 @@ function Moteplan({veileder, enhet}: MoteplanProps) {
                 onClose={() => setErOpen(false)}
                 anchorEl={buttonRef.current}
                 /* Placement kan bli "left-start" igjen når vi oppdaterer @navikt/ds-react til nyare enn v5.6.5
-                 * og kan ta i bruk "flip"-prop. */
+                 * og kan ta i bruk "flip"-prop. - Ingrid, 2024-02-22 */
                 placement="bottom"
             >
                 <Popover.Content className="moteplan_content">
@@ -73,9 +73,11 @@ function Moteplan({veileder, enhet}: MoteplanProps) {
                             Ingen møter
                         </Alert>
                     ) : (
-                        dager
-                            .slice(0, maxAntallDager)
-                            .map((dag, key) => <MoteTabell dato={dag} moter={moter} enhetId={enhet} key={key} />)
+                        <ol>
+                            {dager.slice(0, maxAntallDager).map((dag, key) => (
+                                <MoteTabell dato={dag} moter={moter} enhetId={enhet} key={key} />
+                            ))}
+                        </ol>
                     )}
                     <SeFlereMoterKnapp
                         cssId={'seFlereMoterKnapp'}

--- a/src/minoversikt/moteplan/moteplan.tsx
+++ b/src/minoversikt/moteplan/moteplan.tsx
@@ -59,7 +59,9 @@ function Moteplan({veileder, enhet}: MoteplanProps) {
                 open={erOpen}
                 onClose={() => setErOpen(false)}
                 anchorEl={buttonRef.current}
-                placement="left-start"
+                /* Placement kan bli "left-start" igjen når vi oppdaterer @navikt/ds-react til nyare enn v5.6.5
+                 * og kan ta i bruk "flip"-prop. */
+                placement="bottom"
             >
                 <Popover.Content className="moteplan_content">
                     {fetchError ? (

--- a/src/minoversikt/moteplan/motetabell.tsx
+++ b/src/minoversikt/moteplan/motetabell.tsx
@@ -12,7 +12,7 @@ interface MoteTabellProps {
 
 function MoteTabell({dato, moter, enhetId}: MoteTabellProps) {
     return (
-        <div>
+        <li>
             <Heading className="moteplan_tittel" size="small" level="2">
                 {dagFraDato(dato)} {dato.getDate()}. {dato.toLocaleString('default', {month: 'long'})}
             </Heading>
@@ -36,7 +36,7 @@ function MoteTabell({dato, moter, enhetId}: MoteTabellProps) {
                         moter.map((mote, key) => <MoteKollonne dato={dato} mote={mote} enhetId={enhetId} key={key} />)}
                 </Table.Body>
             </Table>
-        </div>
+        </li>
     );
 }
 

--- a/src/mocks/data/portefolje.ts
+++ b/src/mocks/data/portefolje.ts
@@ -397,6 +397,10 @@ export function hentArbeidslisteForBruker(fnr: {fodselsnummer: any}) {
 export function hentMockPlan() {
     const omToDager = new Date();
     omToDager.setDate(omToDager.getDate() + 4);
+    function randomDate(start, end) {
+        return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
+    }
+
     return [
         {dato: new Date(), deltaker: {fornavn: 'john', etternavn: 'johnson', fnr: '123'}, avtaltMedNav: true},
         {
@@ -424,7 +428,32 @@ export function hentMockPlan() {
             deltaker: {fornavn: 'Mars', etternavn: 'Johnson', fnr: '123'},
             avtaltMedNav: true
         },
-        {dato: omToDager, deltaker: {fornavn: 'X', etternavn: 'tester4', fnr: '123'}, avtaltMedNav: false}
+        {dato: omToDager, deltaker: {fornavn: 'X', etternavn: 'tester4', fnr: '123'}, avtaltMedNav: false},
+        {
+            dato: randomDate(new Date(), new Date(2025, 11, 30)),
+            deltaker: {fornavn: 'X', etternavn: 'tester4', fnr: '123'},
+            avtaltMedNav: false
+        },
+        {
+            dato: randomDate(new Date(), new Date(2025, 11, 30)),
+            deltaker: {fornavn: 'X', etternavn: 'tester4', fnr: '123'},
+            avtaltMedNav: false
+        },
+        {
+            dato: randomDate(new Date(), new Date(2025, 11, 30)),
+            deltaker: {fornavn: 'X', etternavn: 'tester4', fnr: '123'},
+            avtaltMedNav: false
+        },
+        {
+            dato: randomDate(new Date(), new Date(2025, 11, 30)),
+            deltaker: {fornavn: 'X', etternavn: 'tester4', fnr: '123'},
+            avtaltMedNav: false
+        },
+        {
+            dato: randomDate(new Date(), new Date(2025, 11, 30)),
+            deltaker: {fornavn: 'X', etternavn: 'tester4', fnr: '123'},
+            avtaltMedNav: false
+        }
     ];
 }
 


### PR DESCRIPTION
Den pleidde hoppe rundt om kring når ein scrolla. No gjer den ikkje det meir.

Løysinga er litt quick-fix i at den byttar posisjonen på Popover frå "left-start" til "bottom". Når vi har oppdatert designsystemet til v5.6.5 eller nyare kan vi i staden bruke `flip={false}` til å hindre at boksen hoppar rundt om kring.

I tillegg til å låse posisjonen til møteplanen har eg justert storleiken på den. No tek den opp mellom 400px og 50% av skjermhøgda, slik at brukaren kan scrolle inne i møteplanen i staden for å scrolle heile innhaldet. Litt mindre rørsle på skjermen, forhåpentleg vis ei meir logisk brukaroppleving.



Trellokort for detaljar og eksempel: https://trello.com/c/maKZuyfc/557-m%C3%B8teplanen-oppf%C3%B8rer-seg-merkelig-n%C3%A5r-man-har-mange-m%C3%B8ter-og-skroller

Før:

https://github.com/navikt/veilarbportefoljeflatefs/assets/26256569/e856dcdd-c5ab-44f3-8956-675671b78101

Etter:


https://github.com/navikt/veilarbportefoljeflatefs/assets/26256569/437e1258-65d6-4646-976c-f306c66109c8





<img width="297" alt="Screenshot 2024-02-22 at 11 40 52" src="https://github.com/navikt/veilarbportefoljeflatefs/assets/26256569/d7cfd9b5-c9d8-410f-b8a5-e7fe1ca9638c">
