### PR TITLE
Gjer at månadsnamn i møteplanen kjem på norsk

### DIFF
--- a/src/minoversikt/moteplan/moteplan.css
+++ b/src/minoversikt/moteplan/moteplan.css
@@ -29,6 +29,9 @@
 .veilarbportefoljeflatefs .moteplan_tittel {
     margin-left: 0.75rem;
 }
+.veilarbportefoljeflatefs .moteplan_tittel:first-letter {
+    text-transform: capitalize;
+}
 .veilarbportefoljeflatefs .moteplan_tabell_tittelrad th {
     padding-bottom: 0 !important;
     font-size: 1rem;

--- a/src/minoversikt/moteplan/motetabell.tsx
+++ b/src/minoversikt/moteplan/motetabell.tsx
@@ -1,4 +1,3 @@
-import {dagFraDato} from '../../utils/dato-utils';
 import {Heading, Loader, Table} from '@navikt/ds-react';
 import * as React from 'react';
 import {MoteData} from './moteplan';
@@ -14,7 +13,7 @@ function MoteTabell({dato, moter, enhetId}: MoteTabellProps) {
     return (
         <li>
             <Heading className="moteplan_tittel" size="small" level="2">
-                {dagFraDato(dato)} {dato.getDate()}. {dato.toLocaleString('default', {month: 'long'})}
+                {dato.toLocaleString(['no'], {weekday: 'long', day: 'numeric', month: 'long'})}
             </Heading>
             <Table size="small">
                 <Table.Header>

--- a/src/utils/dato-utils.ts
+++ b/src/utils/dato-utils.ts
@@ -177,28 +177,6 @@ export function oppfolgingStartetDato(dato: string): Maybe<Date> {
     return oppfolgingStartetDato < tidligsteDato ? tidligsteDato : oppfolgingStartetDato;
 }
 
-export function dagFraDato(dato: Date): string {
-    const i = dato.getDay();
-    switch (i) {
-        case 0:
-            return 'Søndag';
-        case 1:
-            return 'Mandag';
-        case 2:
-            return 'Tirsdag';
-        case 3:
-            return 'Onsdag';
-        case 4:
-            return 'Torsdag';
-        case 5:
-            return 'Fredag';
-        case 6:
-            return 'Lørdag';
-        default:
-            return '...';
-    }
-}
-
 export function hentSkjermetInfo(
     egenAnsatt: boolean | undefined,
     skjermetTil: string | undefined


### PR DESCRIPTION
Gjer at månadsnamn i møteplanen kjem på norsk sjølv om brukaren har engelsk operativsystem

Dette gjer at språket vert litt meir konsekvent, før hadde vi overskrifter som "Mandag 23. march".


Før:
![Screenshot 2024-02-22 at 15 17 25](https://github.com/navikt/veilarbportefoljeflatefs/assets/26256569/c872018e-b71b-4245-bbde-a4821a0210c9)

Etter:
(kjem snart)