### PR TITLE
Byttar ut eit u-mønster i Cypress-testar der vi lagrar verdiar i variablar

### DIFF
--- a/cypress/e2e/arbeidsliste_spec.js
+++ b/cypress/e2e/arbeidsliste_spec.js
@@ -8,17 +8,10 @@ before('Start server', () => {
 });
 
 describe('Arbeidsliste', () => {
-    let fornavn = '';
-    let antallMedArbeidsliste = 0;
-    let antallMedArbeidslisteEtterOppretting = 0;
     let tittel;
     let kommentar;
-    let antallFor = 0;
-    let antallEtter = 0;
     const redigertTittel = 'Redigering av tittel';
     const redigertKommentar = 'Redigering av kommentar';
-    let antallForSletting = 0;
-    let antallEtterSletting = 0;
     const nyTittel = 'Skal ikke lagres';
     const nyKommentar = 'Kommentar skal heller ikke lagres';
 
@@ -56,80 +49,72 @@ describe('Arbeidsliste', () => {
         // Lagrar ikkje arbeidslista i denne testen
     });
 
-    it('Lagre fornavn til valgt bruker', () => {
-        cy.getByTestId('modal_legg-i-arbeidsliste_navn').then($navn => {
-            fornavn = $navn.text().split(' ')[0];
+    it('Lagre ny arbeidsliste', () => {
+        cy.getByTestId('modal_legg-i-arbeidsliste_navn').then(($navn) => {
+            // Hugsar fornamnet til brukaren vi har valgt
+            const fornavn = $navn.text().split(' ')[0];
+
+            // Lagre innholdet som vart skrive inn i test "Lag én ny arbeidsliste og sjekk validering"
+            cy.getByTestId('modal_arbeidsliste_lagre-knapp').click();
+
+            // Laster-modal
+            cy.get('.veilarbportefoljeflatefs-laster-modal').should('be.visible');
+            cy.get('.veilarbportefoljeflatefs-laster-modal').should('not.exist');
+
+            // Sjekk at brukaren er i lista
+            cy.get('.legg-i-arbeidsliste_modal').should('not.exist');
+            cy.getByTestId('brukerliste_element_arbeidsliste-GUL').contains(fornavn).first();
         });
     });
 
-    it('Lagre ny arbeidsliste', () => {
-        // Lagre innholdet som vart skrive inn i test "Lag én ny arbeidsliste og sjekk validering"
-        cy.getByTestId('modal_arbeidsliste_lagre-knapp').click();
-
-        // Laster-modal
-        cy.get('.veilarbportefoljeflatefs-laster-modal').should('be.visible');
-        cy.get('.veilarbportefoljeflatefs-laster-modal').should('not.exist');
-
-        // Sjekk at brukaren er i lista
-        cy.get('.legg-i-arbeidsliste_modal').should('not.exist');
-        cy.getByTestId('brukerliste_element_arbeidsliste-GUL').contains(fornavn).first();
-    });
-
-    it('Lagre antall med arbeidsliste', () => {
-        cy.get('[data-cy=brukerliste_element_arbeidsliste]')
-            .then(ant => {
-                antallMedArbeidsliste += Cypress.$(ant).length;
-            })
-            .then(() => {
-                expect(antallMedArbeidsliste).to.be.greaterThan(0);
-            });
-    });
-
     it('Lag to nye arbeidslister', () => {
-        // Vel fyrste og siste brukar i arbeidslista
-        cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
-        cy.checkboxFirst('min-oversikt_brukerliste-checkbox');
-        cy.checkboxLast('min-oversikt_brukerliste-checkbox');
+        // Finn alle brukarar som har arbeidslister før nye er oppretta
+        cy.get('[data-cy=brukerliste_element_arbeidsliste]').then(elementIArbeidslisteFor => {
+            // Sjekk at vi fann nokon element
+            expect(elementIArbeidslisteFor.length).to.be.greaterThan(0);
 
-        // Opne legg-til-i-arbeidsliste-modal
-        cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
-        cy.get('.legg-i-arbeidsliste_modal').should('not.exist');
-        cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled').click();
-        cy.get('.legg-i-arbeidsliste_modal').should('be.visible');
+            // Vel fyrste og siste brukar i arbeidslista
+            cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
+            cy.checkboxFirst('min-oversikt_brukerliste-checkbox');
+            cy.checkboxLast('min-oversikt_brukerliste-checkbox');
 
-        // Fyll ut innhald for fyrste brukar
-        cy.getByTestId('modal_arbeidsliste_tittel').type('arbeidslistetittel');
-        cy.getByTestId('modal_arbeidsliste_kommentar').type('arbeidslistekommentar');
-        cy.getByTestId('modal_arbeidslistekategori_LILLA').click();
+            // Opne legg-til-i-arbeidsliste_modal
+            cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
+            cy.get('.legg-i-arbeidsliste_modal').should('not.exist');
+            cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled').click();
+            cy.get('.legg-i-arbeidsliste_modal').should('be.visible');
 
-        // Fyll ut innhald for andre brukar
-        cy.getByTestId('modal_arbeidsliste_tittel_1').type('heiheihei hallå');
-        cy.getByTestId('modal_arbeidsliste_kommentar_1').type('Team Voff er best i test hehehe');
+            // Fyll ut innhald for fyrste brukar
+            cy.getByTestId('modal_arbeidsliste_tittel').type('arbeidslistetittel');
+            cy.getByTestId('modal_arbeidsliste_kommentar').type('arbeidslistekommentar');
+            cy.getByTestId('modal_arbeidslistekategori_LILLA').click();
 
-        // Lagre arbeidslistene
-        cy.getByTestId('modal_arbeidsliste_lagre-knapp').click();
+            // Fyll ut innhald for andre brukar
+            cy.getByTestId('modal_arbeidsliste_tittel_1').type('heiheihei hallå');
+            cy.getByTestId('modal_arbeidsliste_kommentar_1').type('Team Voff er best i test hehehe');
 
-        // Sjekk at modal er lukka og laster-modal fungerer
-        cy.get('.legg-i-arbeidsliste_modal').should('not.exist');
-        cy.get('.veilarbportefoljeflatefs-laster-modal').should('be.visible');
-        cy.get('.veilarbportefoljeflatefs-laster-modal').should('not.exist');
+            // Lagre arbeidslistene
+            cy.getByTestId('modal_arbeidsliste_lagre-knapp').click();
 
-        // Sjekk at det no er 2 fleire personar med arbeidsliste
-        cy.get('[data-cy=brukerliste_element_arbeidsliste]')
-            .then(ant => {
-                antallMedArbeidslisteEtterOppretting += Cypress.$(ant).length;
-            })
-            .then(() => {
-                expect(antallMedArbeidslisteEtterOppretting).to.be.equals(antallMedArbeidsliste + 2);
-            });
+            // Sjekk at modal er lukka og laster-modal fungerer
+            cy.get('.legg-i-arbeidsliste_modal').should('not.exist');
+            cy.get('.veilarbportefoljeflatefs-laster-modal').should('be.visible');
+            cy.get('.veilarbportefoljeflatefs-laster-modal').should('not.exist');
+
+            // Samanlikn talet på brukarar med arbeidslister før og etter at ein har oppretta nye
+            cy.get('[data-cy=brukerliste_element_arbeidsliste]')
+                .then((elementIArbeidslisteEtter) => {
+                    expect(elementIArbeidslisteEtter.length).to.equal(elementIArbeidslisteFor.length + 2);
+                });
+        });
     });
 
     it('Sjekker åpning og lukking av arbeidslistepanel i oversikten', () => {
         cy.apneForsteArbeidslistepanelOgValiderApning();
-        cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_tittel').should('be.visible')
+        cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_tittel').should('be.visible');
 
         cy.lukkForsteArbeidslistepanelOgValiderLukking();
-    })
+    });
 
 
     it('Rediger arbeidsliste', () => {
@@ -159,66 +144,58 @@ describe('Arbeidsliste', () => {
 
     it('Slett arbeidsliste via fjern-knapp', () => {
         // Tel kor mange arbeidslister det er
-        cy.get('[data-cy=brukerliste_element_arbeidsliste]').then(ant => {
-            antallFor += Cypress.$(ant).length;
+        cy.get('[data-cy=brukerliste_element_arbeidsliste]').then(antallArbeidslisterForSletting => {
+            // Finn checkboksen til den fyrste personen med arbeidsliste
+            cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
+            cy.checkboxFirst('min-oversikt_brukerliste-checkbox_arbeidsliste');
+
+            // Fjern personen frå arbeidslista
+            cy.getByTestId('fjern-fra-arbeidsliste_knapp').should('be.enabled').click();
+            cy.getByTestId('modal_varsel_fjern-fra-arbeidsliste_bekreft-knapp').should('be.visible').click();
+
+            // Laster-modal oppfører seg som venta
+            cy.get('.veilarbportefoljeflatefs-laster-modal').should('be.visible');
+            cy.get('.veilarbportefoljeflatefs-laster-modal').should('not.exist');
+            cy.getByTestId('modal_varsel_fjern-fra-arbeidsliste_bekreft-knapp').should('not.exist');
+
+            // Sjekk at det er 1 færre arbeidslister no enn før slettinga
+            cy.get('[data-cy=brukerliste_element_arbeidsliste]')
+                .should('be.visible')
+                .then(antallArbeidslisterEtterSletting => {
+                    expect(antallArbeidslisterEtterSletting.length)
+                        .to.equal(antallArbeidslisterForSletting.length - 1);
+                });
         });
-
-        // Finn checkboksen til den fyrste personen med arbeidsliste
-        cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
-        cy.checkboxFirst('min-oversikt_brukerliste-checkbox_arbeidsliste');
-
-        // Fjern personen frå arbeidslista
-        cy.getByTestId('fjern-fra-arbeidsliste_knapp').should('be.enabled').click();
-        cy.getByTestId('modal_varsel_fjern-fra-arbeidsliste_bekreft-knapp').should('be.visible').click();
-
-        // Laster-modal oppfører seg som venta
-        cy.get('.veilarbportefoljeflatefs-laster-modal').should('be.visible');
-        cy.get('.veilarbportefoljeflatefs-laster-modal').should('not.exist');
-        cy.getByTestId('modal_varsel_fjern-fra-arbeidsliste_bekreft-knapp').should('not.exist');
-
-        // Sjekk at det er 1 færre arbeidslister no enn før slettinga
-        cy.get('[data-cy=brukerliste_element_arbeidsliste]')
-            .should('be.visible')
-            .then(ant => {
-                antallEtter += Cypress.$(ant).length;
-            })
-            .then(() => {
-                expect(antallEtter).to.be.equals(antallFor - 1);
-            });
     });
 
     it('Slett arbeidsliste via rediger-modal', () => {
-        // Tel kor mange arbeidslister det er
-        cy.get('[data-cy=brukerliste_element_arbeidsliste]').then(ant => {
-            antallForSletting += Cypress.$(ant).length;
+        // Hentar brukarane med arbeidslister før sletting
+        cy.get('[data-cy=brukerliste_element_arbeidsliste]').then(antallArbeidslisterForSletting => {
+            // Opne arbeidslistepanel for den fyrste brukaren som har arbeidsliste
+            cy.apneForsteArbeidslistepanel();
+            cy.get('.arbeidsliste-modal').should('not.exist');
+
+            // Trykk på redigeringsknapp
+            cy.getByTestId('min-oversikt_arbeidslistepanel-arbeidsliste_rediger-knapp').click();
+            cy.get('.arbeidsliste-modal').should('be.visible');
+
+            // Fjern arbeidslista
+            cy.getByTestId('modal_rediger-arbeidsliste_fjern-knapp').click();
+            cy.getByTestId('modal_varsel_fjern-fra-arbeidsliste_bekreft-knapp').should('be.visible').click();
+
+            // Laster-modal oppfører seg som venta
+            cy.get('.veilarbportefoljeflatefs-laster-modal').should('be.visible');
+            cy.getByTestId('modal_varsel_fjern-fra-arbeidsliste_bekreft-knapp').should('not.exist');
+            cy.get('.veilarbportefoljeflatefs-laster-modal').should('not.exist');
+
+            // Sjekk at det er 1 færre arbeidslister no enn før slettinga
+            cy.get('[data-cy=brukerliste_element_arbeidsliste]')
+                .should('be.visible')
+                .then(antallArbeidslisterEtterSletting => {
+                    expect(antallArbeidslisterEtterSletting.length)
+                        .to.equal(antallArbeidslisterForSletting.length - 1);
+                });
         });
-
-        // Opne arbeidslistepanel for den fyrste brukaren som har arbeidsliste
-        cy.apneForsteArbeidslistepanel();
-        cy.get('.arbeidsliste-modal').should('not.exist');
-
-        // Trykk på redigeringsknapp
-        cy.getByTestId('min-oversikt_arbeidslistepanel-arbeidsliste_rediger-knapp').click();
-        cy.get('.arbeidsliste-modal').should('be.visible');
-
-        // Fjern arbeidslista
-        cy.getByTestId('modal_rediger-arbeidsliste_fjern-knapp').click();
-        cy.getByTestId('modal_varsel_fjern-fra-arbeidsliste_bekreft-knapp').should('be.visible').click();
-
-        // Laster-modal oppfører seg som venta
-        cy.get('.veilarbportefoljeflatefs-laster-modal').should('be.visible');
-        cy.getByTestId('modal_varsel_fjern-fra-arbeidsliste_bekreft-knapp').should('not.exist');
-        cy.get('.veilarbportefoljeflatefs-laster-modal').should('not.exist');
-
-        // Sjekk at det er 1 færre arbeidslister no enn før slettinga
-        cy.get('[data-cy=brukerliste_element_arbeidsliste]')
-            .should('be.visible')
-            .then(ant => {
-                antallEtterSletting += Cypress.$(ant).length;
-            })
-            .then(() => {
-                expect(antallEtterSletting).to.be.equals(antallForSletting - 1);
-            });
     });
 
     it('Sjekk validering i rediger arbeidsliste-modal', () => {

--- a/cypress/e2e/arbeidsliste_spec.js
+++ b/cypress/e2e/arbeidsliste_spec.js
@@ -8,13 +8,6 @@ before('Start server', () => {
 });
 
 describe('Arbeidsliste', () => {
-    let tittel;
-    let kommentar;
-    const redigertTittel = 'Redigering av tittel';
-    const redigertKommentar = 'Redigering av kommentar';
-    const nyTittel = 'Skal ikke lagres';
-    const nyKommentar = 'Kommentar skal heller ikke lagres';
-
     it('Lag én ny arbeidsliste og sjekk validering', () => {
         // Vel fyrste brukar i lista
         cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
@@ -118,6 +111,9 @@ describe('Arbeidsliste', () => {
 
 
     it('Rediger arbeidsliste', () => {
+        const redigertTittel = 'Redigering av tittel';
+        const redigertKommentar = 'Redigering av kommentar';
+
         // Finn den fyrste personen med arbeidsliste, trykk på chevron og sjekk at det fungerte
         cy.apneForsteArbeidslistepanel();
 
@@ -249,35 +245,33 @@ describe('Arbeidsliste', () => {
         cy.lukkForsteArbeidslistepanel();
     });
 
-    it('Lagre tittel og kommentar', () => {
+    it('Avbryt redigering, ingen endringer lagret', () => {
         cy.apneForsteArbeidslistepanel();
 
-        cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_tittel').then($tittel => {
-            tittel = $tittel.text();
+        // Finn tittel-elementet
+        cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_tittel').then(tittelForRedigering => {
+            // Finn kommentar-elementet også
+            cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_kommentar').then(kommentarForRedigering => {
+                const nyTittel = 'Skal ikke lagres';
+                const nyKommentar = 'Kommentar skal heller ikke lagres';
+
+                // Trykkar på rediger-knapp
+                cy.get('.arbeidsliste-modal').should('not.exist');
+                cy.getByTestId('min-oversikt_arbeidslistepanel-arbeidsliste_rediger-knapp').click();
+                cy.get('.arbeidsliste-modal').should('be.visible');
+
+                // Skriv inn ny tekst i modalen
+                cy.getByTestId('modal_arbeidsliste_tittel').clear().type(nyTittel);
+                cy.getByTestId('modal_arbeidsliste_kommentar').clear().type(nyKommentar);
+
+                // Trykkar "Avbryt"
+                cy.getByTestId('modal_rediger-arbeidsliste_avbryt-knapp').click();
+
+                // Sjekkar at teksten ikkje vart endra
+                cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_tittel').should('contain', tittelForRedigering.text());
+                cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_kommentar').should('contain', kommentarForRedigering.text());
+            })
         });
-        cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_kommentar').then($kommentar => {
-            kommentar = $kommentar.text();
-        });
-    });
-
-    it('Avbryt redigering, ingen endringer lagret', () => {
-        // Arbeidslistepanelet er allereie opent frå førre test
-
-        // Trykkar på rediger-knapp
-        cy.get('.arbeidsliste-modal').should('not.exist');
-        cy.getByTestId('min-oversikt_arbeidslistepanel-arbeidsliste_rediger-knapp').click();
-        cy.get('.arbeidsliste-modal').should('be.visible');
-
-        // Skriv inn ny tekst i modalen
-        cy.getByTestId('modal_arbeidsliste_tittel').clear().type(nyTittel);
-        cy.getByTestId('modal_arbeidsliste_kommentar').clear().type(nyKommentar);
-
-        // Trykkar "Avbryt"
-        cy.getByTestId('modal_rediger-arbeidsliste_avbryt-knapp').click();
-
-        // Sjekkar at teksten ikkje vart endra
-        cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_tittel').should('contain', tittel);
-        cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_kommentar').should('contain', kommentar);
 
         cy.lukkForsteArbeidslistepanel();
     });

--- a/cypress/e2e/arbeidsliste_spec.js
+++ b/cypress/e2e/arbeidsliste_spec.js
@@ -29,20 +29,22 @@ describe('Arbeidsliste', () => {
         cy.getByTestId('modal_arbeidsliste_form').contains('Du må korte ned teksten til 500 tegn');
         cy.getByTestId('modal_arbeidsliste_form').should('not.contain', 'Du må fylle ut en kommentar');
 
+        cy.getByTestId('modal_arbeidsliste_avbryt-knapp').click();
+    });
+
+    it('Lagre ny arbeidsliste', () => {
+        // Opnar "Legg i arbeidsliste"-modal igjen
+        cy.checkboxFirst('min-oversikt_brukerliste-checkbox');
+        cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled').click();
+
         // Nullstillar tittel og kommentar og skriv inn gyldig input
-        cy.getByTestId('modal_arbeidsliste_tittel').clear();
         cy.getByTestId('modal_arbeidsliste_tittel').type('validering');
-        cy.getByTestId('modal_arbeidsliste_kommentar').clear();
         cy.getByTestId('modal_arbeidsliste_kommentar').type('valideringskommentar');
 
         // Set ein frist og kategori
         cy.get('#fristDatovelger').type('01.03.2066');
         cy.getByTestId('modal_arbeidslistekategori_GUL').click();
 
-        // Lagrar ikkje arbeidslista i denne testen
-    });
-
-    it('Lagre ny arbeidsliste', () => {
         cy.getByTestId('modal_legg-i-arbeidsliste_navn').then(($navn) => {
             // Hugsar fornamnet til brukaren vi har valgt
             const fornavn = $navn.text().split(' ')[0];
@@ -270,7 +272,7 @@ describe('Arbeidsliste', () => {
                 // Sjekkar at teksten ikkje vart endra
                 cy.get('@tittel').should('contain', tittelForRedigering.text());
                 cy.get('@kommentar').should('contain', kommentarForRedigering.text());
-            })
+            });
         });
 
         cy.lukkForsteArbeidslistepanel();

--- a/cypress/e2e/arbeidsliste_spec.js
+++ b/cypress/e2e/arbeidsliste_spec.js
@@ -61,8 +61,8 @@ describe('Arbeidsliste', () => {
     });
 
     it('Lag to nye arbeidslister', () => {
-        // Finn alle brukarar som har arbeidslister før nye er oppretta
-        cy.get('[data-cy=brukerliste_element_arbeidsliste]').then(elementIArbeidslisteFor => {
+        // Finn alle brukarar som har arbeidslister frå før
+        cy.get('[data-cy=brukerliste_element_arbeidsliste]').as('elementIArbeidsliste').then(elementIArbeidslisteFor => {
             // Sjekk at vi fann nokon element
             expect(elementIArbeidslisteFor.length).to.be.greaterThan(0);
 
@@ -95,7 +95,7 @@ describe('Arbeidsliste', () => {
             cy.get('.veilarbportefoljeflatefs-laster-modal').should('not.exist');
 
             // Samanlikn talet på brukarar med arbeidslister før og etter at ein har oppretta nye
-            cy.get('[data-cy=brukerliste_element_arbeidsliste]')
+            cy.get('@elementIArbeidsliste')
                 .then((elementIArbeidslisteEtter) => {
                     expect(elementIArbeidslisteEtter.length).to.equal(elementIArbeidslisteFor.length + 2);
                 });
@@ -140,7 +140,7 @@ describe('Arbeidsliste', () => {
 
     it('Slett arbeidsliste via fjern-knapp', () => {
         // Tel kor mange arbeidslister det er
-        cy.get('[data-cy=brukerliste_element_arbeidsliste]').then(antallArbeidslisterForSletting => {
+        cy.get('[data-cy=brukerliste_element_arbeidsliste]').as('elementIArbeidsliste').then(antallArbeidslisterForSletting => {
             // Finn checkboksen til den fyrste personen med arbeidsliste
             cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
             cy.checkboxFirst('min-oversikt_brukerliste-checkbox_arbeidsliste');
@@ -155,7 +155,7 @@ describe('Arbeidsliste', () => {
             cy.getByTestId('modal_varsel_fjern-fra-arbeidsliste_bekreft-knapp').should('not.exist');
 
             // Sjekk at det er 1 færre arbeidslister no enn før slettinga
-            cy.get('[data-cy=brukerliste_element_arbeidsliste]')
+            cy.get('@elementIArbeidsliste')
                 .should('be.visible')
                 .then(antallArbeidslisterEtterSletting => {
                     expect(antallArbeidslisterEtterSletting.length)
@@ -166,7 +166,7 @@ describe('Arbeidsliste', () => {
 
     it('Slett arbeidsliste via rediger-modal', () => {
         // Hentar brukarane med arbeidslister før sletting
-        cy.get('[data-cy=brukerliste_element_arbeidsliste]').then(antallArbeidslisterForSletting => {
+        cy.get('[data-cy=brukerliste_element_arbeidsliste]').as('elementIArbeidsliste').then(antallArbeidslisterForSletting => {
             // Opne arbeidslistepanel for den fyrste brukaren som har arbeidsliste
             cy.apneForsteArbeidslistepanel();
             cy.get('.arbeidsliste-modal').should('not.exist');
@@ -185,7 +185,7 @@ describe('Arbeidsliste', () => {
             cy.get('.veilarbportefoljeflatefs-laster-modal').should('not.exist');
 
             // Sjekk at det er 1 færre arbeidslister no enn før slettinga
-            cy.get('[data-cy=brukerliste_element_arbeidsliste]')
+            cy.get('@elementIArbeidsliste')
                 .should('be.visible')
                 .then(antallArbeidslisterEtterSletting => {
                     expect(antallArbeidslisterEtterSletting.length)
@@ -249,9 +249,9 @@ describe('Arbeidsliste', () => {
         cy.apneForsteArbeidslistepanel();
 
         // Finn tittel-elementet
-        cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_tittel').then(tittelForRedigering => {
+        cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_tittel').as('tittel').then(tittelForRedigering => {
             // Finn kommentar-elementet også
-            cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_kommentar').then(kommentarForRedigering => {
+            cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_kommentar').as('kommentar').then(kommentarForRedigering => {
                 const nyTittel = 'Skal ikke lagres';
                 const nyKommentar = 'Kommentar skal heller ikke lagres';
 
@@ -268,8 +268,8 @@ describe('Arbeidsliste', () => {
                 cy.getByTestId('modal_rediger-arbeidsliste_avbryt-knapp').click();
 
                 // Sjekkar at teksten ikkje vart endra
-                cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_tittel').should('contain', tittelForRedigering.text());
-                cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_kommentar').should('contain', kommentarForRedigering.text());
+                cy.get('@tittel').should('contain', tittelForRedigering.text());
+                cy.get('@kommentar').should('contain', kommentarForRedigering.text());
             })
         });
 

--- a/cypress/e2e/arbeidslistestatus_spec.js
+++ b/cypress/e2e/arbeidslistestatus_spec.js
@@ -23,7 +23,7 @@ describe('Filter min arbeidsliste', () => {
 
     it('Legg til person i lilla arbeidsliste', () => {
         // Hentar ut kor mange som er i Lilla arbeidsliste i starten av testen
-        cy.getByTestId('filter_checkboks-label_minArbeidslisteLilla').then(antallILillaArbeidslisteFor => {
+        cy.getByTestId('filter_checkboks-label_minArbeidslisteLilla').as('lillaArbeidslistetall').then(antallILillaArbeidslisteFor => {
             // Nullstill valg av filter "min arbeidsliste"
             cy.scrollTo('top');
             cy.getByTestId('filtreringlabel_min-arbeidsliste').click();
@@ -35,10 +35,9 @@ describe('Filter min arbeidsliste', () => {
             cy.checkboxFirst('min-oversikt_brukerliste-checkbox');
 
             // Legg dei til i arbeidslista
-            cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
-            cy.getByTestId('legg-i-arbeidsliste_knapp').click();
+            cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled').click();
 
-            // Gjer ting i modal
+            // Gjer ting i modal og lagre det (tittel, kommentar, fargekategori = lilla)
             cy.getByTestId('modal_arbeidsliste_tittel').type('arbeidslistetittel');
             cy.getByTestId('modal_arbeidsliste_kommentar').type('arbeidslistekommentar');
             cy.getByTestId('modal_arbeidslistekategori_LILLA').click();
@@ -50,7 +49,7 @@ describe('Filter min arbeidsliste', () => {
 
             // Sjekk at det no er ein meir person i lilla arbeidsliste
             cy.getByTestId('filter_checkboks-container_minArbeidsliste').click();
-            cy.getByTestId('filter_checkboks-label_minArbeidslisteLilla').then(antallILillaArbeidslisteEtter => {
+            cy.get('@lillaArbeidslistetall').then(antallILillaArbeidslisteEtter => {
                 expect(parseInt(antallILillaArbeidslisteEtter.text()))
                     .to.equal(parseInt(antallILillaArbeidslisteFor.text()) + 1);
             });

--- a/cypress/e2e/arbeidslistestatus_spec.js
+++ b/cypress/e2e/arbeidslistestatus_spec.js
@@ -4,10 +4,11 @@ before('Start server', () => {
     cy.configure();
 });
 
-describe('Filter min arbeidsliste', () => {
-    beforeEach('Gå til Min oversikt', () => {
-        cy.gaTilOversikt('min-oversikt');
-    });
+beforeEach('Gå til Min oversikt', () => {
+    cy.gaTilOversikt('min-oversikt');
+});
+
+describe('Arbeidslistestatus', () => {
 
     it('Sjekk tekst på legg til i / fjern fra arbeidslisteknapp', () => {
         // Sjekkar at rett knapp er synleg frå start

--- a/cypress/e2e/arbeidslistestatus_spec.js
+++ b/cypress/e2e/arbeidslistestatus_spec.js
@@ -5,8 +5,6 @@ before('Start server', () => {
 });
 
 describe('Filter min arbeidsliste', () => {
-    let antallFor = '';
-
     beforeEach('Gå til Min oversikt', () => {
         cy.gaTilOversikt('min-oversikt');
     });
@@ -24,39 +22,38 @@ describe('Filter min arbeidsliste', () => {
     });
 
     it('Legg til person i lilla arbeidsliste', () => {
-        // Tell kor mange som er i Lilla arbeidsliste i starten av testen
-        cy.getByTestId('filter_checkboks-label_minArbeidslisteLilla').then($tall => {
-            antallFor = $tall.text();
-        });
+        // Hentar ut kor mange som er i Lilla arbeidsliste i starten av testen
+        cy.getByTestId('filter_checkboks-label_minArbeidslisteLilla').then(antallILillaArbeidslisteFor => {
+            // Nullstill valg av filter "min arbeidsliste"
+            cy.scrollTo('top');
+            cy.getByTestId('filtreringlabel_min-arbeidsliste').click();
+            cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
 
-        // Nullstill valg av filter "min arbeidsliste"
-        cy.scrollTo('top');
-        cy.getByTestId('filtreringlabel_min-arbeidsliste').click();
-        cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
+            // Vel ein brukar som skal leggast til i arbeidsliste
+            cy.scrollTo('top');
+            cy.wait(200);
+            cy.checkboxFirst('min-oversikt_brukerliste-checkbox');
 
-        // Vel ein brukar som skal leggast til i arbeidsliste
-        cy.scrollTo('top');
-        cy.wait(200);
-        cy.checkboxFirst('min-oversikt_brukerliste-checkbox');
+            // Legg dei til i arbeidslista
+            cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
+            cy.getByTestId('legg-i-arbeidsliste_knapp').click();
 
-        // Legg dei til i arbeidslista
-        cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
-        cy.getByTestId('legg-i-arbeidsliste_knapp').click();
+            // Gjer ting i modal
+            cy.getByTestId('modal_arbeidsliste_tittel').type('arbeidslistetittel');
+            cy.getByTestId('modal_arbeidsliste_kommentar').type('arbeidslistekommentar');
+            cy.getByTestId('modal_arbeidslistekategori_LILLA').click();
+            cy.getByTestId('modal_arbeidsliste_lagre-knapp').click();
 
-        // Gjer ting i modal
-        cy.getByTestId('modal_arbeidsliste_tittel').type('arbeidslistetittel');
-        cy.getByTestId('modal_arbeidsliste_kommentar').type('arbeidslistekommentar');
-        cy.getByTestId('modal_arbeidslistekategori_LILLA').click();
-        cy.getByTestId('modal_arbeidsliste_lagre-knapp').click();
+            // Sjå laster-modal
+            cy.get('.veilarbportefoljeflatefs-laster-modal').should('be.visible');
+            cy.get('.veilarbportefoljeflatefs-laster-modal').should('not.exist');
 
-        // Sjå laster-modal
-        cy.get('.veilarbportefoljeflatefs-laster-modal').should('be.visible');
-        cy.get('.veilarbportefoljeflatefs-laster-modal').should('not.exist');
-
-        // Sjekk at det no er ein meir person i lilla arbeidsliste
-        cy.getByTestId('filter_checkboks-container_minArbeidsliste').click();
-        cy.getByTestId('filter_checkboks-label_minArbeidslisteLilla').then($tall => {
-            expect(antallFor).not.to.eq($tall.text());
+            // Sjekk at det no er ein meir person i lilla arbeidsliste
+            cy.getByTestId('filter_checkboks-container_minArbeidsliste').click();
+            cy.getByTestId('filter_checkboks-label_minArbeidslisteLilla').then(antallILillaArbeidslisteEtter => {
+                expect(parseInt(antallILillaArbeidslisteEtter.text()))
+                    .to.equal(parseInt(antallILillaArbeidslisteFor.text()) + 1);
+            });
         });
     });
 });

--- a/cypress/e2e/filter_spec.js
+++ b/cypress/e2e/filter_spec.js
@@ -8,11 +8,11 @@ before('Start server', () => {
     cy.configure();
 });
 
-describe('Filter', () => {
-    beforeEach('Gå til filter-tab', () => {
-        cy.klikkTab('FILTER');
-    });
+beforeEach('Gå til filter-tab', () => {
+    cy.klikkTab('FILTER');
+});
 
+describe('Filter', () => {
     afterEach('Gå til status-tab', () => {
         cy.klikkTab('STATUS');
     });

--- a/cypress/e2e/mine-filter_spec.js
+++ b/cypress/e2e/mine-filter_spec.js
@@ -3,9 +3,8 @@ import {kebabCase} from '../../src/utils/utils';
 const mineFilterNavn = 'Voff';
 const mineFilterNavnRedigert = 'Mjau';
 const forLangtFilterNavn =
-    "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. Lorem Ipsum Lorem Ipsum.";
+    'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. Lorem Ipsum Lorem Ipsum.';
 const testFilterNavn = 'Denne brukes til test la stå';
-let antallFilter = 0;
 
 const navDsRadioButtonsSelector = '.navds-radio-buttons';
 
@@ -13,23 +12,11 @@ before('Start server', () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
     cy.configure();
+    cy.gaTilOversikt('enhetens-oversikt');
 });
 
 describe('Mine filter', () => {
-
-    it('Finn antall filter', () => {
-        cy.gaTilOversikt('enhetens-oversikt');
-        cy.klikkTab('MINE_FILTER');
-
-        // Tel kor mange filter vi har i mine filter slik at vi kan samanlikne med etter vi har laga nye
-        cy.get('[data-testid=mine-filter_rad-wrapper]').then(ant => {
-            antallFilter += Cypress.$(ant).length;
-        });
-    });
-
     it('Lagre nytt filter', () => {
-        cy.klikkTab('STATUS');
-
         // Vel ufordelte brukarar, sjekkar at vi ser filter-tag etterpå
         cy.getByTestId('filter_checkboks-container_ufordeltebruker').check({force: true});
         cy.getByTestId('filtreringlabel_ufordelte-brukere').should('be.visible');
@@ -41,15 +28,15 @@ describe('Mine filter', () => {
         cy.getByTestId('filter_0-19').check({force: true});
         cy.getByTestId('filtreringlabel_-19-ar').should('be.visible');
 
-        // Lagrar nytt filter
+        // Lagrar nytt filter (i staden for å oppdatere eksisterande)
         cy.getByTestId('lagre-filter_knapp').click();
         cy.getByTestId('oppdater-eksisterende-filter_modal_knapp').should('exist');
         cy.getByTestId('lagre-nytt-filter_modal_knapp').should('exist').click();
     });
 
-    it('Validering', () => {
-        // Held fram med greier frå førre modal
 
+    /* Avhengig av førre test: open modal */
+    it('Validering', () => {
         // Prøvar å lagre utan å ha skrive inn data, får feilmelding
         cy.getByTestId('lagre-nytt-filter_modal_lagre-knapp').click();
         cy.getByTestId('lagre-nytt-filter_modal_form').contains('Filteret mangler navn.');
@@ -65,123 +52,155 @@ describe('Mine filter', () => {
         cy.getByTestId('lagre-nytt-filter_modal_navn-input').clear().type(testFilterNavn);
         cy.getByTestId('lagre-nytt-filter_modal_lagre-knapp').click();
         cy.getByTestId('lagre-nytt-filter_modal_form').contains('Filternavn er allerede i bruk.');
+
+        // Lukkar modal, nullstillar test
+        cy.get('body').type('{esc}');
     });
 
     it('Lagring av riktig filternavn', () => {
-        // Held fram med greier frå førre test
+        cy.klikkTab('MINE_FILTER').then(() => {
+            // Hentar ut filtera før vi legg til den nye
+            cy.getByTestId('mine-filter_rad-wrapper').then(filterForLeggTil => {
+                // Åpnar lagre-modal, lagrar som nytt filter
+                cy.getByTestId('lagre-filter_knapp').click();
+                cy.getByTestId('lagre-nytt-filter_modal_knapp').should('exist').click();
 
-        // Skriv inn eit gyldig namn, lagrar
-        cy.getByTestId('lagre-nytt-filter_modal_navn-input').clear().type(mineFilterNavn);
-        cy.getByTestId('lagre-nytt-filter_modal_lagre-knapp').click();
+                // Skriv inn eit gyldig namn, lagrar
+                cy.getByTestId('lagre-nytt-filter_modal_navn-input').type(mineFilterNavn);
+                cy.getByTestId('lagre-nytt-filter_modal_lagre-knapp').click();
 
-        // Vi kan sjå rett fane, og det nye filteret vårt er synleg
-        cy.getByTestId('sidebar-tab_MINE_FILTER').should('have.class', 'sidebar__tab-valgt');
-        cy.getByTestId('mine-filter_rad-wrapper').contains(mineFilterNavn);
+                // Vi kan sjå rett fane, og det nye filteret vårt er synleg
+                cy.getByTestId('sidebar-tab_MINE_FILTER').should('have.class', 'sidebar__tab-valgt');
+                cy.getByTestId('mine-filter_rad-wrapper').contains(mineFilterNavn);
 
-        // Nyfilteret vårt er valgt, og og begge filtertagsa som skal visast er synlege
-        cy.getByTestId(`mine-filter-rad_${kebabCase(mineFilterNavn)}`).should('be.checked');
-        cy.getByTestId('filtrering_label-container').children().should('have.length', 2);
+                // Nyfilteret vårt er valgt, og og begge filtertagsa som skal visast er synlege
+                cy.getByTestId(`mine-filter-rad_${kebabCase(mineFilterNavn)}`).should('be.checked');
+                cy.getByTestId('filtrering_label-container').children().should('have.length', 2);
 
-        // Det er no eit meir filter enn det var før
-        cy.getByTestId('mine-filter_rad-wrapper').should('have.length', antallFilter + 1);
+                // Det er no eit meir filter enn det var før
+                cy.getByTestId('mine-filter_rad-wrapper').should('have.length', filterForLeggTil.length + 1);
+            });
+        });
 
     });
 
     it('Rediger filter', () => {
-        cy.getByTestId(`rediger-filter_knapp_${kebabCase(mineFilterNavn)}`).click();
+        // Finn kor mange filter burkaren har laga, så vi kan sjekke at det ikkje endrar seg gjennom testen
+        cy.getByTestId('mine-filter_rad-wrapper').then(mineFilterForRedigering => {
+            const antallFilterForRedigering = mineFilterForRedigering.length;
 
-        cy.getByTestId('redigere-filter-navn-input').clear().type(mineFilterNavnRedigert);
+            /* Del 1: endre namn på eksisterande filter */
 
-        cy.getByTestId('rediger-filter_modal_lagre-knapp').click();
+            // Opne redigering for filter "Voff"
+            cy.getByTestId(`rediger-filter_knapp_${kebabCase(mineFilterNavn)}`).click();
 
-        cy.getByTestId('mine-filter_rad-wrapper').contains(mineFilterNavnRedigert);
+            // Skriv inn nytt filternamn ("Mjau") og lagre det
+            cy.getByTestId('redigere-filter-navn-input').clear().type(mineFilterNavnRedigert);
+            cy.getByTestId('rediger-filter_modal_lagre-knapp').click();
 
-        cy.getByTestId('filtrering_label-container').children().should('have.length', 2);
+            // Sjekk at namnet er oppdatert etter lagring
+            cy.getByTestId('mine-filter_rad-wrapper').contains(mineFilterNavnRedigert);
 
-        cy.getByTestId('mine-filter_rad-wrapper').should('have.length', antallFilter + 1);
+            // Sjekk at det er to filtertags, og at talet på filter er det same
+            cy.getByTestId('filtrering_label-container').children().should('have.length', 2);
+            cy.getByTestId('mine-filter_rad-wrapper').should('have.length', antallFilterForRedigering);
 
-        cy.getByTestId('filtreringlabel_ufordelte-brukere').should('be.visible').click();
 
-        cy.klikkTab('STATUS');
+            /* Del 2: Oppdatere kva filterverdiar filteret inneheld */
 
-        cy.getByTestId('filter_checkboks-container_avtaltMoteMedNav').check({
-            force: true
+            // Vel ufordelte brukarar og status-fana
+            cy.getByTestId('filtreringlabel_ufordelte-brukere').should('be.visible').click();
+            cy.klikkTab('STATUS');
+
+            // Huk av for "Avtalt møte med nav"
+            cy.getByTestId('filter_checkboks-container_avtaltMoteMedNav').check({force: true});
+
+            // Ta bort filtreringslabel for 0-19 år
+            cy.getByTestId('filtreringlabel_-19-ar').should('be.visible').click();
+            cy.getByTestId('filtrering_label-container').children().should('have.length', 1);
+
+
+            // Trykk på lagre filter og få spørsmål om du vil oppdatere filteret
+            cy.getByTestId('lagre-filter_knapp').click();
+            cy.getByTestId('mine-filter_modal_oppdater-filter-tekst').contains(mineFilterNavnRedigert);
+
+            // Vel å oppdatere filteret, lagre endringane
+            cy.getByTestId('oppdater-eksisterende-filter_modal_knapp').click();
+            cy.getByTestId('rediger-filter_modal_lagre-knapp').click();
+
+            // Sjekk at vi kan sjå filtertag "møte med nav i dag" og at talet på filter framleis ikkje har endra seg
+            cy.getByTestId('filtreringlabel_mote-med-nav-idag').should('be.visible');
+            cy.getByTestId('mine-filter_rad-wrapper').should('have.length', antallFilterForRedigering);
         });
-
-        cy.getByTestId('filtreringlabel_-19-ar').should('be.visible').click();
-
-        cy.getByTestId('lagre-filter_knapp').click();
-
-        cy.getByTestId('mine-filter_modal_oppdater-filter-tekst').contains(mineFilterNavnRedigert);
-
-        cy.getByTestId('oppdater-eksisterende-filter_modal_knapp').click();
-
-        cy.getByTestId('rediger-filter_modal_lagre-knapp').click();
-
-        cy.getByTestId('filtreringlabel_mote-med-nav-idag').should('be.visible');
-
-        cy.getByTestId('mine-filter_rad-wrapper').should('have.length', antallFilter + 1);
     });
 
+    /* Avhengig av førre test: namn på redigert filter */
     it('Slett filter', () => {
-        cy.getByTestId(`rediger-filter_knapp_${kebabCase(mineFilterNavnRedigert)}`).click();
+        cy.getByTestId('mine-filter_rad-wrapper').then(filterForSletting => {
+            // Opne redigering på filteret vi skal slette ("Mjau")
+            cy.getByTestId(`rediger-filter_knapp_${kebabCase(mineFilterNavnRedigert)}`).as('filterSomSkalSlettes').click();
 
-        cy.getByTestId('rediger-filter_modal_slett-knapp').click();
+            // Slett filteret
+            cy.getByTestId('rediger-filter_modal_slett-knapp').click();
+            cy.getByTestId('bekreft-sletting_modal_slett-knapp').click();
 
-        cy.getByTestId('bekreft-sletting_modal_slett-knapp').click();
-
-        cy.getByTestId('mine-filter_rad-wrapper').should('have.length', antallFilter);
+            // Sjekk at vi no har færre filter
+            cy.getByTestId('mine-filter_rad-wrapper').should('have.length', filterForSletting.length - 1);
+            cy.get('@filterSomSkalSlettes').should('not.exist');
+        });
     });
 
     it('Verifiser fjernet permittert-filter i Min oversikt', () => {
+        // Gå til Mine filter
         cy.gaTilOversikt('min-oversikt');
-
         cy.klikkTab('MINE_FILTER');
 
+        // Sjekk at vi får eit varsel om at filter er fjerna. Lukk varselet.
         cy.getByTestId('mine-filter_alertstripe').should('be.visible')
             .within(() => {
-                cy.contains( "'Permitterte filter' er slettet fordi filteret 'Alle utenom permitterte etter 09.03.2020' er fjernet.");
+                cy.contains('\'Permitterte filter\' er slettet fordi filteret \'Alle utenom permitterte etter 09.03.2020\' er fjernet.');
                 cy.get('button').should('be.visible').click();
             });
 
+        // Varselet er borte etter lukking
         cy.getByTestId('mine-filter_alertstripe').should('not.exist');
     });
 
-    it('Drag and drop - Validering av hengelåsen', () => {
+    it('Drag and drop - Validering av åpning/lukking av redigering (hengelåsen)', () => {
+        // Gå til enhetens oversikt
         cy.gaTilOversikt('enhetens-oversikt');
 
-        cy.getByTestId('toggle-knapp').click();
-
-        cy.getByTestId('drag-drop_infotekst').should('be.visible');
-
-        cy.getByTestId('mine-filter_sortering_lagre-knapp').should('be.visible');
-
-        cy.getByTestId('mine-filter_sortering_avbryt-knapp').should('be.visible');
-
-        cy.getByTestId('mine-filter_sortering_nullstill-knapp').should('be.visible');
-
-        cy.getByTestId('toggle-knapp').click();
-
+        // Sjekk at vi ikkje kan sjå ting for endring av rekkefølge
         cy.getByTestId('drag-drop_infotekst').should('not.exist');
-
         cy.getByTestId('mine-filter_sortering_lagre-knapp').should('not.exist');
-
         cy.getByTestId('mine-filter_sortering_avbryt-knapp').should('not.exist');
-
         cy.getByTestId('mine-filter_sortering_nullstill-knapp').should('not.exist');
 
+        // Skru på endring av rekkefølge
         cy.getByTestId('toggle-knapp').click();
 
+        // Skal kunne sjå infotekst og knappar for lagring, avbryt og nullstill.
         cy.getByTestId('drag-drop_infotekst').should('be.visible');
-
         cy.getByTestId('mine-filter_sortering_lagre-knapp').should('be.visible');
-
         cy.getByTestId('mine-filter_sortering_avbryt-knapp').should('be.visible');
-
         cy.getByTestId('mine-filter_sortering_nullstill-knapp').should('be.visible');
+
+        // Skru av endring av rekkefølge
+        cy.getByTestId('toggle-knapp').click();
+
+        // Sjekk at ting for endring av rekkefølgje er borte igjen
+        cy.getByTestId('drag-drop_infotekst').should('not.exist');
+        cy.getByTestId('mine-filter_sortering_lagre-knapp').should('not.exist');
+        cy.getByTestId('mine-filter_sortering_avbryt-knapp').should('not.exist');
+        cy.getByTestId('mine-filter_sortering_nullstill-knapp').should('not.exist');
     });
 
+    /* Avhengig av tidlegare testar: sikre plassering av element i lista */
     it('Drag and drop - Verifiser lagring', () => {
+        // Skru på endring av rekkefølge
+        cy.getByTestId('toggle-knapp').click();
+
+        // Sjekkar at vi har testfilteret som tredje element i lista over filter
         cy.getByTestId('mine-filter_radio-container')
             .children()
             .children()
@@ -190,20 +209,23 @@ describe('Mine filter', () => {
             .next()
             .contains(testFilterNavn);
 
+        // Finn testfilteret på plass 2 i lista. Flyttar den to hakk ned
         cy.getByTestId(`drag-drop_rad_${kebabCase(testFilterNavn)}`)
             .contains(testFilterNavn)
             .should('have.value', 2)
             .click()
             .type('{shift}{downarrow}{downarrow}');
 
+        // Testfilteret er no på plass 4 (sist)
         cy.getByTestId(`drag-drop_rad_${kebabCase(testFilterNavn)}`)
             .contains(testFilterNavn)
             .should('have.value', 4);
 
+        // Lagre rekkefølga, sjekk at vi er ute av plassendringsvisninga
         cy.getByTestId('mine-filter_sortering_lagre-knapp').click();
-
         cy.getByTestId('drag-drop_infotekst').should('not.exist');
 
+        // Testfilteret skal no vere list i lista over filter
         cy.getByTestId('mine-filter_radio-container')
             .get(navDsRadioButtonsSelector)
             .children()
@@ -211,25 +233,29 @@ describe('Mine filter', () => {
             .contains(testFilterNavn);
     });
 
+    /* Avhengig av tidlegare testar: sikre plassering av element i lista */
     it('Drag and drop - Verifiser avbryt-knapp', () => {
+        // Skru på redigering av rekkefølge
         cy.getByTestId('toggle-knapp').click();
-
         cy.getByTestId('drag-drop_infotekst').should('be.visible');
 
+        // Finn testfilteret i botnen av lista, flyttar den opp eit hakk
         cy.getByTestId(`drag-drop_rad_${kebabCase(testFilterNavn)}`)
             .contains(testFilterNavn)
             .should('have.value', 4)
             .click()
             .type('{shift}{uparrow}');
 
+        // Sjekkar at den har flytta seg
         cy.getByTestId(`drag-drop_rad_${kebabCase(testFilterNavn)}`)
             .contains(testFilterNavn)
             .should('have.value', 3);
 
+        // Avbryt redigering av rekkefølgje
         cy.getByTestId('mine-filter_sortering_avbryt-knapp').click();
-
         cy.getByTestId('drag-drop_infotekst').should('not.exist');
 
+        // Sjekkar at filteret er på botnen av lista igjen (at endringane ikkje vart lagra)
         cy.getByTestId('mine-filter_radio-container')
             .get(navDsRadioButtonsSelector)
             .children()
@@ -237,17 +263,20 @@ describe('Mine filter', () => {
             .contains(testFilterNavn);
     });
 
+    /* Avhengig av tidlegare testar: sikre plassering av element i lista */
     it('Drag and drop - Verifiser nullstill-knapp', () => {
+        // Skru på redigeringsmodus
         cy.getByTestId('toggle-knapp').click();
-
         cy.getByTestId('drag-drop_infotekst').should('be.visible');
 
+        // Nullstill sortering
         cy.getByTestId('mine-filter_sortering_nullstill-knapp').click();
 
+        // Lagre (og lukk redigering)
         cy.getByTestId('mine-filter_sortering_lagre-knapp').click();
-
         cy.getByTestId('drag-drop_infotekst').should('not.exist');
 
+        // Sjekk at testfilteret er på plass 2 i lista igjen
         cy.getByTestId('mine-filter_radio-container')
             .get(navDsRadioButtonsSelector)
             .children()
@@ -255,18 +284,35 @@ describe('Mine filter', () => {
             .next()
             .contains(testFilterNavn);
 
+        // Fjern filter som var valgt (dette har lite med denne testen å gjere eigentleg)
         cy.getByTestId('filtreringlabel_mote-med-nav-idag').should('be.visible').click();
     });
 
-    it('Tiltaksfilter borte fra lagret filter', () => {
-        cy.getByTestId('mine-filter_rad-wrapper').should('have.length', 5);
-        cy.getByTestId('mine-filter-rad_tiltaksfilter').click({force: true});
+    it('Test oppførsel når et lagra filter bruker et tiltaksfilter som ikke finnes lenger', () => {
+        cy.getByTestId('mine-filter_rad-wrapper').then(filterraderForSletting => {
+            // Sjekkar at vi finn testfilteret vi skal bruke
+            cy.getByTestId('mine-filter_rad-wrapper').should('contain.text', testFilterNavn);
 
-        cy.getByTestId('la-sta-knapp').click();
-        cy.getByTestId('mine-filter-rad_tiltaksfilter').click({force: true});
+            // Vel eit lagra filter som inneheld tiltakstypar som ikkje lenger kan brukast
+            cy.getByTestId('mine-filter-rad_tiltaksfilter').click({force: true});
 
-        cy.getByTestId('slett-knapp').click();
-        cy.getByTestId('bekreft-sletting_modal_slett-knapp').click();
-        cy.getByTestId('mine-filter_rad-wrapper').should('have.length', 4);
+            // Får opp ein modal som fortel at tiltakstypen ikkje kan brukast nett no.
+            cy.get('.testid-feil-tiltak_modal').should('be.visible');
+
+            // Vel å la filteret vere i lista (lukkar modal)
+            cy.getByTestId('la-sta-knapp').click();
+            cy.get('.testid-feil-tiltak_modal').should('not.exist');
+
+            // Trykkar på tiltaksfilteret igjen og får opp same modalen
+            cy.getByTestId('mine-filter-rad_tiltaksfilter').click({force: true});
+            cy.get('.testid-feil-tiltak_modal').should('be.visible');
+
+            // Denne gongen slettar vi filteret
+            cy.getByTestId('slett-knapp').click();
+            cy.getByTestId('bekreft-sletting_modal_slett-knapp').click();
+
+            // Sjekkar at vi har færre filter enn i starten av testen
+            cy.getByTestId('mine-filter_rad-wrapper').should('have.length', filterraderForSletting.length - 1);
+        });
     });
 });

--- a/cypress/e2e/veiledergrupper_spec.js
+++ b/cypress/e2e/veiledergrupper_spec.js
@@ -56,7 +56,7 @@ describe('Veiledergrupper', () => {
             cy.getByTestId('veiledergruppe_modal_lagre-knapp').click();
             cy.getByTestId('timed-toast_gruppen-er-opprettet').contains('Gruppen er opprettet');
 
-            // Sjekkar at den nye gruppa vart lagt til og at den er valgt
+            // Sjekkar at den nye gruppa vart lagt til og at den er vald
             cy.get('@veiledergrupper').should('have.length', veiledergrupperForOpprettNy.length + 1)
                 .contains(gruppenavn);
             cy.getByTestId(`veiledergruppe-rad_${kebabCase(gruppenavn)}`).should('be.checked');

--- a/src/components/modal/mine-filter/feil-tiltak-modal.tsx
+++ b/src/components/modal/mine-filter/feil-tiltak-modal.tsx
@@ -41,7 +41,7 @@ export function FeilTiltakModal({gammeltFilterNavn, filterId, lukkModal, oversik
     return (
         <>
             <EgenModal
-                className="feil-tiltak_modal"
+                className="feil-tiltak_modal testid-feil-tiltak_modal"
                 open={erFeilTiltakModalApen}
                 onClose={lukkModal}
                 tittel="Tiltaksfilter finnes ikke"

--- a/src/components/modal/veiledergruppe/søk-veiledere-veiledergrupper.tsx
+++ b/src/components/modal/veiledergruppe/søk-veiledere-veiledergrupper.tsx
@@ -25,6 +25,7 @@ function SokVeiledereVeiledergrupper({handterVeiledereValgt, valgteVeiledere}: S
                     legend=""
                     onChange={handterVeiledereValgt}
                     value={valgteVeiledere}
+                    data-testid="sokfilter-veilederliste_veiledere"
                 >
                     {liste.map((elem, index) => (
                         <Checkbox


### PR DESCRIPTION
Cypress-testar køyrer async. Testar som baserar seg på at ting skal skje i ei bestemt rekkefølgje risikerar å feile litt no og då. Eit døme er når ein hentar ut ein verdi, lagrar den, og så ein annan stad går ut i frå at denne lagringa faktisk har skjedd. Vi har gjort det masse. (Cypress-dokumentasjonen trøystar oss med at dette er ein veldig vanleg feil.)

I denne PR-en byttar vi ut `let variabelnamn`-notasjonen med å nøste funksjonskall i `.then`-notasjon. Då får vi tilgang på verdiane der vi treng dei, utan at andre funksjonar kan risikere å manipulere dei i mellomtida.


For enno meir detaljar og døme sjå https://docs.cypress.io/guides/references/best-practices#Assigning-Return-Values


---
Vi har også teke i bruk aliasing av DOM-element. For detaljert forklaring sjå [Cypress sin dokumentasjon om Alias](https://docs.cypress.io/guides/core-concepts/variables-and-aliases#Aliases). Kort forklart:
- hent ein ting med eit `cy.get`-kall. 
- Chain get-en med ein `.as('string-som-blir-alias')`
- no kan du bruke `cy.get('@string-som-blir-alias')`
- Aliasing av DOM-element gjer (veldig upresist forklart) at Cypress ikkje må gå til DOM for å finne elementa kvar gong, men lagrar ei referanse til objektet. Cypress sikrar at elementa ikkje vert utdaterte ved å dobbeltsjekke status når ein brukar aliaset. Eg antar dette er raskare enn å hente elementet frå DOM på nytt.