### PR TITLE
Kunne slette arbeidsliste uten å slette fargekategori ved huskelapp

### DIFF
--- a/src/middleware/api.ts
+++ b/src/middleware/api.ts
@@ -231,6 +231,12 @@ export function slettArbeidsliste(arbeidsliste) {
     return fetchToJson(url, config);
 }
 
+export function slettArbeidslisteUtenFargekategori(fnr: string) {
+    const url = `${VEILARBPORTEFOLJE_URL}/v2/arbeidsliste?slettFargekategori=false`;
+    const config = {...MED_CREDENTIALS, method: 'delete', body: JSON.stringify({fnr})};
+    return fetchToJson(url, config);
+}
+
 export function oppdaterFargekategori(fnrlisteOgFargekategori: FargekategoriDataModell) {
     const url = `${VEILARBPORTEFOLJE_URL}/v1/fargekategorier`;
     const config = {...MED_CREDENTIALS, method: 'put', body: JSON.stringify(fnrlisteOgFargekategori)};

--- a/src/minoversikt/huskelapp/HuskelappPanel.tsx
+++ b/src/minoversikt/huskelapp/HuskelappPanel.tsx
@@ -1,25 +1,16 @@
 import React from 'react';
 import {LagHuskelappInngang} from './LagHuskelappInngang';
 import {EksisterendeArbeidslisteVisning} from './EksisterendeArbeidslisteVisning';
-import {ArbeidslisteDataModell, BrukerModell, HuskelappModell} from '../../model-interfaces';
+import {BrukerModell, HuskelappModell} from '../../model-interfaces';
 import './huskelapp.css';
 import {HuskelappPanelvisning} from './HuskelappPanelvisning';
-import {slettArbeidslisteAction} from '../../ducks/arbeidsliste';
 import {useDispatch} from 'react-redux';
-import {oppdaterStateVedSlettArbeidsliste} from './slettEksisterendeArbeidsliste';
+import {slettArbeidslisteUtenFargekategoriOgOppdaterRedux} from './slettEksisterendeArbeidsliste';
 
 export const HuskelappPanel = ({bruker}: {bruker: BrukerModell}) => {
     const dispatch = useDispatch();
     const onSlettArbeidsliste = () => {
-        const arbeidsliste: ArbeidslisteDataModell[] = [bruker].map(bruker => ({
-            fnr: bruker.fnr,
-            kommentar: bruker.arbeidsliste.kommentar ?? null,
-            frist: bruker.arbeidsliste.frist,
-            kategori: bruker.arbeidsliste.kategori
-        }));
-        slettArbeidslisteAction(arbeidsliste)(dispatch).then(res =>
-            oppdaterStateVedSlettArbeidsliste(res, arbeidsliste, dispatch)
-        );
+        slettArbeidslisteUtenFargekategoriOgOppdaterRedux(bruker, dispatch);
     };
 
     return (

--- a/src/minoversikt/huskelapp/LagEllerEndreHuskelappModal.tsx
+++ b/src/minoversikt/huskelapp/LagEllerEndreHuskelappModal.tsx
@@ -55,14 +55,14 @@ export const LagEllerEndreHuskelappModal = ({isModalOpen, onModalClose, huskelap
                                             'Du må legge til enten frist eller kommentar for å kunne lagre huskelappen'
                                     });
                                 }
-                                const arbeidslisteArray: ArbeidslisteDataModell[] = arbeidsliste
-                                    ? [bruker].map(bruker => ({
+                                const arbeidslisteSomSkalSlettes: ArbeidslisteDataModell | null = arbeidsliste
+                                    ? {
                                           fnr: bruker.fnr,
                                           kommentar: bruker.arbeidsliste.kommentar ?? null,
                                           frist: bruker.arbeidsliste.frist,
                                           kategori: bruker.arbeidsliste.kategori
-                                      }))
-                                    : [];
+                                      }
+                                    : null;
                                 try {
                                     if (huskelapp?.huskelappId) {
                                         await endreHuskelapp(
@@ -80,7 +80,7 @@ export const LagEllerEndreHuskelappModal = ({isModalOpen, onModalClose, huskelap
                                             bruker,
                                             enhetId!!,
                                             onModalClose,
-                                            arbeidslisteArray
+                                            arbeidslisteSomSkalSlettes
                                         );
                                     }
                                 } catch (error) {

--- a/src/minoversikt/huskelapp/lagreHuskelapp.ts
+++ b/src/minoversikt/huskelapp/lagreHuskelapp.ts
@@ -6,8 +6,7 @@ import {AppState} from '../../reducer';
 import {AnyAction} from 'redux';
 import {ArbeidslisteDataModell, BrukerModell} from '../../model-interfaces';
 import {FormikValues} from 'formik';
-import {slettArbeidslisteAction} from '../../ducks/arbeidsliste';
-import {oppdaterStateVedSlettArbeidsliste} from './slettEksisterendeArbeidsliste';
+import {slettArbeidslisteUtenFargekategoriOgOppdaterRedux} from './slettEksisterendeArbeidsliste';
 
 export const lagreHuskelapp = async (
     dispatch: ThunkDispatch<AppState, any, AnyAction>,
@@ -15,7 +14,7 @@ export const lagreHuskelapp = async (
     bruker: BrukerModell,
     enhetId: string,
     onModalClose: () => void,
-    arbeidsliste: ArbeidslisteDataModell[]
+    arbeidsliste: ArbeidslisteDataModell | null
 ) => {
     await dispatch(
         lagreHuskelappAction({
@@ -27,9 +26,8 @@ export const lagreHuskelapp = async (
     );
     await dispatch(hentHuskelappForBruker(bruker.fnr, enhetId!!));
     await dispatch(leggTilStatustall('mineHuskelapper', 1));
-    if (!!arbeidsliste.length) {
-        const res = await dispatch(slettArbeidslisteAction(arbeidsliste));
-        await oppdaterStateVedSlettArbeidsliste(res, arbeidsliste, dispatch);
+    if (!!arbeidsliste) {
+        await slettArbeidslisteUtenFargekategoriOgOppdaterRedux(bruker, dispatch);
     }
     await onModalClose();
 };

--- a/src/minoversikt/huskelapp/slettEksisterendeArbeidsliste.ts
+++ b/src/minoversikt/huskelapp/slettEksisterendeArbeidsliste.ts
@@ -1,8 +1,26 @@
-import {ArbeidslisteDataModell} from '../../model-interfaces';
+import {ArbeidslisteDataModell, BrukerModell} from '../../model-interfaces';
 import {visServerfeilModal} from '../../ducks/modal-serverfeil';
 import {FJERN_FRA_ARBEIDSLISTE_FEILET, visFeiletModal} from '../../ducks/modal-feilmelding-brukere';
 import {leggTilStatustall} from '../../ducks/statustall-veileder';
 import {oppdaterArbeidslisteForBruker} from '../../ducks/portefolje';
+import {slettArbeidslisteUtenFargekategori} from '../../middleware/api';
+import {ThunkDispatch} from 'redux-thunk';
+import {AppState} from '../../reducer';
+import {AnyAction} from 'redux';
+
+export const slettArbeidslisteUtenFargekategoriOgOppdaterRedux = async (
+    bruker: BrukerModell,
+    dispatch: ThunkDispatch<AppState, any, AnyAction>
+) => {
+    try {
+        const arbeidslisteUtenFargekategori = await slettArbeidslisteUtenFargekategori(bruker.fnr);
+        const ikkeAktivArbeidsliste = {...arbeidslisteUtenFargekategori, arbeidslisteAktiv: false, fnr: bruker.fnr};
+        leggTilStatustall('minArbeidsliste', -1)(dispatch);
+        oppdaterArbeidslisteForBruker([ikkeAktivArbeidsliste])(dispatch);
+    } catch (error) {
+        return visServerfeilModal()(dispatch);
+    }
+};
 
 export const oppdaterStateVedSlettArbeidsliste = (res, arbeidsliste: ArbeidslisteDataModell[], dispatch) => {
     if (!res) {


### PR DESCRIPTION
Må ha to forskjellige kall mot endepunkt "slett arbeidsliste" så lenge vi fortsatt støtter arbeidslistefunksjon i oversikten. 
1. Slett arbeidsliste med tilhørende fargekategori (slett fra arbeidsliste modal)
2. Slett arbeidsliste uten å slette fargekategori (slett fra migreringsmodal: arbeidsliste til huskelapp) 