### PR TITLE
Fjern unødvendig if-else sjekk

### DIFF
--- a/src/hooks/use-redirect-on-mount.ts
+++ b/src/hooks/use-redirect-on-mount.ts
@@ -3,7 +3,6 @@ import {useOnMount} from './use-on-mount';
 import * as queryString from 'query-string';
 import {settSortering} from '../ducks/portefolje';
 import {useDispatch} from 'react-redux';
-import {erGithubPages} from '../utils/utils';
 
 export function useRedirectOnMount() {
     const history = useHistory();
@@ -21,9 +20,6 @@ export function useRedirectOnMount() {
             const stringified = queryString.stringify(parsed);
             dispatch(settSortering('ikke_satt', 'ikke_satt'));
             history.replace(`${pathname}?${stringified}`);
-        } else if (erGithubPages()) {
-            history.push('/enhet');
-            return;
         } else if (lastPath && location.pathname === '/tilbake') {
             history.replace({pathname: lastPath, search: lastSearch});
             const sorteringsfelt = queryString.parse(lastSearch).sorteringsfelt;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -55,10 +55,6 @@ export function utledValgteAktivitetsTyper(
         }, {});
 }
 
-export function erGithubPages() {
-    return window.location.host.includes('navikt.github.io');
-}
-
 export function utlopsdatoUker(utlopsdatoStr?: string): number | undefined {
     if (!utlopsdatoStr) {
         return undefined;


### PR DESCRIPTION
Vi har en Dependabot alert på følgende linje:

```
return window.location.host.includes('navikt.github.io');
```

Dette er i og for seg ikke er så farlig siden den bare styrer oppførselen til `useRedirectOnMount`. Så jeg kunne bare dismisset alerten, men tenkte jeg ville kikke litt på det likevel.

Jeg ser ikke helt poenget med å ha denne sjekken i det hele tatt. Når vi har denne sjekken på så resulterer det i at dersom man bruker demoen, står på "Min oversikt" og så refresher så byttes det automatisk til "Enhetens oversikt" som er litt rart. Fjerner derfor sjekken slik at det oppfører seg likt som lokalt, samt at vi slipper å ha en sjekk som er avhengig av en URL på et gitt format.