### PR TITLE
Bytt ut pil-ikon frå @navikt-ds-icons med dei frå @navikt-aksel-icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,6 @@
                 "nav-frontend-knapper-style": "2.1.2",
                 "nav-frontend-lenker": "2.0.2",
                 "nav-frontend-lenker-style": "2.0.2",
-                "nav-frontend-lukknapp": "2.0.2",
-                "nav-frontend-lukknapp-style": "2.0.2",
                 "nav-frontend-paneler": "3.0.2",
                 "nav-frontend-paneler-style": "2.0.2",
                 "nav-frontend-skjema": "4.0.6",
@@ -13592,25 +13590,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/nav-frontend-lenker-style/-/nav-frontend-lenker-style-2.0.2.tgz",
             "integrity": "sha512-vTK7TP/eebnSQFV++mi0SLtCeDw80TjQ9W/bcJeOEYRojaL8P68qvVwNyz2SlUdaMH+CRiXRKUq4Uv9DZnvonA==",
-            "peerDependencies": {
-                "nav-frontend-core": "^6.0.0"
-            }
-        },
-        "node_modules/nav-frontend-lukknapp": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/nav-frontend-lukknapp/-/nav-frontend-lukknapp-2.0.2.tgz",
-            "integrity": "sha512-ItSQSmbfSE8GPDcAGkWGIVydYUuzvYAMVJ9pMKpItvAUfZ+Dt7HyYLXjfSxwi10ign4fpi9dsZGKfsFYyOQ2RQ==",
-            "peerDependencies": {
-                "classnames": "^2.2.5",
-                "nav-frontend-lukknapp-style": "^2.0.0",
-                "prop-types": "^15.5.10",
-                "react": "^16.8.0 || ^17.0.0"
-            }
-        },
-        "node_modules/nav-frontend-lukknapp-style": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/nav-frontend-lukknapp-style/-/nav-frontend-lukknapp-style-2.0.2.tgz",
-            "integrity": "sha512-mROE+VwmYVQtMxCtwLjqGZmOzoRRgAR391VMz/lYcZsRljcvNAMF9oFIQEAdd/Fg32WUGcOG0SUPDP6vbsZrrQ==",
             "peerDependencies": {
                 "nav-frontend-core": "^6.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -76,8 +76,6 @@
         "nav-frontend-knapper-style": "2.1.2",
         "nav-frontend-lenker": "2.0.2",
         "nav-frontend-lenker-style": "2.0.2",
-        "nav-frontend-lukknapp": "2.0.2",
-        "nav-frontend-lukknapp-style": "2.0.2",
         "nav-frontend-paneler": "3.0.2",
         "nav-frontend-paneler-style": "2.0.2",
         "nav-frontend-skjema": "4.0.6",

--- a/src/components/sidebar/sidebar-tab.tsx
+++ b/src/components/sidebar/sidebar-tab.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import Lukknapp from 'nav-frontend-lukknapp';
+import {Button, Heading} from '@navikt/ds-react';
+import {XMarkIcon} from '@navikt/aksel-icons';
 import {SidebarTabInfo} from '../../store/sidebar/sidebar-view-store';
 import {logEvent} from '../../utils/frontend-logger';
 import {finnSideNavn} from '../../middleware/metrics-middleware';
-import {Heading} from '@navikt/ds-react';
 
 interface TabProps {
     tittel: string;
@@ -30,7 +30,12 @@ function SidebarTab({tittel, handleLukk, meta, children, tab}: TabProps) {
 
                 {meta && <div className="sidebar-header__meta">{meta}</div>}
 
-                <Lukknapp onClick={lukkTab} className="sidebar-header__lukknapp" />
+                <Button
+                    onClick={lukkTab}
+                    variant="tertiary-neutral"
+                    size="small"
+                    icon={<XMarkIcon title="Lukk panel" fontSize="1.5rem" />}
+                />
             </div>
             {children}
         </>

--- a/src/components/sidebar/sidebar.css
+++ b/src/components/sidebar/sidebar.css
@@ -88,8 +88,9 @@
     margin-left: 0.5rem;
 }
 .veilarbportefoljeflatefs .sidebar__content-container .sidebar-header__lukknapp {
-    width: 2.5rem;
+    width: 2.25rem;
     border: none;
+    margin-left: 0.25rem;
 }
 @media (max-height: 1250px) {
     .veilarbportefoljeflatefs .sidebar .sidebar__content-container .filtrering-filter,

--- a/src/components/sidebar/sidebar.css
+++ b/src/components/sidebar/sidebar.css
@@ -75,6 +75,7 @@
     margin-bottom: 1rem;
     justify-content: space-between;
     max-height: 320px;
+    column-gap: 0.25rem;
 }
 .veilarbportefoljeflatefs .sidebar__content-container .sidebar-header__tekst h2 {
     margin-bottom: 0;
@@ -86,11 +87,6 @@
 }
 .veilarbportefoljeflatefs .sidebar__content-container .sidebar-header__meta .toggle-switch {
     margin-left: 0.5rem;
-}
-.veilarbportefoljeflatefs .sidebar__content-container .sidebar-header__lukknapp {
-    width: 2.25rem;
-    border: none;
-    margin-left: 0.25rem;
 }
 @media (max-height: 1250px) {
     .veilarbportefoljeflatefs .sidebar .sidebar__content-container .filtrering-filter,

--- a/src/components/tabell/sortering-header-ikon.tsx
+++ b/src/components/tabell/sortering-header-ikon.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import {Button} from '@navikt/ds-react';
+import {ArrowDownIcon, ArrowsUpDownIcon, ArrowUpIcon} from '@navikt/aksel-icons';
 import {Sorteringsfelt, Sorteringsrekkefolge} from '../../model-interfaces';
 import {OrNothing} from '../../utils/types/types';
-import {Down, Up, UpDown} from '@navikt/ds-icons';
-import {Button} from '@navikt/ds-react';
 import './tabell.css';
 
 interface SorteringHeaderIkonProps {
@@ -34,11 +34,11 @@ function SorteringHeaderIkon({
     const sorteringspil = () => {
         const className = 'sorteringspil';
         if (sorteringsrekkefolge === Sorteringsrekkefolge.stigende) {
-            return <Up className={className} aria-hidden />;
+            return <ArrowUpIcon title="Sortert stigende" className={className} aria-hidden />;
         } else if (sorteringsrekkefolge === Sorteringsrekkefolge.synkende) {
-            return <Down className={className} aria-hidden />;
+            return <ArrowDownIcon title="Sortert synkende" className={className} aria-hidden />;
         } else {
-            return <UpDown className={className} aria-hidden />;
+            return <ArrowsUpDownIcon title="Sorter" className={className} aria-hidden />;
         }
     };
 

--- a/src/components/tabell/sortering-header.tsx
+++ b/src/components/tabell/sortering-header.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import classNames from 'classnames';
+import {Button} from '@navikt/ds-react';
+import {ArrowDownIcon, ArrowUpIcon} from '@navikt/aksel-icons';
 import {Sorteringsfelt, Sorteringsrekkefolge} from '../../model-interfaces';
 import Header, {HeaderProps} from './header';
 import './tabell.css';
 import {OrNothing} from '../../utils/types/types';
-import {Down, Up} from '@navikt/ds-icons';
-import {Button} from '@navikt/ds-react';
 
 interface SorteringHeaderProps extends HeaderProps {
     sortering: OrNothing<Sorteringsfelt>;
@@ -34,9 +34,9 @@ function SorteringHeader({
     const sorteringspil = () => {
         const className = 'sorteringheader__pil';
         if (sorteringsrekkefolge === Sorteringsrekkefolge.stigende) {
-            return <Up className={className} />;
+            return <ArrowUpIcon title="Sortert stigende" className={className} aria-hidden />;
         } else if (sorteringsrekkefolge === Sorteringsrekkefolge.synkende) {
-            return <Down className={className} />;
+            return <ArrowDownIcon title="Sortert synkende" className={className} aria-hidden />;
         } else {
             return null;
         }

--- a/src/components/tabell/tabell.css
+++ b/src/components/tabell/tabell.css
@@ -10,12 +10,13 @@
     height: 1rem;
     grid-column: 2;
     float: left;
-    margin: 2px 0 0 2px;
+    align-self: center;
+    margin-left: 0.125rem;
 }
 
 .veilarbportefoljeflatefs .sorteringspil {
     color: var(--a-icon-default);
-    width: 0.667em;
+    width: 0.667em; /* Tilsvarer 1rem */
 }
 
 .veilarbportefoljeflatefs .huskelapp__sorteringsheader .sorteringspil {

--- a/src/components/til-toppen-knapp/til-toppen-knapp.css
+++ b/src/components/til-toppen-knapp/til-toppen-knapp.css
@@ -21,10 +21,6 @@
 .veilarbportefoljeflatefs .til-toppen-knapp--skjul:hover {
     cursor: unset;
 }
-.veilarbportefoljeflatefs .til-toppen-knapp svg {
-    width: 22px;
-    height: 24px;
-}
 .veilarbportefoljeflatefs .til-toppen-knapp:focus {
     fill: #0074df;
 }

--- a/src/components/til-toppen-knapp/til-toppen-knapp.tsx
+++ b/src/components/til-toppen-knapp/til-toppen-knapp.tsx
@@ -1,11 +1,11 @@
 import React, {useEffect, useRef, useState} from 'react';
 import throttle from 'lodash.throttle';
 import classNames from 'classnames';
+import {Button} from '@navikt/ds-react';
+import {ArrowUpIcon} from '@navikt/aksel-icons';
 import './til-toppen-knapp.css';
 import {logEvent} from '../../utils/frontend-logger';
 import {finnSideNavn} from '../../middleware/metrics-middleware';
-import {Up} from '@navikt/ds-icons';
-import {Button} from '@navikt/ds-react';
 
 export const TilToppenKnapp = () => {
     const [scrollPosition, setScrollPosition] = useState<number | undefined>();
@@ -43,8 +43,8 @@ export const TilToppenKnapp = () => {
             ref={knappRef}
             hidden={!knappSkalVises}
             onClick={onClick}
-            icon={<Up />}
+            icon={<ArrowUpIcon title="Til toppen av sida" />}
             data-testid="til-toppen_knapp"
-        ></Button>
+        />
     );
 };

--- a/src/filtrering/filtrering-mine-filter/drag-and-drop/drag-and-drop.css
+++ b/src/filtrering/filtrering-mine-filter/drag-and-drop/drag-and-drop.css
@@ -30,11 +30,10 @@
     margin-top: 0.25rem;
 }
 .drag-and-drop-row {
-    height: 2rem;
-    padding: 0.2rem;
+    height: fit-content;
+    margin: 0.4rem 0.2rem;
     display: flex;
     align-items: center;
-    height: fit-content;
     cursor: grab;
     cursor: -moz-grab;
     cursor: -webkit-grab;
@@ -83,6 +82,7 @@
     display: grid;
     grid-template-columns: 2rem 2rem;
     margin-left: auto;
+    gap: 0.25rem;
 }
 .flytt-knapp_opp {
     grid-column: 1;
@@ -91,13 +91,15 @@
     grid-column: 2;
 }
 .flytt-knapp {
-    pointer-events: none;
     border-radius: 6px;
     border-style: solid;
     border-width: 2px;
     border-color: transparent;
     display: flex;
-    padding: 0.2rem 0.5rem;
+    padding: 0.2rem 0.4rem;
+}
+.flytt-knapp:hover {
+    background: var(--a-surface-hover);
 }
 .drag-and-drop-row #Symbols {
     visibility: hidden;

--- a/src/filtrering/filtrering-mine-filter/drag-and-drop/flytt-knapp-wrapper.tsx
+++ b/src/filtrering/filtrering-mine-filter/drag-and-drop/flytt-knapp-wrapper.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Down, Up} from '@navikt/ds-icons';
+import {ArrowDownIcon, ArrowUpIcon} from '@navikt/aksel-icons';
 
 export interface FlyttKnappWraperProps {
     showUpBtn: boolean;
@@ -20,7 +20,7 @@ function FlyttKnappWrapper({showUpBtn, showDownBtn, onClickUp, onClickDown, idx}
                     onClick={onClickUp}
                     data-testid={`flytt-knapp_opp_${idx}`}
                 >
-                    <Up />
+                    <ArrowUpIcon title="Flytt filter oppover" />
                 </div>
             ) : (
                 <></>
@@ -34,7 +34,7 @@ function FlyttKnappWrapper({showUpBtn, showDownBtn, onClickUp, onClickDown, idx}
                     onClick={onClickDown}
                     data-testid={`flytt-knapp_ned_${idx}`}
                 >
-                    <Down />
+                    <ArrowDownIcon title="Flytt filter nedover" />
                 </div>
             ) : (
                 <></>

--- a/src/filtrering/filtrering-mine-filter/toggle-switch/toggle-switch.css
+++ b/src/filtrering/filtrering-mine-filter/toggle-switch/toggle-switch.css
@@ -63,7 +63,7 @@
 }
 .toggle-switch-las__apen {
     position: absolute;
-    top: 0.2rem;
+    top: 0.25rem;
     left: 0.4rem;
     bottom: 0.192rem;
     visibility: hidden;
@@ -71,7 +71,7 @@
 }
 .toggle-switch-las__lukked {
     position: absolute;
-    top: 0.2rem;
+    top: 0.25rem;
     left: 1.537rem;
     bottom: 0.192rem;
     visibility: hidden;

--- a/src/filtrering/filtrering-mine-filter/toggle-switch/toggle-switch.css
+++ b/src/filtrering/filtrering-mine-filter/toggle-switch/toggle-switch.css
@@ -49,7 +49,7 @@
 .toggle-switch-border {
     width: 100%;
     height: 100%;
-    top: 0px;
+    top: 0;
     position: absolute;
     border-radius: 1.6rem;
     box-sizing: border-box;
@@ -67,7 +67,6 @@
     left: 0.4rem;
     bottom: 0.192rem;
     visibility: hidden;
-    color: var(--a-text-on-inverted);
 }
 .toggle-switch-las__lukked {
     position: absolute;

--- a/src/filtrering/filtrering-mine-filter/toggle-switch/toggle-switch.css
+++ b/src/filtrering/filtrering-mine-filter/toggle-switch/toggle-switch.css
@@ -3,6 +3,8 @@
     display: inline-block;
     width: 2.9rem;
     height: 1.6rem;
+    color: var(--a-text-on-inverted);
+    cursor: pointer;
 }
 .toggle-switch .toggle-input {
     opacity: 0;
@@ -11,12 +13,11 @@
 }
 .switch-slider {
     position: absolute;
-    cursor: pointer;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: #ccc;
+    background-color: var(--a-surface-neutral);
     border-radius: 1.6rem;
 }
 .switch-slider:before {
@@ -32,13 +33,13 @@
     border-radius: 50%;
 }
 .toggle-input:checked + .switch-slider {
-    background-color: #0067c5;
+    background-color: var(--a-blue-700); /* --a-surface-action-selected */
 }
 .toggle-input:hover + .switch-slider {
-    background-color: #99b3ca;
+    background-color: var(--a-surface-neutral-hover);
 }
 .toggle-input:checked:hover + .switch-slider {
-    background-color: #3380c7;
+    background-color: var(--a-blue-800); /* --a-surface-action-selected-hover */
 }
 .toggle-input:checked + .switch-slider:before {
     -webkit-transform: translateX(1.223rem);
@@ -53,8 +54,9 @@
     border-radius: 1.6rem;
     box-sizing: border-box;
 }
-.toggle-input:focus ~ .toggle-switch-border {
-    border: 2px solid #00347d;
+.toggle-input:focus-visible ~ .toggle-switch-border {
+    outline: 2px solid var(--a-border-focus);
+    outline-offset: 2px;
 }
 .toggle-switch-las {
     cursor: pointer;
@@ -62,9 +64,10 @@
 .toggle-switch-las__apen {
     position: absolute;
     top: 0.2rem;
-    left: 0.203rem;
+    left: 0.4rem;
     bottom: 0.192rem;
     visibility: hidden;
+    color: var(--a-text-on-inverted);
 }
 .toggle-switch-las__lukked {
     position: absolute;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,6 @@ import 'nav-frontend-chevron-style/dist/main.css';
 import 'nav-frontend-ekspanderbartpanel-style/dist/main.css';
 import 'nav-frontend-grid-style/dist/main.css';
 import 'nav-frontend-lenker-style/dist/main.css';
-import 'nav-frontend-lukknapp-style/dist/main.css';
 import 'nav-frontend-paneler-style/dist/main.css';
 import 'nav-frontend-skjema-style/dist/main.css';
 import 'nav-frontend-typografi-style/dist/main.css';

--- a/src/veiledere/veiledere-tabell.tsx
+++ b/src/veiledere/veiledere-tabell.tsx
@@ -51,11 +51,15 @@ function VeilederTabell({
         if (sorterPaa) {
             if (currentSortering.direction === 'stigende') {
                 return (
-                    <ArrowUpIcon title="Sorter stigende" className={className} data-testid="sorteringspil_stigende" />
+                    <ArrowUpIcon title="Sortert stigende" className={className} data-testid="sorteringspil_stigende" />
                 );
             } else if (currentSortering.direction === 'synkende') {
                 return (
-                    <ArrowDownIcon title="Sorter synkende" className={className} data-testid="sorteringspil_synkende" />
+                    <ArrowDownIcon
+                        title="Sortert synkende"
+                        className={className}
+                        data-testid="sorteringspil_synkende"
+                    />
                 );
             }
         }

--- a/src/veiledere/veiledere-tabell.tsx
+++ b/src/veiledere/veiledere-tabell.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import classNames from 'classnames';
 import {Link} from 'react-router-dom';
-import './veiledere.css';
-import {Down, Up} from '@navikt/ds-icons';
+import classNames from 'classnames';
 import {BodyShort, Button} from '@navikt/ds-react';
+import {ArrowDownIcon, ArrowUpIcon} from '@navikt/aksel-icons';
+import './veiledere.css';
 
 interface VeiledereTabellProps {
     veiledere: any;
@@ -50,9 +50,13 @@ function VeilederTabell({
         const className = 'tabellheader__pil';
         if (sorterPaa) {
             if (currentSortering.direction === 'stigende') {
-                return <Up className={className} data-testid="sorteringspil_stigende" />;
+                return (
+                    <ArrowUpIcon title="Sorter stigende" className={className} data-testid="sorteringspil_stigende" />
+                );
             } else if (currentSortering.direction === 'synkende') {
-                return <Down className={className} data-testid="sorteringspil_synkende" />;
+                return (
+                    <ArrowDownIcon title="Sorter synkende" className={className} data-testid="sorteringspil_synkende" />
+                );
             }
         }
         return null;
@@ -67,7 +71,7 @@ function VeilederTabell({
                             <th scope="col" className="tabellheader">
                                 <div className="tabellheader__lenke tabellheader__tekst">
                                     <Button
-                                        size="small"
+                                        size="xsmall"
                                         variant="tertiary"
                                         onClick={sorterPaaEtternavn}
                                         className={classNames('lenke lenke--frittstaende', {
@@ -95,7 +99,7 @@ function VeilederTabell({
                                     data-testid="veilederoversikt_sortering_antall-brukere"
                                 >
                                     <Button
-                                        size="small"
+                                        size="xsmall"
                                         variant="tertiary"
                                         onClick={sorterPaaPortefoljestorrelse}
                                         className={classNames('lenke lenke--frittstaende tabellheader__tekst', {


### PR DESCRIPTION
## Kva har blitt gjort

Denne PR-en er i all hovudsak bytting av pil-ikon frå @navikt-ds-icons til @navikt-aksel-icons, med andre ord "frå dei mellomgamle ikona til dei nyaste".

Lukk-knappen for filterpanelet er bytta ut med knapp + ikon frå det nyaste designsystemet. Avhengigheiter til `navikt-frontend-lukknapp` og tilhøyrande styling er fjerna.

## Anna småfiks og før/etter-bilete:


### Ting er no på linje i tabelloverskrifta i veilederoversikten

#### Før:

![Screenshot 2024-03-20 at 11 45 36](https://github.com/navikt/veilarbportefoljeflatefs/assets/26256569/0b73e053-c250-42c7-9c26-8db34daa5457)

#### Etter: 
![Screenshot 2024-03-20 at 11 48 09](https://github.com/navikt/veilarbportefoljeflatefs/assets/26256569/f098a6b2-217b-4c55-8f40-711cfa5d6593)


### Toggle-låsing-av-filter-knapp har fått litt kjærleik
Og er no litt mindre UU-uvennleg reint fargemessig. Den er også likare toggle-knappen i designsystemet no.

#### Før
![Screenshot 2024-03-21 at 08 58 34](https://github.com/navikt/veilarbportefoljeflatefs/assets/26256569/de3aab32-16ba-4e27-a134-7f64d3a716bf)
![Screenshot 2024-03-21 at 08 58 42](https://github.com/navikt/veilarbportefoljeflatefs/assets/26256569/5afe4031-455a-4cc5-b500-1e6e3d638e0b)

#### Etter
![Screenshot 2024-03-21 at 08 57 39](https://github.com/navikt/veilarbportefoljeflatefs/assets/26256569/b718cd07-ccdd-4d62-a0c9-72ddbac6c1ca)
![Screenshot 2024-03-21 at 08 57 34](https://github.com/navikt/veilarbportefoljeflatefs/assets/26256569/b629a628-9945-430e-ad7c-72a447debba7)

