### PR TITLE
Renaming og oppdatering av typer

### DIFF
--- a/src/components/nullstill-valg-knapp/nullstill-knapp.tsx
+++ b/src/components/nullstill-valg-knapp/nullstill-knapp.tsx
@@ -8,17 +8,17 @@ import {Button} from '@navikt/ds-react';
 interface Props {
     nullstillValg: () => void;
     dataTestId: string;
-    form: string;
+    filterId: string;
     disabled: boolean;
     className?: string;
 }
 
-function NullstillKnapp({nullstillValg, dataTestId, form, disabled, className}: Props) {
+function NullstillKnapp({nullstillValg, dataTestId, filterId, disabled, className}: Props) {
     const nullstille = e => {
         e.persist();
         logEvent('portefolje.metrikker.nullstill-knapp', {
             sideNavn: finnSideNavn(),
-            dropdown: form
+            dropdown: filterId
         });
         return nullstillValg();
     };

--- a/src/components/sidebar/sidevelger.tsx
+++ b/src/components/sidebar/sidevelger.tsx
@@ -6,7 +6,7 @@ import {useDispatch} from 'react-redux';
 import {oppdaterKolonneAlternativer, OversiktType} from '../../ducks/ui/listevisning';
 import {skjulSidebar} from '../../ducks/sidebar-tab';
 import {Sidebarelement} from './sidebar';
-import {FiltervalgModell} from '../../model-interfaces';
+import {FilterId, FiltervalgModell} from '../../model-interfaces';
 import {OrNothing} from '../../utils/types/types';
 import {Tiltak} from '../../ducks/enhettiltak';
 import FiltreringFilter from '../../filtrering/filtrering-filter/filtrering-filter';
@@ -24,7 +24,7 @@ interface SidevelgerProps {
 
 function Sidevelger({selectedTabData, oversiktType, filtervalg, enhettiltak, statustall}: SidevelgerProps) {
     const dispatch = useDispatch();
-    const doEndreFiltervalg = (filterId: string, filterVerdi: React.ReactNode) => {
+    const doEndreFiltervalg = (filterId: FilterId, filterVerdi: React.ReactNode) => {
         dispatch(pagineringSetup({side: 1}));
         dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType));
         oppdaterKolonneAlternativer(dispatch, {...filtervalg, [filterId]: filterVerdi}, oversiktType);

--- a/src/components/toolbar/sok-veileder.tsx
+++ b/src/components/toolbar/sok-veileder.tsx
@@ -3,7 +3,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {endreFiltervalg, veilederSoktFraToolbar} from '../../ducks/filtrering';
 import {nameToStateSliceMap} from '../../ducks/utils';
-import {FiltervalgModell} from '../../model-interfaces';
+import {FilterId, FiltervalgModell} from '../../model-interfaces';
 import {VeiledereState} from '../../ducks/veiledere';
 import {useEffect, useState} from 'react';
 import SokVeiledere from '../sok-veiledere/sok-veiledere';
@@ -18,7 +18,7 @@ interface SokVeilederProps {
 }
 
 interface DispatchProps {
-    sokEtterVeileder: (filterId: string, filterverdi: string[], filtervalg: FiltervalgModell) => void;
+    sokEtterVeileder: (filterId: FilterId, filterverdi: string[], filtervalg: FiltervalgModell) => void;
     veilederSokt: () => void;
 }
 
@@ -72,7 +72,7 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = (dispatch, ownProps) =>
     bindActionCreators(
         {
-            sokEtterVeileder(filterId: string, filterverdi: string[], filterValg: FiltervalgModell) {
+            sokEtterVeileder(filterId: FilterId, filterverdi: string[], filterValg: FiltervalgModell) {
                 oppdaterKolonneAlternativer(dispatch, {...filterValg, [filterId]: filterverdi}, ownProps.oversiktType);
                 return endreFiltervalg(filterId, filterverdi, ownProps.oversiktType);
             },

--- a/src/components/veileder-checkbox-liste/veileder-checkbox-liste.tsx
+++ b/src/components/veileder-checkbox-liste/veileder-checkbox-liste.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {useEffect, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {VeiledereState} from '../../ducks/veiledere';
-import {FiltervalgModell, VeilederModell} from '../../model-interfaces';
+import {FilterId, FiltervalgModell, VeilederModell} from '../../model-interfaces';
 import './veileder-checkbox-liste.css';
 import {AppState} from '../../reducer';
 import NullstillKnapp from '../nullstill-valg-knapp/nullstill-knapp';
@@ -19,7 +19,7 @@ function VeilederCheckboxListe({nullstillInputfelt}: VeilederCheckboxListeProps)
     const veiledere: VeiledereState = useSelector((state: AppState) => state.veiledere); //SAMME SOM VALG
     const veilederNavnQuery = useSelector((state: AppState) => state.filtreringVeilederoversikt.veilederNavnQuery);
     const [valgteVeiledere, setValgteVeiledere] = useState<string[]>([]);
-    const filterId = 'veiledere';
+    const filterId: FilterId = 'veiledere';
     const dispatch = useDispatch();
 
     useEffect(() => {

--- a/src/components/veileder-checkbox-liste/veileder-checkbox-liste.tsx
+++ b/src/components/veileder-checkbox-liste/veileder-checkbox-liste.tsx
@@ -19,7 +19,7 @@ function VeilederCheckboxListe({nullstillInputfelt}: VeilederCheckboxListeProps)
     const veiledere: VeiledereState = useSelector((state: AppState) => state.veiledere); //SAMME SOM VALG
     const veilederNavnQuery = useSelector((state: AppState) => state.filtreringVeilederoversikt.veilederNavnQuery);
     const [valgteVeiledere, setValgteVeiledere] = useState<string[]>([]);
-    const formNavn = 'veiledere';
+    const filterId = 'veiledere';
     const dispatch = useDispatch();
 
     useEffect(() => {
@@ -40,18 +40,18 @@ function VeilederCheckboxListe({nullstillInputfelt}: VeilederCheckboxListeProps)
 
     const handterValgteVeiledere = (valgteVeiledere: string[]) => {
         setValgteVeiledere(valgteVeiledere);
-        dispatch(endreFiltervalg(formNavn, valgteVeiledere, OversiktType.veilederOversikt));
+        dispatch(endreFiltervalg(filterId, valgteVeiledere, OversiktType.veilederOversikt));
         oppdaterKolonneAlternativer(
             dispatch,
-            {...filtervalg, [formNavn]: valgteVeiledere},
+            {...filtervalg, [filterId]: valgteVeiledere},
             OversiktType.veilederOversikt
         );
     };
 
     const nullstillValg = () => {
         nullstillInputfelt();
-        dispatch(endreFiltervalg(formNavn, [], OversiktType.veilederOversikt));
-        oppdaterKolonneAlternativer(dispatch, {...filtervalg, [formNavn]: []}, OversiktType.veilederOversikt);
+        dispatch(endreFiltervalg(filterId, [], OversiktType.veilederOversikt));
+        oppdaterKolonneAlternativer(dispatch, {...filtervalg, [filterId]: []}, OversiktType.veilederOversikt);
     };
 
     const mapToCheckboxList = (veiledere?: VeilederModell[]) => {
@@ -94,7 +94,7 @@ function VeilederCheckboxListe({nullstillInputfelt}: VeilederCheckboxListeProps)
                 <NullstillKnapp
                     dataTestId="veileder-checkbox-filterform"
                     nullstillValg={nullstillValg}
-                    form={formNavn}
+                    filterId={filterId}
                     disabled={valgteVeiledere.length <= 0}
                     className="veilederoversikt-nullstill-knapp"
                 />

--- a/src/ducks/filtrering.ts
+++ b/src/ducks/filtrering.ts
@@ -1,4 +1,4 @@
-import {FiltervalgModell} from '../model-interfaces';
+import {FilterId, FiltervalgModell} from '../model-interfaces';
 import {VELG_MINE_FILTER} from './lagret-filter-ui-state';
 import {OversiktType} from './ui/listevisning';
 import {LagretFilter} from './lagret-filter';
@@ -138,7 +138,7 @@ export function velgMineFilter(filterVerdi: LagretFilter, oversiktType: Oversikt
 }
 
 export function endreFiltervalg(
-    filterId: string,
+    filterId: FilterId,
     filterVerdi: React.ReactNode,
     oversiktType: OversiktType = OversiktType.enhetensOversikt
 ) {

--- a/src/enhetsportefolje/enhet-side.tsx
+++ b/src/enhetsportefolje/enhet-side.tsx
@@ -39,6 +39,7 @@ import {Alert} from '@navikt/ds-react';
 import {Informasjonsmeldinger} from '../components/informasjonsmeldinger/informasjonsmeldinger';
 import {useStatustallEnhetSelector} from '../hooks/redux/use-statustall';
 import {StatustallEnhet, StatustallEnhetState} from '../ducks/statustall-enhet';
+import {FilterId} from '../model-interfaces';
 
 export function antallFilter(filtervalg) {
     function mapAktivitetFilter(value) {
@@ -109,7 +110,7 @@ export default function EnhetSide() {
     useSetLocalStorageOnUnmount();
     LagredeFilterUIController({oversiktType: oversiktType});
 
-    const doEndreFiltervalg = (filterId: string, filterVerdi: React.ReactNode) => {
+    const doEndreFiltervalg = (filterId: FilterId, filterVerdi: React.ReactNode) => {
         dispatch(pagineringSetup({side: 1}));
         dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType));
         oppdaterKolonneAlternativer(dispatch, {...filtervalg, [filterId]: filterVerdi}, oversiktType);

--- a/src/filtrering/filtrering-filter/filterform/aktiviteter-filterform/aktivitet-filterform-avansert.tsx
+++ b/src/filtrering/filtrering-filter/filterform/aktiviteter-filterform/aktivitet-filterform-avansert.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import '../filterform.css';
 import NullstillKnapp from '../../../../components/nullstill-valg-knapp/nullstill-knapp';
 import {Dictionary} from '../../../../utils/types/types';
-import {FiltervalgModell} from '../../../../model-interfaces';
+import {FilterId, FiltervalgModell} from '../../../../model-interfaces';
 import {BodyShort, Button, Label, Radio, RadioGroup} from '@navikt/ds-react';
 
 interface AktivitetFilterformProps {
     valg: Dictionary<string>;
     filtervalg: FiltervalgModell;
-    endreFiltervalg: (filterId: string, filterVerdi: React.ReactNode) => void;
+    endreFiltervalg: (filterId: FilterId, filterVerdi: React.ReactNode) => void;
     klikkPaForenkletLenke: (e: any) => void;
     nullstillAvanserteAktiviteter: () => void;
     nullstillForenkledeAktiviteter: () => void;

--- a/src/filtrering/filtrering-filter/filterform/aktiviteter-filterform/aktivitet-filterform-avansert.tsx
+++ b/src/filtrering/filtrering-filter/filterform/aktiviteter-filterform/aktivitet-filterform-avansert.tsx
@@ -8,7 +8,7 @@ import {BodyShort, Button, Label, Radio, RadioGroup} from '@navikt/ds-react';
 interface AktivitetFilterformProps {
     valg: Dictionary<string>;
     filtervalg: FiltervalgModell;
-    endreFiltervalg: (form: string, filterVerdi: React.ReactNode) => void;
+    endreFiltervalg: (filterId: string, filterVerdi: React.ReactNode) => void;
     klikkPaForenkletLenke: (e: any) => void;
     nullstillAvanserteAktiviteter: () => void;
     nullstillForenkledeAktiviteter: () => void;
@@ -85,7 +85,7 @@ function AktivitetFilterformAvansert({
                 <NullstillKnapp
                     dataTestId="aktivitet-filterform"
                     nullstillValg={nullstillAvanserteAktiviteter}
-                    form="aktiviteter"
+                    filterId="aktiviteter"
                     disabled={!harAvanserteAktiviteter}
                 />
             </div>

--- a/src/filtrering/filtrering-filter/filterform/aktiviteter-filterform/aktivitet-filterform-controller.tsx
+++ b/src/filtrering/filtrering-filter/filterform/aktiviteter-filterform/aktivitet-filterform-controller.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import '../filterform.css';
-import {FiltervalgModell} from '../../../../model-interfaces';
+import {FilterId, FiltervalgModell} from '../../../../model-interfaces';
 import AktivitetFilterformForenklet from './aktivitet-filterform-forenklet';
 import {aktiviteter} from '../../../filter-konstanter';
 import AktivitetFilterformAvansert from './aktivitet-filterform-avansert';
@@ -10,7 +10,7 @@ import {finnSideNavn} from '../../../../middleware/metrics-middleware';
 
 interface AktivitetFilterformProps {
     filtervalg: FiltervalgModell;
-    endreFiltervalg: (filterId: string, filterVerdi: any) => void;
+    endreFiltervalg: (filterId: FilterId, filterVerdi: any) => void;
 }
 
 const aktivitetInitialState: FiltreringAktiviteterValg = {

--- a/src/filtrering/filtrering-filter/filterform/aktiviteter-filterform/aktivitet-filterform-controller.tsx
+++ b/src/filtrering/filtrering-filter/filterform/aktiviteter-filterform/aktivitet-filterform-controller.tsx
@@ -10,7 +10,7 @@ import {finnSideNavn} from '../../../../middleware/metrics-middleware';
 
 interface AktivitetFilterformProps {
     filtervalg: FiltervalgModell;
-    endreFiltervalg: (form: string, filterVerdi: any) => void;
+    endreFiltervalg: (filterId: string, filterVerdi: any) => void;
 }
 
 const aktivitetInitialState: FiltreringAktiviteterValg = {

--- a/src/filtrering/filtrering-filter/filterform/aktiviteter-filterform/aktivitet-filterform-forenklet.tsx
+++ b/src/filtrering/filtrering-filter/filterform/aktiviteter-filterform/aktivitet-filterform-forenklet.tsx
@@ -6,7 +6,7 @@ import {Button, Checkbox, CheckboxGroup} from '@navikt/ds-react';
 
 interface AktivitetFilterformProps {
     valg: Dictionary<string>;
-    endreFiltervalg: (form: string, filterVerdi: React.ReactNode) => void;
+    endreFiltervalg: (filterId: string, filterVerdi: React.ReactNode) => void;
     klikkPaAvansertLenke: (e: any) => void;
     nullstillAvanserteAktiviteter: () => void;
     nullstillForenkledeAktiviteter: () => void;
@@ -64,7 +64,7 @@ function AktivitetFilterformForenklet({
                 <NullstillKnapp
                     dataTestId="aktivitet-filterform-forenklet"
                     nullstillValg={nullstillForenkledeAktiviteter}
-                    form="aktiviteterForenklet"
+                    filterId="aktiviteterForenklet"
                     disabled={valgteForenkledeAktiviteter.length <= 0}
                 />
             </div>

--- a/src/filtrering/filtrering-filter/filterform/aktiviteter-filterform/aktivitet-filterform-forenklet.tsx
+++ b/src/filtrering/filtrering-filter/filterform/aktiviteter-filterform/aktivitet-filterform-forenklet.tsx
@@ -3,10 +3,11 @@ import '../filterform.css';
 import NullstillKnapp from '../../../../components/nullstill-valg-knapp/nullstill-knapp';
 import {Dictionary} from '../../../../utils/types/types';
 import {Button, Checkbox, CheckboxGroup} from '@navikt/ds-react';
+import {FilterId} from '../../../../model-interfaces';
 
 interface AktivitetFilterformProps {
     valg: Dictionary<string>;
-    endreFiltervalg: (filterId: string, filterVerdi: React.ReactNode) => void;
+    endreFiltervalg: (filterId: FilterId, filterVerdi: React.ReactNode) => void;
     klikkPaAvansertLenke: (e: any) => void;
     nullstillAvanserteAktiviteter: () => void;
     nullstillForenkledeAktiviteter: () => void;

--- a/src/filtrering/filtrering-filter/filterform/alder-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/alder-filterform.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {FiltervalgModell} from '../../../model-interfaces';
+import {FilterId, FiltervalgModell} from '../../../model-interfaces';
 import {Dictionary} from '../../../utils/types/types';
 import Grid from '../../../components/grid/grid';
 import classNames from 'classnames';
@@ -10,9 +10,9 @@ import NullstillKnapp from '../../../components/nullstill-valg-knapp/nullstill-k
 import {BodyShort, Button, Checkbox, CheckboxGroup, TextField} from '@navikt/ds-react';
 
 interface AlderFilterformProps {
-    filterId: string;
+    filterId: FilterId;
     valg: Dictionary<string>;
-    endreFiltervalg: (filterId: string, filterVerdi: string[]) => void;
+    endreFiltervalg: (filterId: FilterId, filterVerdi: string[]) => void;
     closeDropdown: () => void;
     filtervalg: FiltervalgModell;
     className?: string;
@@ -33,7 +33,7 @@ function AlderFilterform({
     const harValg = Object.keys(valg).length > 0;
     const kanVelgeFilter = checkBoxValg.length > 0 || inputAlderFra.length > 0 || inputAlderTil.length > 0;
     useEffect(() => {
-        filtervalg[filterId].forEach(alder => {
+        (filtervalg[filterId] as string[]).forEach(alder => {
             if (
                 Object.entries(valg)
                     .map(([filterKey]) => filterKey)
@@ -41,7 +41,7 @@ function AlderFilterform({
             ) {
                 setInputAlderTil('');
                 setInputAlderFra('');
-                setCheckBoxValg(filtervalg[filterId]);
+                setCheckBoxValg(filtervalg[filterId] as string[]);
             } else {
                 const [alderFra, alderTil] = alder.split('-');
                 alderFra && setInputAlderFra(alderFra);

--- a/src/filtrering/filtrering-filter/filterform/alder-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/alder-filterform.tsx
@@ -10,14 +10,21 @@ import NullstillKnapp from '../../../components/nullstill-valg-knapp/nullstill-k
 import {BodyShort, Button, Checkbox, CheckboxGroup, TextField} from '@navikt/ds-react';
 
 interface AlderFilterformProps {
-    form: string;
+    filterId: string;
     valg: Dictionary<string>;
-    endreFiltervalg: (form: string, filterVerdi: string[]) => void;
+    endreFiltervalg: (filterId: string, filterVerdi: string[]) => void;
     closeDropdown: () => void;
     filtervalg: FiltervalgModell;
     className?: string;
 }
-function AlderFilterform({endreFiltervalg, valg, closeDropdown, form, filtervalg, className}: AlderFilterformProps) {
+function AlderFilterform({
+    endreFiltervalg,
+    valg,
+    closeDropdown,
+    filterId,
+    filtervalg,
+    className
+}: AlderFilterformProps) {
     const [checkBoxValg, setCheckBoxValg] = useState<string[]>([]);
     const [inputAlderFra, setInputAlderFra] = useState<string>('');
     const [inputAlderTil, setInputAlderTil] = useState<string>('');
@@ -26,7 +33,7 @@ function AlderFilterform({endreFiltervalg, valg, closeDropdown, form, filtervalg
     const harValg = Object.keys(valg).length > 0;
     const kanVelgeFilter = checkBoxValg.length > 0 || inputAlderFra.length > 0 || inputAlderTil.length > 0;
     useEffect(() => {
-        filtervalg[form].forEach(alder => {
+        filtervalg[filterId].forEach(alder => {
             if (
                 Object.entries(valg)
                     .map(([filterKey]) => filterKey)
@@ -34,14 +41,14 @@ function AlderFilterform({endreFiltervalg, valg, closeDropdown, form, filtervalg
             ) {
                 setInputAlderTil('');
                 setInputAlderFra('');
-                setCheckBoxValg(filtervalg[form]);
+                setCheckBoxValg(filtervalg[filterId]);
             } else {
                 const [alderFra, alderTil] = alder.split('-');
                 alderFra && setInputAlderFra(alderFra);
                 alderTil && setInputAlderTil(alderTil);
             }
         });
-    }, [filtervalg, form, valg]);
+    }, [filtervalg, filterId, valg]);
 
     const submitCheckBoxValg = (checkboxValg: string[]) => {
         setInputAlderTil('');
@@ -49,7 +56,7 @@ function AlderFilterform({endreFiltervalg, valg, closeDropdown, form, filtervalg
         setFeil(false);
 
         setCheckBoxValg(checkboxValg);
-        endreFiltervalg(form, checkboxValg);
+        endreFiltervalg(filterId, checkboxValg);
 
         logEvent('portefolje.metrikker.aldersfilter', {
             checkbox: true,
@@ -70,7 +77,7 @@ function AlderFilterform({endreFiltervalg, valg, closeDropdown, form, filtervalg
     const onSubmitCustomInput = e => {
         const inputFraNummer: number = parseInt(inputAlderFra);
         const inputTilNummer: number = parseInt(inputAlderTil);
-        endreFiltervalg(form, []);
+        endreFiltervalg(filterId, []);
         e.preventDefault();
         if (!kanVelgeFilter) {
             closeDropdown();
@@ -85,11 +92,11 @@ function AlderFilterform({endreFiltervalg, valg, closeDropdown, form, filtervalg
                 setFeil(false);
                 setFeilTekst('');
                 if (inputAlderFra.length === 0 && inputAlderTil.length > 0) {
-                    endreFiltervalg(form, [0 + '-' + inputAlderTil]);
+                    endreFiltervalg(filterId, [0 + '-' + inputAlderTil]);
                 } else if (inputAlderFra.length > 0 && inputAlderTil.length === 0) {
-                    endreFiltervalg(form, [inputAlderFra + '-' + 100]);
+                    endreFiltervalg(filterId, [inputAlderFra + '-' + 100]);
                 } else if (inputAlderFra.length > 0 && inputAlderTil.length > 0) {
-                    endreFiltervalg(form, [inputAlderFra + '-' + inputAlderTil]);
+                    endreFiltervalg(filterId, [inputAlderFra + '-' + inputAlderTil]);
                 }
                 closeDropdown();
             }
@@ -108,7 +115,7 @@ function AlderFilterform({endreFiltervalg, valg, closeDropdown, form, filtervalg
         setInputAlderFra('');
         setInputAlderTil('');
         setCheckBoxValg([]);
-        endreFiltervalg(form, []);
+        endreFiltervalg(filterId, []);
     };
 
     return (
@@ -192,7 +199,7 @@ function AlderFilterform({endreFiltervalg, valg, closeDropdown, form, filtervalg
             <NullstillKnapp
                 dataTestId="alder-filterform"
                 nullstillValg={nullstillValg}
-                form={form}
+                filterId={filterId}
                 disabled={!kanVelgeFilter}
             />
         </form>

--- a/src/filtrering/filtrering-filter/filterform/barn-under-18-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/barn-under-18-filterform.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {FiltervalgModell} from '../../../model-interfaces';
+import {FilterId, FiltervalgModell} from '../../../model-interfaces';
 import {Dictionary} from '../../../utils/types/types';
 import Grid from '../../../components/grid/grid';
 import classNames from 'classnames';
@@ -11,7 +11,7 @@ import {BodyShort, Button, Checkbox, CheckboxGroup, TextField} from '@navikt/ds-
 
 interface BarnUnder18Props {
     valg: Dictionary<string>;
-    endreFiltervalg: (filterId: string, filterVerdi: string[]) => void;
+    endreFiltervalg: (filterId: FilterId, filterVerdi: string[]) => void;
     closeDropdown: () => void;
     filtervalg: FiltervalgModell;
     className?: string;
@@ -24,20 +24,20 @@ function BarnUnder18FilterForm({endreFiltervalg, valg, closeDropdown, filtervalg
     const [feilTekst, setFeilTekst] = useState<string>('');
     const harValg = Object.keys(valg).length > 0;
     const kanVelgeFilter = checkBoxValg.length > 0 || inputAlderFra.length > 0 || inputAlderTil.length > 0;
-    let filterIdBarnAlder = 'barnUnder18AarAlder';
-    let filterIdHarBarnUnder18 = 'barnUnder18Aar';
+    let filterIdBarnAlder: FilterId = 'barnUnder18AarAlder';
+    let filterIdHarBarnUnder18: FilterId = 'barnUnder18Aar';
     useEffect(() => {
-        filtervalg[filterIdHarBarnUnder18].forEach(barnFilterValg => {
+        (filtervalg[filterIdHarBarnUnder18] as string[]).forEach(barnFilterValg => {
             if (
                 Object.entries(valg)
                     .map(([filterKey]) => filterKey)
                     .includes(barnFilterValg)
             ) {
-                setCheckBoxValg(filtervalg[filterIdHarBarnUnder18]);
+                setCheckBoxValg(filtervalg[filterIdHarBarnUnder18] as string[]);
             }
         });
-        if (filtervalg[filterIdBarnAlder] != null && filtervalg[filterIdBarnAlder].length > 0) {
-            const [alderFra, alderTil] = filtervalg[filterIdBarnAlder][0].split('-');
+        if (filtervalg[filterIdBarnAlder] != null && (filtervalg[filterIdBarnAlder] as string[]).length > 0) {
+            const [alderFra, alderTil] = (filtervalg[filterIdBarnAlder] as string[])[0].split('-');
             alderFra && setInputAlderFra(alderFra);
             alderTil && setInputAlderTil(alderTil);
         }

--- a/src/filtrering/filtrering-filter/filterform/barn-under-18-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/barn-under-18-filterform.tsx
@@ -11,7 +11,7 @@ import {BodyShort, Button, Checkbox, CheckboxGroup, TextField} from '@navikt/ds-
 
 interface BarnUnder18Props {
     valg: Dictionary<string>;
-    endreFiltervalg: (form: string, filterVerdi: string[]) => void;
+    endreFiltervalg: (filterId: string, filterVerdi: string[]) => void;
     closeDropdown: () => void;
     filtervalg: FiltervalgModell;
     className?: string;
@@ -24,24 +24,24 @@ function BarnUnder18FilterForm({endreFiltervalg, valg, closeDropdown, filtervalg
     const [feilTekst, setFeilTekst] = useState<string>('');
     const harValg = Object.keys(valg).length > 0;
     const kanVelgeFilter = checkBoxValg.length > 0 || inputAlderFra.length > 0 || inputAlderTil.length > 0;
-    let filterFormBarnAlder = 'barnUnder18AarAlder';
-    let filterFormHarBarnUnder18 = 'barnUnder18Aar';
+    let filterIdBarnAlder = 'barnUnder18AarAlder';
+    let filterIdHarBarnUnder18 = 'barnUnder18Aar';
     useEffect(() => {
-        filtervalg[filterFormHarBarnUnder18].forEach(barnFilterValg => {
+        filtervalg[filterIdHarBarnUnder18].forEach(barnFilterValg => {
             if (
                 Object.entries(valg)
                     .map(([filterKey]) => filterKey)
                     .includes(barnFilterValg)
             ) {
-                setCheckBoxValg(filtervalg[filterFormHarBarnUnder18]);
+                setCheckBoxValg(filtervalg[filterIdHarBarnUnder18]);
             }
         });
-        if (filtervalg[filterFormBarnAlder] != null && filtervalg[filterFormBarnAlder].length > 0) {
-            const [alderFra, alderTil] = filtervalg[filterFormBarnAlder][0].split('-');
+        if (filtervalg[filterIdBarnAlder] != null && filtervalg[filterIdBarnAlder].length > 0) {
+            const [alderFra, alderTil] = filtervalg[filterIdBarnAlder][0].split('-');
             alderFra && setInputAlderFra(alderFra);
             alderTil && setInputAlderTil(alderTil);
         }
-    }, [filtervalg, filterFormBarnAlder, filterFormHarBarnUnder18, valg]);
+    }, [filtervalg, filterIdBarnAlder, filterIdHarBarnUnder18, valg]);
 
     const submitCheckBoxValg = (checkboxValg: string[]) => {
         setFeil(false);
@@ -49,9 +49,9 @@ function BarnUnder18FilterForm({endreFiltervalg, valg, closeDropdown, filtervalg
         if (checkboxValg.length > 0) {
             setInputAlderFra('');
             setInputAlderTil('');
-            endreFiltervalg(filterFormBarnAlder, []);
+            endreFiltervalg(filterIdBarnAlder, []);
         }
-        endreFiltervalg(filterFormHarBarnUnder18, checkboxValg);
+        endreFiltervalg(filterIdHarBarnUnder18, checkboxValg);
 
         logEvent('portefolje.metrikker.barn_under_18_filter', {
             checkbox: true,
@@ -75,7 +75,7 @@ function BarnUnder18FilterForm({endreFiltervalg, valg, closeDropdown, filtervalg
         const inputTilNummer: number = parseInt(inputAlderTil);
         e.preventDefault();
 
-        endreFiltervalg(filterFormHarBarnUnder18, []);
+        endreFiltervalg(filterIdHarBarnUnder18, []);
         if (!kanVelgeFilter) {
             closeDropdown();
         } else {
@@ -92,11 +92,11 @@ function BarnUnder18FilterForm({endreFiltervalg, valg, closeDropdown, filtervalg
                 setFeil(false);
                 setFeilTekst('');
                 if (inputAlderFra.length === 0 && inputAlderTil.length > 0) {
-                    endreFiltervalg(filterFormBarnAlder, [0 + '-' + inputAlderTil]);
+                    endreFiltervalg(filterIdBarnAlder, [0 + '-' + inputAlderTil]);
                 } else if (inputAlderFra.length > 0 && inputAlderTil.length === 0) {
-                    endreFiltervalg(filterFormBarnAlder, [inputAlderFra + '-' + 18]);
+                    endreFiltervalg(filterIdBarnAlder, [inputAlderFra + '-' + 18]);
                 } else if (inputAlderFra.length > 0 && inputAlderTil.length > 0) {
-                    endreFiltervalg(filterFormBarnAlder, [inputAlderFra + '-' + inputAlderTil]);
+                    endreFiltervalg(filterIdBarnAlder, [inputAlderFra + '-' + inputAlderTil]);
                 }
                 closeDropdown();
             }
@@ -115,8 +115,8 @@ function BarnUnder18FilterForm({endreFiltervalg, valg, closeDropdown, filtervalg
         setInputAlderFra('');
         setInputAlderTil('');
         setCheckBoxValg([]);
-        endreFiltervalg(filterFormHarBarnUnder18, []);
-        endreFiltervalg(filterFormBarnAlder, []);
+        endreFiltervalg(filterIdHarBarnUnder18, []);
+        endreFiltervalg(filterIdBarnAlder, []);
     };
 
     // @ts-ignore
@@ -205,7 +205,7 @@ function BarnUnder18FilterForm({endreFiltervalg, valg, closeDropdown, filtervalg
             <NullstillKnapp
                 dataTestId="alder-filterform"
                 nullstillValg={nullstillValg}
-                form={filterFormBarnAlder}
+                filterId={filterIdBarnAlder}
                 disabled={!kanVelgeFilter}
             />
         </form>

--- a/src/filtrering/filtrering-filter/filterform/checkbox-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/checkbox-filterform.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {Dictionary} from '../../../utils/types/types';
-import {FiltervalgModell} from '../../../model-interfaces';
+import {FilterId, FiltervalgModell} from '../../../model-interfaces';
 import Grid from '../../../components/grid/grid';
 import './filterform.css';
 import classNames from 'classnames';
@@ -9,9 +9,9 @@ import {Alert, Checkbox, CheckboxGroup, Tooltip} from '@navikt/ds-react';
 import {CheckboxFilter, CheckboxFilterMap} from '../../filter-konstanter';
 
 interface CheckboxFilterformProps {
-    filterId: string;
+    filterId: FilterId;
     valg: CheckboxFilterMap;
-    endreFiltervalg: (filterId: string, filterVerdi: string[]) => void;
+    endreFiltervalg: (filterId: FilterId, filterVerdi: string[]) => void;
     filtervalg: FiltervalgModell;
     gridColumns?: number;
     className?: string;
@@ -30,10 +30,10 @@ function CheckboxFilterform({
     tooltips
 }: CheckboxFilterformProps) {
     const harValg = Object.keys(valg).length > 0;
-    const [checkBoxValg, setCheckBoxValg] = useState<string[]>(filtervalg[filterId]);
+    const [checkBoxValg, setCheckBoxValg] = useState<string[]>(filtervalg[filterId] as string[]);
 
     useEffect(() => {
-        setCheckBoxValg(filtervalg[filterId]);
+        setCheckBoxValg(filtervalg[filterId] as string[]);
     }, [filtervalg, filterId]);
 
     const nullstillValg = () => {

--- a/src/filtrering/filtrering-filter/filterform/checkbox-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/checkbox-filterform.tsx
@@ -9,9 +9,9 @@ import {Alert, Checkbox, CheckboxGroup, Tooltip} from '@navikt/ds-react';
 import {CheckboxFilter, CheckboxFilterMap} from '../../filter-konstanter';
 
 interface CheckboxFilterformProps {
-    form: string;
+    filterId: string;
     valg: CheckboxFilterMap;
-    endreFiltervalg: (form: string, filterVerdi: string[]) => void;
+    endreFiltervalg: (filterId: string, filterVerdi: string[]) => void;
     filtervalg: FiltervalgModell;
     gridColumns?: number;
     className?: string;
@@ -22,7 +22,7 @@ interface CheckboxFilterformProps {
 function CheckboxFilterform({
     endreFiltervalg,
     valg,
-    form,
+    filterId,
     filtervalg,
     gridColumns = 1,
     className,
@@ -30,14 +30,14 @@ function CheckboxFilterform({
     tooltips
 }: CheckboxFilterformProps) {
     const harValg = Object.keys(valg).length > 0;
-    const [checkBoxValg, setCheckBoxValg] = useState<string[]>(filtervalg[form]);
+    const [checkBoxValg, setCheckBoxValg] = useState<string[]>(filtervalg[filterId]);
 
     useEffect(() => {
-        setCheckBoxValg(filtervalg[form]);
-    }, [filtervalg, form]);
+        setCheckBoxValg(filtervalg[filterId]);
+    }, [filtervalg, filterId]);
 
     const nullstillValg = () => {
-        endreFiltervalg(form, []);
+        endreFiltervalg(filterId, []);
     };
 
     const checkBoxKomponent = ([filterKey, filterValue]: [string, CheckboxFilter | string]) => {
@@ -65,7 +65,7 @@ function CheckboxFilterform({
                         <CheckboxGroup
                             hideLegend
                             legend=""
-                            onChange={(filtre: string[]) => endreFiltervalg(form, filtre)}
+                            onChange={(filtre: string[]) => endreFiltervalg(filterId, filtre)}
                             size="small"
                             value={checkBoxValg}
                         >
@@ -92,7 +92,7 @@ function CheckboxFilterform({
             <NullstillKnapp
                 dataTestId="checkbox-filterform"
                 nullstillValg={nullstillValg}
-                form={form}
+                filterId={filterId}
                 disabled={checkBoxValg?.length <= 0}
             />
             {!harValg && (

--- a/src/filtrering/filtrering-filter/filterform/fodselsdato-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/fodselsdato-filterform.tsx
@@ -6,33 +6,33 @@ import NullstillKnapp from '../../../components/nullstill-valg-knapp/nullstill-k
 import {Alert} from '@navikt/ds-react';
 
 interface CheckboxFilterformProps {
-    form: string;
+    filterId: string;
     valg: Dictionary<string>;
-    endreFiltervalg: (form: string, filterVerdi: string[]) => void;
+    endreFiltervalg: (filterId: string, filterVerdi: string[]) => void;
     filtervalg: FiltervalgModell;
 }
 
-function FodselsdatoFilterform({endreFiltervalg, valg, form, filtervalg}: CheckboxFilterformProps) {
+function FodselsdatoFilterform({endreFiltervalg, valg, filterId, filtervalg}: CheckboxFilterformProps) {
     const harValg = Object.keys(valg).length > 0;
 
-    const [checkBoxValg, setCheckBoxValg] = useState<string[]>(filtervalg[form]);
+    const [checkBoxValg, setCheckBoxValg] = useState<string[]>(filtervalg[filterId]);
 
     const velgCheckBox = e => {
         e.persist();
         return e.target.checked
-            ? endreFiltervalg(form, [...checkBoxValg, e.target.value])
+            ? endreFiltervalg(filterId, [...checkBoxValg, e.target.value])
             : endreFiltervalg(
-                  form,
+                  filterId,
                   checkBoxValg.filter(value => value !== e.target.value)
               );
     };
 
     useEffect(() => {
-        setCheckBoxValg(filtervalg[form]);
-    }, [filtervalg, form]);
+        setCheckBoxValg(filtervalg[filterId]);
+    }, [filtervalg, filterId]);
 
     const nullstillValg = () => {
-        endreFiltervalg(form, []);
+        endreFiltervalg(filterId, []);
     };
 
     return (
@@ -64,7 +64,7 @@ function FodselsdatoFilterform({endreFiltervalg, valg, form, filtervalg}: Checkb
             <NullstillKnapp
                 dataTestId="fodselsdato-filterform"
                 nullstillValg={nullstillValg}
-                form={form}
+                filterId={filterId}
                 disabled={checkBoxValg.length <= 0}
             />
             {!harValg && (

--- a/src/filtrering/filtrering-filter/filterform/fodselsdato-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/fodselsdato-filterform.tsx
@@ -1,21 +1,21 @@
 import React, {useEffect, useState} from 'react';
 import {Dictionary} from '../../../utils/types/types';
-import {FiltervalgModell} from '../../../model-interfaces';
+import {FiltervalgModell, FilterId} from '../../../model-interfaces';
 import './filterform.css';
 import NullstillKnapp from '../../../components/nullstill-valg-knapp/nullstill-knapp';
 import {Alert} from '@navikt/ds-react';
 
 interface CheckboxFilterformProps {
-    filterId: string;
+    filterId: FilterId;
     valg: Dictionary<string>;
-    endreFiltervalg: (filterId: string, filterVerdi: string[]) => void;
+    endreFiltervalg: (filterId: FilterId, filterVerdi: string[]) => void;
     filtervalg: FiltervalgModell;
 }
 
 function FodselsdatoFilterform({endreFiltervalg, valg, filterId, filtervalg}: CheckboxFilterformProps) {
     const harValg = Object.keys(valg).length > 0;
 
-    const [checkBoxValg, setCheckBoxValg] = useState<string[]>(filtervalg[filterId]);
+    const [checkBoxValg, setCheckBoxValg] = useState<string[]>(filtervalg[filterId] as string[]);
 
     const velgCheckBox = e => {
         e.persist();
@@ -28,7 +28,7 @@ function FodselsdatoFilterform({endreFiltervalg, valg, filterId, filtervalg}: Ch
     };
 
     useEffect(() => {
-        setCheckBoxValg(filtervalg[filterId]);
+        setCheckBoxValg(filtervalg[filterId] as string[]);
     }, [filtervalg, filterId]);
 
     const nullstillValg = () => {

--- a/src/filtrering/filtrering-filter/filterform/foedeland-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/foedeland-filterform.tsx
@@ -1,4 +1,4 @@
-import {FiltervalgModell} from '../../../model-interfaces';
+import {FilterId, FiltervalgModell} from '../../../model-interfaces';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
 import classNames from 'classnames';
@@ -11,7 +11,7 @@ import {landgruppe, landgruppeTooltips} from '../../filter-konstanter';
 import {MultiSelect} from 'react-multi-select-component';
 
 interface FoedelandFilterformProps {
-    endreFiltervalg: (filterId: string, filterVerdi: string[]) => void;
+    endreFiltervalg: (filterId: FilterId, filterVerdi: string[]) => void;
     filtervalg: FiltervalgModell;
     gridColumns?: number;
     emptyCheckboxFilterFormMessage?: string;

--- a/src/filtrering/filtrering-filter/filterform/foedeland-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/foedeland-filterform.tsx
@@ -11,7 +11,7 @@ import {landgruppe, landgruppeTooltips} from '../../filter-konstanter';
 import {MultiSelect} from 'react-multi-select-component';
 
 interface FoedelandFilterformProps {
-    endreFiltervalg: (form: string, filterVerdi: string[]) => void;
+    endreFiltervalg: (filterId: string, filterVerdi: string[]) => void;
     filtervalg: FiltervalgModell;
     gridColumns?: number;
     emptyCheckboxFilterFormMessage?: string;
@@ -145,7 +145,7 @@ function FoedelandFilterform({endreFiltervalg, filtervalg, gridColumns = 1}: Foe
                 <NullstillKnapp
                     dataTestId="checkbox-filterform"
                     nullstillValg={nullstillValg}
-                    form={'landgruppe'}
+                    filterId={'landgruppe'}
                     disabled={landgrupppeValg.length <= 0 && selectedFoedeland.length <= 0}
                 />
             </form>

--- a/src/filtrering/filtrering-filter/filterform/geografiskbosted-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/geografiskbosted-filterform.tsx
@@ -11,7 +11,7 @@ import {MultiSelect} from 'react-multi-select-component';
 import {isEmptyArray} from 'formik';
 
 interface GeografiskBostedFilterformProps {
-    endreFiltervalg: (form: string, filterVerdi: string[]) => void;
+    endreFiltervalg: (filterId: string, filterVerdi: string[]) => void;
     filtervalg: FiltervalgModell;
     gridColumns?: number;
     emptyCheckboxFilterFormMessage?: string;
@@ -129,7 +129,7 @@ function GeografiskBostedFilterform({endreFiltervalg, filtervalg, gridColumns = 
             <NullstillKnapp
                 dataTestId="checkbox-filterform"
                 nullstillValg={nullstillValg}
-                form={'landgruppe'}
+                filterId={'landgruppe'}
                 disabled={visGeografiskBosted.length <= 0 && selectedGeografiskBosted.length <= 0}
             />
         </form>

--- a/src/filtrering/filtrering-filter/filterform/geografiskbosted-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/geografiskbosted-filterform.tsx
@@ -1,4 +1,4 @@
-import {FiltervalgModell} from '../../../model-interfaces';
+import {FilterId, FiltervalgModell} from '../../../model-interfaces';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
 import classNames from 'classnames';
@@ -11,7 +11,7 @@ import {MultiSelect} from 'react-multi-select-component';
 import {isEmptyArray} from 'formik';
 
 interface GeografiskBostedFilterformProps {
-    endreFiltervalg: (filterId: string, filterVerdi: string[]) => void;
+    endreFiltervalg: (filterId: FilterId, filterVerdi: string[]) => void;
     filtervalg: FiltervalgModell;
     gridColumns?: number;
     emptyCheckboxFilterFormMessage?: string;

--- a/src/filtrering/filtrering-filter/filterform/hendelser-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/hendelser-filterform.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {useEffect, useState} from 'react';
 import NullstillKnapp from '../../../components/nullstill-valg-knapp/nullstill-knapp';
-import {FiltervalgModell} from '../../../model-interfaces';
+import {FilterId, FiltervalgModell} from '../../../model-interfaces';
 import {hendelserLabels, ulesteEndringer} from '../../filter-konstanter';
 import './filterform.css';
 import {kebabCase} from '../../../utils/utils';
@@ -10,9 +10,9 @@ import {OrNothing} from '../../../utils/types/types';
 import {HelpText, Checkbox, CheckboxGroup, Radio, RadioGroup} from '@navikt/ds-react';
 
 interface HendelserFilterformProps {
-    filterId: string;
-    endreFiltervalg: (filterId: string, filterVerdi: string[]) => void;
-    endreCheckboxFiltervalg: (filterId: string, filterVerdi: OrNothing<string>) => void;
+    filterId: FilterId;
+    endreFiltervalg: (filterId: FilterId, filterVerdi: string[]) => void;
+    endreCheckboxFiltervalg: (filterId: FilterId, filterVerdi: OrNothing<string>) => void;
     filtervalg: FiltervalgModell;
     oversiktType: OversiktType;
 }
@@ -34,7 +34,7 @@ export function HendelserFilterform({
 
     useEffect(() => {
         if (filtervalg[filterId]) {
-            setHendelserValg(filtervalg[filterId][0]);
+            setHendelserValg((filtervalg[filterId] as string[])[0]);
         } else {
             setHendelserValg('');
         }

--- a/src/filtrering/filtrering-filter/filterform/hendelser-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/hendelser-filterform.tsx
@@ -10,15 +10,15 @@ import {OrNothing} from '../../../utils/types/types';
 import {HelpText, Checkbox, CheckboxGroup, Radio, RadioGroup} from '@navikt/ds-react';
 
 interface HendelserFilterformProps {
-    form: string;
-    endreFiltervalg: (form: string, filterVerdi: string[]) => void;
-    endreCheckboxFiltervalg: (form: string, filterVerdi: OrNothing<string>) => void;
+    filterId: string;
+    endreFiltervalg: (filterId: string, filterVerdi: string[]) => void;
+    endreCheckboxFiltervalg: (filterId: string, filterVerdi: OrNothing<string>) => void;
     filtervalg: FiltervalgModell;
     oversiktType: OversiktType;
 }
 
 export function HendelserFilterform({
-    form,
+    filterId,
     filtervalg,
     endreFiltervalg,
     endreCheckboxFiltervalg,
@@ -28,17 +28,17 @@ export function HendelserFilterform({
     const [checkboxValg, setCheckboxValg] = useState<string | null>(null);
 
     const nullstillValg = () => {
-        endreFiltervalg(form, []);
+        endreFiltervalg(filterId, []);
         endreCheckboxFiltervalg('ulesteEndringer', null);
     };
 
     useEffect(() => {
-        if (filtervalg[form]) {
-            setHendelserValg(filtervalg[form][0]);
+        if (filtervalg[filterId]) {
+            setHendelserValg(filtervalg[filterId][0]);
         } else {
             setHendelserValg('');
         }
-    }, [filtervalg, hendelserValg, form]);
+    }, [filtervalg, hendelserValg, filterId]);
 
     useEffect(() => {
         setCheckboxValg(filtervalg['ulesteEndringer']);
@@ -46,7 +46,7 @@ export function HendelserFilterform({
 
     const onRadioChange = e => {
         e.persist();
-        endreFiltervalg(form, [e.target.value]);
+        endreFiltervalg(filterId, [e.target.value]);
     };
 
     const onCheckboxChange = e => {
@@ -155,7 +155,7 @@ export function HendelserFilterform({
             <NullstillKnapp
                 dataTestId="hendelser-filterform"
                 nullstillValg={nullstillValg}
-                form={form}
+                filterId={filterId}
                 disabled={hendelserValg === undefined && checkboxValg === null}
             />
         </form>

--- a/src/filtrering/filtrering-filter/filterform/radio-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/radio-filterform.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import './filterform.css';
 import {kebabCase} from '../../../utils/utils';
-import {FiltervalgModell} from '../../../model-interfaces';
+import {FilterId, FiltervalgModell} from '../../../model-interfaces';
 import NullstillKnapp from '../../../components/nullstill-valg-knapp/nullstill-knapp';
 import {OrNothing} from '../../../utils/types/types';
 import {Radio, RadioGroup} from '@navikt/ds-react';
@@ -12,8 +12,8 @@ interface ValgType {
 }
 
 interface RadioFilterformProps {
-    filterId: string;
-    endreFiltervalg: (filterId: string, filterVerdi: OrNothing<string>) => void;
+    filterId: FilterId;
+    endreFiltervalg: (filterId: FilterId, filterVerdi: OrNothing<string>) => void;
     valg: ValgType;
     filtervalg: FiltervalgModell;
     gridColumns?: number;

--- a/src/filtrering/filtrering-filter/filterform/radio-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/radio-filterform.tsx
@@ -12,22 +12,22 @@ interface ValgType {
 }
 
 interface RadioFilterformProps {
-    form: string;
-    endreFiltervalg: (form: string, filterVerdi: OrNothing<string>) => void;
+    filterId: string;
+    endreFiltervalg: (filterId: string, filterVerdi: OrNothing<string>) => void;
     valg: ValgType;
     filtervalg: FiltervalgModell;
     gridColumns?: number;
 }
-export function RadioFilterform({form, endreFiltervalg, valg, filtervalg, gridColumns = 1}: RadioFilterformProps) {
-    const valgtFilterValg = filtervalg[form];
+export function RadioFilterform({filterId, endreFiltervalg, valg, filtervalg, gridColumns = 1}: RadioFilterformProps) {
+    const valgtFilterValg = filtervalg[filterId];
 
     const nullstillValg = () => {
-        endreFiltervalg(form, null);
+        endreFiltervalg(filterId, null);
     };
 
     const onChange = e => {
         e.persist();
-        endreFiltervalg(form, e.target.value);
+        endreFiltervalg(filterId, e.target.value);
     };
 
     return (
@@ -51,7 +51,7 @@ export function RadioFilterform({form, endreFiltervalg, valg, filtervalg, gridCo
             <NullstillKnapp
                 dataTestId="radio-filterform"
                 nullstillValg={nullstillValg}
-                form={form}
+                filterId={filterId}
                 disabled={valgtFilterValg === '' || valgtFilterValg === null}
             />
         </form>

--- a/src/filtrering/filtrering-filter/filterform/tolkebehov-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/tolkebehov-filterform.tsx
@@ -1,4 +1,4 @@
-import {FiltervalgModell} from '../../../model-interfaces';
+import {FilterId, FiltervalgModell} from '../../../model-interfaces';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
 import classNames from 'classnames';
@@ -11,7 +11,7 @@ import NullstillKnapp from '../../../components/nullstill-valg-knapp/nullstill-k
 import {MultiSelect} from 'react-multi-select-component';
 
 interface TolkebehovFilterformProps {
-    endreFiltervalg: (filterId: string, filterVerdi: string[]) => void;
+    endreFiltervalg: (filterId: FilterId, filterVerdi: string[]) => void;
     filtervalg: FiltervalgModell;
     gridColumns?: number;
     emptyCheckboxFilterFormMessage?: string;

--- a/src/filtrering/filtrering-filter/filterform/tolkebehov-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/tolkebehov-filterform.tsx
@@ -11,7 +11,7 @@ import NullstillKnapp from '../../../components/nullstill-valg-knapp/nullstill-k
 import {MultiSelect} from 'react-multi-select-component';
 
 interface TolkebehovFilterformProps {
-    endreFiltervalg: (form: string, filterVerdi: string[]) => void;
+    endreFiltervalg: (filterId: string, filterVerdi: string[]) => void;
     filtervalg: FiltervalgModell;
     gridColumns?: number;
     emptyCheckboxFilterFormMessage?: string;
@@ -144,7 +144,7 @@ function TolkebehovFilterform({endreFiltervalg, filtervalg, gridColumns = 1}: To
                 <NullstillKnapp
                     dataTestId="checkbox-filterform"
                     nullstillValg={nullstillValg}
-                    form={'tolkbehov'}
+                    filterId={'tolkbehov'}
                     disabled={tolkebehovValg.length <= 0 && selectedTolkbehovSpraak.length <= 0}
                 />
             </form>

--- a/src/filtrering/filtrering-filter/filtrering-filter.tsx
+++ b/src/filtrering/filtrering-filter/filtrering-filter.tsx
@@ -34,7 +34,7 @@ import {RadioFilterform} from './filterform/radio-filterform';
 import {HendelserFilterform} from './filterform/hendelser-filterform';
 import {OversiktType} from '../../ducks/ui/listevisning';
 import AktivitetFilterformController from './filterform/aktiviteter-filterform/aktivitet-filterform-controller';
-import {FiltervalgModell} from '../../model-interfaces';
+import {FilterId, FiltervalgModell} from '../../model-interfaces';
 import {Alert, Label, Link} from '@navikt/ds-react';
 import GeografiskbostedFilterform from './filterform/geografiskbosted-filterform';
 import FoedelandFilterform from './filterform/foedeland-filterform';
@@ -47,7 +47,7 @@ import {usePortefoljeSelector} from '../../hooks/redux/use-portefolje-selector';
 
 interface FiltreringFilterProps {
     filtervalg: FiltervalgModell;
-    endreFiltervalg: (filterId: string, filterVerdi: React.ReactNode) => void;
+    endreFiltervalg: (filterId: FilterId, filterVerdi: React.ReactNode) => void;
     enhettiltak: any;
     oversiktType: OversiktType;
 }
@@ -94,7 +94,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
     };
 
     const endreAvvik14aVedtakFilterValg = () => {
-        return (filterId: string, filterVerdi: string[]) => {
+        return (filterId: FilterId, filterVerdi: string[]) => {
             const filterForEndring: string[] = filtervalg.avvik14aVedtak;
             const filterEtterEndring: string[] = filterVerdi;
 

--- a/src/filtrering/filtrering-filter/filtrering-filter.tsx
+++ b/src/filtrering/filtrering-filter/filtrering-filter.tsx
@@ -94,7 +94,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
     };
 
     const endreAvvik14aVedtakFilterValg = () => {
-        return (form: string, filterVerdi: string[]) => {
+        return (filterId: string, filterVerdi: string[]) => {
             const filterForEndring: string[] = filtervalg.avvik14aVedtak;
             const filterEtterEndring: string[] = filterVerdi;
 
@@ -105,11 +105,11 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
             );
 
             if (hovedfilterEndring === 'FJERNET') {
-                return endreFiltervalg(form, []);
+                return endreFiltervalg(filterId, []);
             }
 
             if (hovedfilterEndring === 'LAGT_TIL') {
-                return endreFiltervalg(form, Object.keys(avvik14aVedtak));
+                return endreFiltervalg(filterId, Object.keys(avvik14aVedtak));
             }
 
             const ingenAvhengigeFilterValgt: boolean = !filterEtterEndring.some(f =>
@@ -117,11 +117,11 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
             );
 
             if (ingenAvhengigeFilterValgt) {
-                return endreFiltervalg(form, []);
+                return endreFiltervalg(filterId, []);
             }
 
             return endreFiltervalg(
-                form,
+                filterId,
                 filterVerdi.includes(mapFilternavnTilFilterValue.harAvvik)
                     ? filterVerdi
                     : [mapFilternavnTilFilterValue.harAvvik, ...filterVerdi]
@@ -140,7 +140,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                     id="alder"
                     render={lukkDropdown => (
                         <AlderFilterform
-                            form="alder"
+                            filterId="alder"
                             valg={alder}
                             filtervalg={filtervalg}
                             endreFiltervalg={endreFiltervalg}
@@ -153,7 +153,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                     id="fodselsdato"
                     render={() => (
                         <FodselsdatoFilterform
-                            form="fodselsdagIMnd"
+                            filterId="fodselsdagIMnd"
                             valg={fodselsdagIMnd()}
                             filtervalg={filtervalg}
                             endreFiltervalg={endreFiltervalg}
@@ -168,7 +168,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                             valg={kjonn}
                             endreFiltervalg={endreFiltervalg}
                             filtervalg={filtervalg}
-                            form="kjonn"
+                            filterId="kjonn"
                             gridColumns={2}
                         />
                     )}
@@ -213,7 +213,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                     id="sisteEndringKategori"
                     render={() => (
                         <HendelserFilterform
-                            form="sisteEndringKategori"
+                            filterId="sisteEndringKategori"
                             filtervalg={filtervalg}
                             endreFiltervalg={endreFiltervalg}
                             endreCheckboxFiltervalg={endreFiltervalg}
@@ -233,7 +233,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                                 Svar bruker oppga ved registrering. Det finnes ikke svar for alle, f.eks. sykmeldte.
                             </Alert>
                             <CheckboxFilterform
-                                form="registreringstype"
+                                filterId="registreringstype"
                                 valg={registreringstype}
                                 filtervalg={filtervalg}
                                 endreFiltervalg={endreFiltervalg}
@@ -252,7 +252,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                                     Svar bruker oppga ved endring i brukers situasjon
                                 </Alert>
                                 <CheckboxFilterform
-                                    form="registreringstype"
+                                    filterId="registreringstype"
                                     valg={endringISituasjon}
                                     filtervalg={filtervalg}
                                     endreFiltervalg={endreFiltervalg}
@@ -271,7 +271,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                                 Svar bruker oppga ved registrering. Det finnes ikke svar for alle, f.eks. sykmeldte.
                             </Alert>
                             <CheckboxFilterform
-                                form="utdanning"
+                                filterId="utdanning"
                                 valg={utdanning}
                                 filtervalg={filtervalg}
                                 endreFiltervalg={endreFiltervalg}
@@ -288,7 +288,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                                 Svar bruker oppga ved registrering. Det finnes ikke svar for alle, f.eks. sykmeldte.
                             </Alert>
                             <CheckboxFilterform
-                                form="utdanningGodkjent"
+                                filterId="utdanningGodkjent"
                                 valg={utdanningGodkjent}
                                 filtervalg={filtervalg}
                                 endreFiltervalg={endreFiltervalg}
@@ -305,7 +305,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                                 Svar bruker oppga ved registrering. Det finnes ikke svar for alle, f.eks. sykmeldte.
                             </Alert>
                             <CheckboxFilterform
-                                form="utdanningBestatt"
+                                filterId="utdanningBestatt"
                                 valg={utdanningBestatt}
                                 filtervalg={filtervalg}
                                 endreFiltervalg={endreFiltervalg}
@@ -337,7 +337,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                                 valg={avvik14aVedtakValg()}
                                 endreFiltervalg={endreAvvik14aVedtakFilterValg()}
                                 filtervalg={filtervalg}
-                                form="avvik14aVedtak"
+                                filterId="avvik14aVedtak"
                             />
                         </>
                     )}
@@ -353,7 +353,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                             valg={cvJobbprofil}
                             endreFiltervalg={endreFiltervalg}
                             filtervalg={filtervalg}
-                            form="cvJobbprofil"
+                            filterId="cvJobbprofil"
                         />
                     )}
                 />
@@ -362,7 +362,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                     id="innsatsgruppe"
                     render={() => (
                         <CheckboxFilterform
-                            form="innsatsgruppe"
+                            filterId="innsatsgruppe"
                             valg={innsatsgruppe}
                             filtervalg={filtervalg}
                             endreFiltervalg={endreFiltervalg}
@@ -374,7 +374,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                     id="hovedmal"
                     render={() => (
                         <CheckboxFilterform
-                            form="hovedmal"
+                            filterId="hovedmal"
                             valg={hovedmal}
                             filtervalg={filtervalg}
                             endreFiltervalg={endreFiltervalg}
@@ -386,7 +386,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                     id="formidlingsgruppe"
                     render={() => (
                         <CheckboxFilterform
-                            form="formidlingsgruppe"
+                            filterId="formidlingsgruppe"
                             valg={formidlingsgruppe}
                             filtervalg={filtervalg}
                             endreFiltervalg={endreFiltervalg}
@@ -398,7 +398,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                     id="servicegruppe"
                     render={() => (
                         <CheckboxFilterform
-                            form="servicegruppe"
+                            filterId="servicegruppe"
                             valg={servicegruppe}
                             filtervalg={filtervalg}
                             endreFiltervalg={endreFiltervalg}
@@ -410,7 +410,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                     id="manuell-oppfolging"
                     render={() => (
                         <CheckboxFilterform
-                            form="manuellBrukerStatus"
+                            filterId="manuellBrukerStatus"
                             valg={manuellBrukerStatus}
                             filtervalg={filtervalg}
                             endreFiltervalg={endreFiltervalg}
@@ -425,7 +425,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                     id="rettighetsgruppe"
                     render={() => (
                         <CheckboxFilterform
-                            form="rettighetsgruppe"
+                            filterId="rettighetsgruppe"
                             valg={rettighetsgruppe}
                             filtervalg={filtervalg}
                             endreFiltervalg={endreFiltervalg}
@@ -440,7 +440,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                             valg={ytelse}
                             filtervalg={filtervalg}
                             endreFiltervalg={endreFiltervalg}
-                            form="ytelse"
+                            filterId="ytelse"
                         />
                     )}
                 />
@@ -449,7 +449,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                     id="ensligeForsorgere"
                     render={() => (
                         <CheckboxFilterform
-                            form="ensligeForsorgere"
+                            filterId="ensligeForsorgere"
                             valg={ensligeForsorgere}
                             filtervalg={filtervalg}
                             endreFiltervalg={endreFiltervalg}
@@ -471,7 +471,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                     id="tiltakstype"
                     render={() => (
                         <CheckboxFilterform
-                            form="tiltakstyper"
+                            filterId="tiltakstyper"
                             valg={enhettiltak}
                             filtervalg={filtervalg}
                             endreFiltervalg={endreFiltervalg}
@@ -485,7 +485,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                     id="stillingFraNav"
                     render={() => (
                         <CheckboxFilterform
-                            form="stillingFraNavFilter"
+                            filterId="stillingFraNavFilter"
                             valg={stillingFraNavFilter}
                             filtervalg={filtervalg}
                             endreFiltervalg={endreFiltervalg}

--- a/src/filtrering/filtrering-navnellerfnr.tsx
+++ b/src/filtrering/filtrering-navnellerfnr.tsx
@@ -1,11 +1,11 @@
 import React, {useRef} from 'react';
-import {FiltervalgModell} from '../model-interfaces';
+import {FilterId, FiltervalgModell} from '../model-interfaces';
 import {useEffect, useState} from 'react';
 import {TextField} from '@navikt/ds-react';
 
 interface FiltreringNavnEllerFnrProps {
     filtervalg: FiltervalgModell;
-    endreFiltervalg: (filterId: string, filterVerdi: string) => void;
+    endreFiltervalg: (filterId: FilterId, filterVerdi: string) => void;
 }
 
 function FiltreringNavnellerfnr({filtervalg, endreFiltervalg}: FiltreringNavnEllerFnrProps) {

--- a/src/filtrering/filtrering-veiledere.tsx
+++ b/src/filtrering/filtrering-veiledere.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import VeilederCheckboxListe from '../components/veileder-checkbox-liste/veileder-checkbox-liste';
 import {useEffect, useRef, useState} from 'react';
-import {FiltervalgModell} from '../model-interfaces';
+import {FilterId, FiltervalgModell} from '../model-interfaces';
 import {TextField} from '@navikt/ds-react';
 
 interface FiltreringVeiledereProps {
     filtervalg: FiltervalgModell;
-    endreFiltervalg: (filterId: string, filterVerdi: string) => void;
+    endreFiltervalg: (filterId: FilterId, filterVerdi: string) => void;
 }
 
 export default function FiltreringVeiledere({endreFiltervalg, filtervalg}: FiltreringVeiledereProps) {

--- a/src/minoversikt/minoversikt-side.tsx
+++ b/src/minoversikt/minoversikt-side.tsx
@@ -41,7 +41,7 @@ import {lukkFeilTiltakModal} from '../ducks/lagret-filter-ui-state';
 import {FeilTiltakModal} from '../components/modal/mine-filter/feil-tiltak-modal';
 import {AppState} from '../reducer';
 import {Alert} from '@navikt/ds-react';
-import {IdentParam} from '../model-interfaces';
+import {FilterId, IdentParam} from '../model-interfaces';
 import {Informasjonsmeldinger} from '../components/informasjonsmeldinger/informasjonsmeldinger';
 import {useStatustallVeilederSelector} from '../hooks/redux/use-statustall';
 import {StatustallVeileder, StatustallVeilederState} from '../ducks/statustall-veileder';
@@ -80,7 +80,7 @@ export default function MinoversiktSide() {
     const {ident} = useParams<IdentParam>();
     const veiledere = useVeilederListeSelector();
     const veilederFraUrl = veiledere.find(veileder => veileder.ident === ident) || {fornavn: '', etternavn: ''};
-    const doEndreFiltervalg = (filterId: string, filterVerdi: React.ReactNode) => {
+    const doEndreFiltervalg = (filterId: FilterId, filterVerdi: React.ReactNode) => {
         dispatch(pagineringSetup({side: 1}));
         dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType));
         oppdaterKolonneAlternativer(dispatch, {...filtervalg, [filterId]: filterVerdi}, oversiktType);

--- a/src/model-interfaces.ts
+++ b/src/model-interfaces.ts
@@ -104,6 +104,7 @@ export interface FiltervalgModell {
     barnUnder18Aar: string[];
     barnUnder18AarAlder: string[];
 }
+export type FilterId = keyof FiltervalgModell;
 
 export interface EnhetModell {
     enhetId: string;

--- a/src/veiledere/veiledere-side.tsx
+++ b/src/veiledere/veiledere-side.tsx
@@ -24,6 +24,7 @@ import LagredeFilterUIController from '../filtrering/lagrede-filter-controller';
 import {Panel} from '@navikt/ds-react';
 import {Informasjonsmeldinger} from '../components/informasjonsmeldinger/informasjonsmeldinger';
 import {useSelectGjeldendeVeileder} from '../hooks/portefolje/use-select-gjeldende-veileder';
+import {FilterId} from '../model-interfaces';
 
 function VeiledereSide() {
     const gjeldendeVeileder = useSelectGjeldendeVeileder();
@@ -57,7 +58,7 @@ function VeiledereSide() {
     useSetLocalStorageOnUnmount();
     LagredeFilterUIController({oversiktType: oversiktType});
 
-    const doEndreFiltervalg = (filterId: string, filterVerdi: React.ReactNode) => {
+    const doEndreFiltervalg = (filterId: FilterId, filterVerdi: React.ReactNode) => {
         dispatch(pagineringSetup({side: 1}));
         oppdaterKolonneAlternativer(dispatch, {...filtervalg, [filterId]: filterVerdi}, oversiktType);
         dispatch(endreFiltervalg(filterId, filterVerdi, oversiktType));


### PR DESCRIPTION
Forsøker å gjøre det litt lettere å ressonere rundt hva som skjer i appen, samt navigere seg rundt, ved å rename noen dårlig navngitte props/parameter samt innføre litt strengere typing. 

Merk at etter at jeg innførte `FilterId`-typen så vil TypeScript klage noen steder på at typen ikke passer helt. Her har jeg eksplisitt castet til forventet type (`as string[]`). Slik casting skal man jo være forsiktig med dersom man ikke er helt sikker på at typen man caster til er riktig også ved kjøretid. I dette tilfellet er jeg rimelig sikker, samt at utgangspunktet heller ikke var noe bedre (da skjedde det implisitt).