### PR TITLE
Feilhåndtering for fargekategorier

### DIFF
--- a/src/components/fargekategori/FargekategoriFeilhandtering.tsx
+++ b/src/components/fargekategori/FargekategoriFeilhandtering.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import {Alert, List, useId} from '@navikt/ds-react';
+import {Status} from '../../model-interfaces';
+
+interface Props {
+    children: React.ReactNode;
+    apiResponse: {status: string; data: {response?: Response; data: string | {data: string[]; errors: string[]}}};
+}
+
+function isString(data: string | {data: string[]; errors: string[]}): data is string {
+    return typeof data === 'string';
+}
+
+const mapErrorToText = (okFnrs: string[], errorFnrs: string[], status: number | undefined) => {
+    if (!okFnrs?.length) {
+        if (status === 400) return `Kunne ikke oppdatere kategori. Fødselsnummer er ugyldig.`;
+        if (status === 403) return `Du har ikke tilgang til å oppdatere kategori.`;
+        if (status === 500) return `Noe gikk galt, prøv igjen senere.`;
+    }
+
+    return (
+        <List as="ul" size="small" title="Kunne ikke oppdatere kategori på følgende personer:">
+            {errorFnrs?.map(fnr => (
+                <List.Item key={useId()}>{fnr}</List.Item>
+            ))}
+        </List>
+    );
+};
+export const FargekategoriFeilhandtering = ({children, apiResponse}: Props) => {
+    const responseJson =
+        apiResponse.status === Status.ERROR && isString(apiResponse.data.data)
+            ? JSON.parse(apiResponse.data.data)
+            : apiResponse.data;
+
+    const {data: okFnrs, errors: errorFnrs} = !!responseJson ? responseJson : {data: [], errors: []};
+
+    return (
+        <>
+            {apiResponse.status === Status.ERROR || !!errorFnrs?.length ? (
+                <Alert size="small" variant="error">
+                    {mapErrorToText(okFnrs, errorFnrs, apiResponse.data.response?.status)}
+                </Alert>
+            ) : (
+                children
+            )}
+        </>
+    );
+};

--- a/src/components/fargekategori/fargekategori-tabellrad-knapp.tsx
+++ b/src/components/fargekategori/fargekategori-tabellrad-knapp.tsx
@@ -3,12 +3,18 @@ import {BrukerModell} from '../../model-interfaces';
 import {Button} from '@navikt/ds-react';
 import {FargekategoriPopover} from './fargekategori-popover';
 import fargekategoriIkonMapper from './fargekategori-ikon-mapper';
+import {resetFargekategoriStateAction} from '../../ducks/fargekategori';
+import {ThunkDispatch} from 'redux-thunk';
+import {AppState} from '../../reducer';
+import {AnyAction} from 'redux';
+import {useDispatch} from 'react-redux';
 
 interface FargekategoriPopoverKnappProps {
     bruker: BrukerModell;
 }
 
 export default function FargekategoriTabellradKnapp({bruker}: FargekategoriPopoverKnappProps) {
+    const dispatch: ThunkDispatch<AppState, any, AnyAction> = useDispatch();
     const buttonRef = useRef<HTMLButtonElement>(null);
     const [openState, setOpenState] = useState(false);
 
@@ -19,7 +25,10 @@ export default function FargekategoriTabellradKnapp({bruker}: FargekategoriPopov
                 variant="tertiary"
                 icon={fargekategoriIkonMapper(bruker.fargekategori)}
                 ref={buttonRef}
-                onClick={() => setOpenState(!openState)}
+                onClick={() => {
+                    setOpenState(!openState);
+                    dispatch(resetFargekategoriStateAction());
+                }}
                 className="fargekategori-tabellrad-knapp"
             />
             <FargekategoriPopover

--- a/src/components/toolbar/fargekategori-toolbar-knapp.tsx
+++ b/src/components/toolbar/fargekategori-toolbar-knapp.tsx
@@ -2,12 +2,19 @@ import React, {useRef, useState} from 'react';
 import {ReactComponent as FargekategoriIkonBokmerke} from '../ikoner/fargekategorier/Fargekategoriikon_bokmerke.svg';
 import {BodyShort, Button} from '@navikt/ds-react';
 import {FargekategoriPopover} from '../fargekategori/fargekategori-popover';
+import {ThunkDispatch} from 'redux-thunk';
+import {AppState} from '../../reducer';
+import {AnyAction} from 'redux';
+import {useDispatch} from 'react-redux';
+import {resetFargekategoriStateAction} from '../../ducks/fargekategori';
+import {oppdaterBrukerfeil} from '../../ducks/brukerfeilmelding';
 
 interface FargekategoriToolbarKnappProps {
     valgteBrukereFnrs: string[];
 }
 
 export default function FargekategoriToolbarKnapp({valgteBrukereFnrs}: FargekategoriToolbarKnappProps) {
+    const dispatch: ThunkDispatch<AppState, any, AnyAction> = useDispatch();
     const buttonRef = useRef<HTMLButtonElement>(null);
     const [openState, setOpenState] = useState(false);
 
@@ -19,7 +26,14 @@ export default function FargekategoriToolbarKnapp({valgteBrukereFnrs}: Fargekate
                 icon={<FargekategoriIkonBokmerke />}
                 title="Sett fargekategori for alle valgte brukere"
                 ref={buttonRef}
-                onClick={() => setOpenState(!openState)}
+                onClick={() => {
+                    if (valgteBrukereFnrs.length === 0) {
+                        dispatch(oppdaterBrukerfeil());
+                    } else {
+                        setOpenState(!openState);
+                        dispatch(resetFargekategoriStateAction());
+                    }
+                }}
                 className="toolbar_btn"
             >
                 Fargekategori

--- a/src/mocks/api/veilarbportefolje.ts
+++ b/src/mocks/api/veilarbportefolje.ts
@@ -231,11 +231,24 @@ export const veilarbportefoljeHandlers: RequestHandler[] = [
                 fnr: string[];
                 fargekategoriVerdi: FargekategoriModell;
             };
-            const randomize = rnd(0, 1);
-            return randomize > 0.2
+            /**
+             * Mulige options fra backend er:
+             *  -status: 403, body: null  --> Finner ikke innlogget bruker
+             *  -status: 403, body: {data: string[], errors: [], fargekategoriVerdi: FargekategoriModell} --> Dersom man ikke har tilgang til noen bruker, ikke oppdatert i db. data vil være tom.
+             *  -status: 400, body: {data: string[], errors: [], fargekategoriVerdi: FargekategoriModell} --> Dersom ingen fnr er gyldige vil spørringen være ugyldig og derfor ikke oppdatere i db. data vil være tom.
+             *  -status: 500, body: {data: string[], errors: [], fargekategoriVerdi: FargekategoriModell} --> Dersom noe gikk galt i oppdatering mot db (men validerong og autorisering har gått ok), har ikke oppdatert db. data vil være tom.
+             *  -status: 200, body: {data: string[], errors: [], fargekategoriVerdi: FargekategoriModell} --> Dersom noen oppdateringer i db har gått bra. både data og errors kan være fylt.
+             */
+            const randomize = rnd(0, 10);
+            const okFnrs = oppdaterFargekategoriRequest.fnr.slice(0, randomize);
+            const errorFnrs = oppdaterFargekategoriRequest.fnr.slice(
+                randomize,
+                oppdaterFargekategoriRequest.fnr.length
+            );
+            return randomize > 2
                 ? HttpResponse.json({
-                      data: oppdaterFargekategoriRequest.fnr,
-                      errors: [],
+                      data: okFnrs,
+                      errors: errorFnrs,
                       fargekategoriVerdi: oppdaterFargekategoriRequest.fargekategoriVerdi
                   })
                 : HttpResponse.json(


### PR DESCRIPTION
Tar gjerne en gjennomgang for å forklare dette 😅 

Men kommentar i `src/mocks/api/veilarbportefolje.ts` viser hvor mange muligheter man har fra backend mtp på responser. Måten man håndterer feilkall og ok-kall er litt forskjellig med tanke på om body-objektet fra backend sendes videre fra `doThenDispatch`-funksjonen som JSON eller string, noe som gjør det litt vanskelig når man skal lese body ved en eventuell feil.