### PR TITLE
Bruk header frå designsystemet på varsel-modalar

### DIFF
--- a/src/components/fnr-list.tsx
+++ b/src/components/fnr-list.tsx
@@ -10,11 +10,7 @@ interface FnrListProps {
 }
 
 export function FnrList({listeMedFnr}: FnrListProps) {
-    const listElements = listeMedFnr.map(tilordning => (
-        <li key={tilordning.brukerFnr} className="fnr__listitem">
-            {tilordning.brukerFnr}
-        </li>
-    ));
+    const listElements = listeMedFnr.map(tilordning => <li key={tilordning.brukerFnr}>{tilordning.brukerFnr}</li>);
 
     const className = listElements.length >= 18 ? 'modal-liste__lang' : 'modal-liste';
 

--- a/src/components/modal-liste.css
+++ b/src/components/modal-liste.css
@@ -1,9 +1,10 @@
 .modal-liste__lang {
     max-height: 20rem;
     overflow-y: scroll;
+    /* Legg til skugge i scrollbar boks slik at brukaren ser at det er noko å scrolle på */
     box-shadow:
         rgba(0, 0, 0, 0.06) 0 2px 4px 0 inset,
-        rgba(0, 0, 0, 0.06) 0 -2px 2px 0 inset; /* Skugge-verdiane er teken frå fargeboksane på design-tokensida til Aksel. */
+        rgba(0, 0, 0, 0.06) 0 -2px 2px 0 inset;
     padding-top: 0.5rem;
 }
 .modal-liste__lang,

--- a/src/components/modal-liste.css
+++ b/src/components/modal-liste.css
@@ -1,12 +1,14 @@
 .modal-liste__lang {
     max-height: 20rem;
     overflow-y: scroll;
-    border-top: 1px solid #a0a0a0;
-    border-bottom: 1px solid #a0a0a0;
-    width: 40%;
-    margin: 1rem auto;
+    box-shadow:
+        rgba(0, 0, 0, 0.06) 0 2px 4px 0 inset,
+        rgba(0, 0, 0, 0.06) 0 -2px 2px 0 inset; /* Skugge-verdiane er teken frå fargeboksane på design-tokensida til Aksel. */
+    padding-top: 0.5rem;
 }
 .modal-liste__lang,
 .modal-liste {
-    text-align: left;
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-left: 1.5rem;
 }

--- a/src/components/modal/arbeidsliste/arbeidsliste-modal.tsx
+++ b/src/components/modal/arbeidsliste/arbeidsliste-modal.tsx
@@ -9,7 +9,7 @@ import {AppState} from '../../../reducer';
 import {STATUS} from '../../../ducks/utils';
 import {VarselModal, VarselModalType} from '../varselmodal/varselmodal';
 import FjernFraArbeidslisteForm from './fjern-fra-arbeidsliste-form';
-import {BodyShort, Heading, Modal} from '@navikt/ds-react';
+import {BodyShort, Modal} from '@navikt/ds-react';
 import LasterModal from '../lastermodal/laster-modal';
 
 interface ArbeidslisteModalProps {
@@ -46,22 +46,18 @@ const ArbeidslisteModal = ({isOpen, valgteBrukere}: ArbeidslisteModalProps) => {
                 <>
                     {fjerneBrukere ? (
                         <VarselModal
+                            overskrift="Fjern fra arbeidsliste"
                             isOpen={isModalOpen}
                             onClose={lukkModal}
                             type={VarselModalType.ADVARSEL}
                             dataTestClass="modal_varsel_fjern-fra-arbeidsliste"
                         >
                             <div className="fjern-arbeidsliste">
-                                <div className="arbeidsliste-headertekst">
-                                    <Heading size="large" level="1">
-                                        Fjern fra arbeidsliste
-                                    </Heading>
-                                    <BodyShort size="small">
-                                        {`Du har valgt å fjerne ${brukereSomSkalFjernes.length} ${
-                                            brukereSomSkalFjernes.length === 1 ? 'bruker' : 'brukere'
-                                        } fra arbeidslisten.`}
-                                    </BodyShort>
-                                </div>
+                                <BodyShort size="small">
+                                    {`Du har valgt å fjerne ${brukereSomSkalFjernes.length} ${
+                                        brukereSomSkalFjernes.length === 1 ? 'bruker' : 'brukere'
+                                    } fra arbeidslisten.`}
+                                </BodyShort>
                                 <FjernFraArbeidslisteForm valgteBrukere={brukereSomSkalFjernes} lukkModal={lukkModal} />
                             </div>
                         </VarselModal>

--- a/src/components/modal/arbeidsliste/arbeidsliste.css
+++ b/src/components/modal/arbeidsliste/arbeidsliste.css
@@ -76,9 +76,6 @@
     flex-direction: column;
     gap: 1rem;
 }
-.fjern-arbeidsliste .arbeidsliste-headertekst {
-    text-align: center;
-}
 .fjern-arbeidsliste .arbeidsliste-listetekst {
     width: 60%;
     margin: 0 auto;

--- a/src/components/modal/arbeidsliste/fjern-fra-arbeidsliste-modal.tsx
+++ b/src/components/modal/arbeidsliste/fjern-fra-arbeidsliste-modal.tsx
@@ -2,7 +2,7 @@ import {VarselModal, VarselModalType} from '../varselmodal/varselmodal';
 import FjernFraArbeidslisteForm from './fjern-fra-arbeidsliste-form';
 import React from 'react';
 import {BrukerModell} from '../../../model-interfaces';
-import {BodyShort, Heading} from '@navikt/ds-react';
+import {BodyShort} from '@navikt/ds-react';
 
 interface FjernFraArbeidslisteModalProps {
     isOpen: boolean;
@@ -18,18 +18,14 @@ function FjernArbeidslisteModal({isOpen, valgteBrukere, lukkModal, bruker}: Fjer
 
     return (
         <VarselModal
+            overskrift="Fjern fra arbeidsliste"
             isOpen={isOpen}
             onClose={lukkModal}
             type={VarselModalType.ADVARSEL}
             dataTestClass="modal_varsel_fjern-fra-arbeidsliste"
         >
             <div className="fjern-arbeidsliste">
-                <div className="arbeidsliste-headertekst">
-                    <Heading size="large" level="1">
-                        Fjern fra arbeidsliste
-                    </Heading>
-                    <BodyShort size="small">{`Du har valgt å fjerne ${navn} fra arbeidslisten.`}</BodyShort>
-                </div>
+                <BodyShort size="small">{`Du har valgt å fjerne ${navn} fra arbeidslisten.`}</BodyShort>
                 <FjernFraArbeidslisteForm
                     valgteBrukere={brukereSomSkalFjernes}
                     lukkModal={lukkModal}

--- a/src/components/modal/feilmelding-brukere-modal.tsx
+++ b/src/components/modal/feilmelding-brukere-modal.tsx
@@ -21,15 +21,13 @@ function FeilmeldingBrukereModal({
 }: FeilmeldingBrukereModalProps) {
     return (
         <VarselModal
+            overskrift={tittelTekst}
             isOpen={isOpen}
             onClose={onClose}
             type={VarselModalType.FEIL}
             portalClassName="arbeidsliste-modal"
             className="arbeidsliste-modal__content"
         >
-            <Heading size="small" level="1">
-                {tittelTekst}
-            </Heading>
             <BodyShort size="small">{infotekstTekst}</BodyShort>
             <FnrList listeMedFnr={fnrFeil} />
             <Button onClick={onClose} size="small">

--- a/src/components/modal/feilmelding-brukere.css
+++ b/src/components/modal/feilmelding-brukere.css
@@ -16,9 +16,9 @@
 .filter-feil-modal__vellykkedebrukere {
     margin: 1rem 0;
 }
-.server-feil-modal {
-    margin: 1rem;
-    text-align: center;
+.server-feil-modal__ok-knapp {
+    align-self: center;
+    min-width: 4rem;
 }
 .arbeidsliste-alert {
     margin-bottom: 0.5rem;

--- a/src/components/modal/feilmelding-brukere.css
+++ b/src/components/modal/feilmelding-brukere.css
@@ -1,13 +1,12 @@
-.tildeling-veileder-modal__vellykkedebrukere,
-.filter-feil-modal__vellykkedebrukere {
-    margin: 1rem 0;
+.tildeling-veileder-statusinfo {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 }
-.server-feil-modal__ok-knapp,
-.feilmelding-tildeling-modal__lukk-knapp,
-.tildeling-veileder-modal__lukk-knapp {
-    align-self: center;
-    min-width: 4rem;
+.tildeling-veileder-statusinfo:not(:last-of-type) {
+    margin-bottom: 1rem;
 }
+
 .arbeidsliste-alert {
     margin-bottom: 0.5rem;
 }

--- a/src/components/modal/feilmelding-brukere.css
+++ b/src/components/modal/feilmelding-brukere.css
@@ -2,21 +2,12 @@
     display: flex;
     flex-direction: column;
 }
-.tildeling-veileder-modal .modal-liste {
-    width: 40%;
-    margin: 1rem auto;
-}
-.tildeling-veileder-modal .modal-liste__lang {
-    max-height: 20rem;
-    overflow-y: scroll;
-    border-top: 1px solid #a0a0a0;
-    border-bottom: 1px solid #a0a0a0;
-}
 .tildeling-veileder-modal__vellykkedebrukere,
 .filter-feil-modal__vellykkedebrukere {
     margin: 1rem 0;
 }
-.server-feil-modal__ok-knapp {
+.server-feil-modal__ok-knapp,
+.feilmelding-tildeling-modal__lukk-knapp {
     align-self: center;
     min-width: 4rem;
 }

--- a/src/components/modal/feilmelding-brukere.css
+++ b/src/components/modal/feilmelding-brukere.css
@@ -1,13 +1,10 @@
-.tildeling-veileder-modal__tekstgruppe {
-    display: flex;
-    flex-direction: column;
-}
 .tildeling-veileder-modal__vellykkedebrukere,
 .filter-feil-modal__vellykkedebrukere {
     margin: 1rem 0;
 }
 .server-feil-modal__ok-knapp,
-.feilmelding-tildeling-modal__lukk-knapp {
+.feilmelding-tildeling-modal__lukk-knapp,
+.tildeling-veileder-modal__lukk-knapp {
     align-self: center;
     min-width: 4rem;
 }

--- a/src/components/modal/feilmelding-tildeling-modal.tsx
+++ b/src/components/modal/feilmelding-tildeling-modal.tsx
@@ -42,12 +42,7 @@ function FeilmeldingTildelingModal({isOpen, fnrFeil, fnrSuksess, onClose}: Feilm
                     </BodyShort>
                 </div>
             )}
-            <Button
-                variant="secondary"
-                size="small"
-                onClick={onClose}
-                className="feilmelding-tildeling-modal__lukk-knapp"
-            >
+            <Button variant="secondary" size="small" onClick={onClose}>
                 Lukk
             </Button>
         </VarselModal>

--- a/src/components/modal/feilmelding-tildeling-modal.tsx
+++ b/src/components/modal/feilmelding-tildeling-modal.tsx
@@ -14,15 +14,12 @@ interface FeilmeldingBrukereModalProps {
 function FeilmeldingTildelingModal({isOpen, fnrFeil, fnrSuksess, onClose}: FeilmeldingBrukereModalProps) {
     return (
         <VarselModal
+            overskrift="Handling kan ikke utføres"
             isOpen={isOpen}
             onClose={onClose}
             type={VarselModalType.FEIL}
             portalClassName="tildeling-veileder-modal"
-            className="tildeling-veileder-modal__content"
         >
-            <Heading size="large" level="1">
-                Handling kan ikke utføres
-            </Heading>
             <BodyShort size="small">Tildeling av veileder til følgende bruker(e) feilet:</BodyShort>
             <FnrList listeMedFnr={fnrFeil} />
             <BodyShort size="small">
@@ -39,7 +36,12 @@ function FeilmeldingTildelingModal({isOpen, fnrFeil, fnrSuksess, onClose}: Feilm
                     </BodyShort>
                 </div>
             )}
-            <Button variant="secondary" size="small" onClick={onClose}>
+            <Button
+                variant="secondary"
+                size="small"
+                onClick={onClose}
+                className="feilmelding-tildeling-modal__lukk-knapp"
+            >
                 Lukk
             </Button>
         </VarselModal>

--- a/src/components/modal/feilmelding-tildeling-modal.tsx
+++ b/src/components/modal/feilmelding-tildeling-modal.tsx
@@ -20,16 +20,22 @@ function FeilmeldingTildelingModal({isOpen, fnrFeil, fnrSuksess, onClose}: Feilm
             type={VarselModalType.FEIL}
             portalClassName="tildeling-veileder-modal"
         >
-            <BodyShort size="small">Tildeling av veileder til følgende bruker(e) feilet:</BodyShort>
-            <FnrList listeMedFnr={fnrFeil} />
-            <BodyShort size="small">
-                Det kan skyldes manglende tilgang til bruker, at veilederen allerede er tildelt brukeren, eller at
-                brukeren ikke er under oppfølging.
-            </BodyShort>
+            <div className="tildeling-veileder-statusinfo">
+                <Heading level="2" size="xsmall">
+                    Tildeling av veileder til følgende bruker(e) feilet:
+                </Heading>
+                <FnrList listeMedFnr={fnrFeil} />
+                <BodyShort size="small">
+                    Det kan skyldes manglende tilgang til bruker, at veilederen allerede er tildelt brukeren, eller at
+                    brukeren ikke er under oppfølging.
+                </BodyShort>
+            </div>
 
             {fnrSuksess?.length > 0 && (
-                <div className="tildeling-veileder-modal__vellykkedebrukere">
-                    <BodyShort size="small">Tildeling av veileder lyktes for følgende bruker(e):</BodyShort>
+                <div className="tildeling-veileder-statusinfo">
+                    <Heading level="2" size="xsmall">
+                        Tildeling av veileder lyktes for følgende bruker(e):
+                    </Heading>
                     <FnrList listeMedFnr={fnrSuksess} />
                     <BodyShort size="small">
                         Det kan ta noe tid før oversikten blir oppdatert med tildelt veileder.

--- a/src/components/modal/filter-feil-modal.tsx
+++ b/src/components/modal/filter-feil-modal.tsx
@@ -17,15 +17,13 @@ export default function FilterFeilModal({isOpen}: FilterFeilModalProps) {
 
     return (
         <VarselModal
+            overskrift="Det oppstod en teknisk feil"
             isOpen={erAapen}
             type={VarselModalType.FEIL}
             onClose={lukkModal}
             portalClassName="filter-feil-modal"
             className="filter-feil-modal__content"
         >
-            <Heading size="small" level="1">
-                Det oppstod en teknisk feil.
-            </Heading>
             <BodyShort size="small">
                 Det oppstod et problem med ett eller flere filter.
                 <br />

--- a/src/components/modal/mine-filter/mine-filter-varsel-modal.tsx
+++ b/src/components/modal/mine-filter/mine-filter-varsel-modal.tsx
@@ -50,7 +50,7 @@ export function MineFilterVarselModal({filterNavn, modalType, erApen, setErrorMo
                     Det oppsto en feil, og filteret <b>{filterNavn}</b> kunne ikke slettes. Prøv igjen senere.
                 </BodyShort>
             )}
-            <Button size="small" className="error-knapp" onClick={() => setErrorModalErApen(false)}>
+            <Button size="small" onClick={() => setErrorModalErApen(false)}>
                 Lukk
             </Button>
         </VarselModal>

--- a/src/components/modal/mine-filter/mine-filter-varsel-modal.tsx
+++ b/src/components/modal/mine-filter/mine-filter-varsel-modal.tsx
@@ -14,6 +14,12 @@ const errorModalTypeToTittel = new Map<ErrorModalType, string>([
     [ErrorModalType.SLETTE, 'Filteret kunne ikke slettes']
 ]);
 
+const errorModaltypeTilTittel: {[key in ErrorModalType]: string} = {
+    [ErrorModalType.LAGRE]: 'Filteret kunne ikke opprettes',
+    [ErrorModalType.OPPDATERE]: 'Filteret kunne ikke lagres',
+    [ErrorModalType.SLETTE]: 'Filteret kunne ikke slettes'
+};
+
 interface Props {
     filterNavn: string;
     modalType: ErrorModalType;
@@ -23,11 +29,12 @@ interface Props {
 
 export function MineFilterVarselModal({filterNavn, modalType, erApen, setErrorModalErApen}: Props) {
     return (
-        <VarselModal onClose={() => setErrorModalErApen(false)} isOpen={erApen} type={VarselModalType.FEIL}>
-            <Heading size="large" level="1">
-                {errorModalTypeToTittel.get(modalType)}
-            </Heading>
-            <br />
+        <VarselModal
+            overskrift={errorModaltypeTilTittel[modalType]}
+            onClose={() => setErrorModalErApen(false)}
+            isOpen={erApen}
+            type={VarselModalType.FEIL}
+        >
             {modalType === ErrorModalType.LAGRE && (
                 <BodyShort size="small">
                     Det oppsto en feil, og filteret <b>{filterNavn}</b> kunne ikke opprettes. Prøv igjen senere.

--- a/src/components/modal/mine-filter/mine-filter-varsel-modal.tsx
+++ b/src/components/modal/mine-filter/mine-filter-varsel-modal.tsx
@@ -1,18 +1,12 @@
 import React from 'react';
 import {VarselModal, VarselModalType} from '../varselmodal/varselmodal';
-import {BodyShort, Button, Heading} from '@navikt/ds-react';
+import {BodyShort, Button} from '@navikt/ds-react';
 
 export enum ErrorModalType {
     OPPDATERE,
     LAGRE,
     SLETTE
 }
-
-const errorModalTypeToTittel = new Map<ErrorModalType, string>([
-    [ErrorModalType.LAGRE, 'Filteret kunne ikke opprettes'],
-    [ErrorModalType.OPPDATERE, 'Filteret kunne ikke lagres'],
-    [ErrorModalType.SLETTE, 'Filteret kunne ikke slettes']
-]);
 
 const errorModaltypeTilTittel: {[key in ErrorModalType]: string} = {
     [ErrorModalType.LAGRE]: 'Filteret kunne ikke opprettes',

--- a/src/components/modal/modal-tildelinger-ok.tsx
+++ b/src/components/modal/modal-tildelinger-ok.tsx
@@ -21,12 +21,7 @@ export function TildelingerOk({fnr, isOpen, onRequestClose}: Props) {
         >
             <BodyShort size="small">Følgende bruker(e) ble tildelt veileder:</BodyShort>
             <FnrList listeMedFnr={fnr} />
-            <Button
-                size="small"
-                type="submit"
-                onClick={onRequestClose}
-                className="tildeling-veileder-modal__lukk-knapp"
-            >
+            <Button size="small" type="submit" onClick={onRequestClose}>
                 Lukk
             </Button>
         </VarselModal>

--- a/src/components/modal/modal-tildelinger-ok.tsx
+++ b/src/components/modal/modal-tildelinger-ok.tsx
@@ -2,7 +2,7 @@ import {VarselModal, VarselModalType} from './varselmodal/varselmodal';
 import React from 'react';
 import {Fnr, FnrList} from '../fnr-list';
 import './feilmelding-brukere.css';
-import {BodyShort, Button, Heading} from '@navikt/ds-react';
+import {BodyShort, Button} from '@navikt/ds-react';
 
 interface Props {
     fnr: Fnr[];
@@ -13,21 +13,20 @@ interface Props {
 export function TildelingerOk({fnr, isOpen, onRequestClose}: Props) {
     return (
         <VarselModal
+            overskrift="Det tar litt tid å overføre informasjonen til oversikten"
             isOpen={isOpen}
             onClose={onRequestClose}
-            portalClassName="tildeling-veileder-modal"
-            className="tildeling-veileder-modal__content"
             type={VarselModalType.SUKSESS}
             dataTestClass="modal-suksess_tildel-veileder" /* Denne utgåva av modal har ingen data-testid-prop, difor brukar vi klassenamn */
         >
-            <div className="tildeling-veileder-modal__tekstgruppe">
-                <Heading size="large" level="1">
-                    Det tar litt tid å overføre informasjonen til oversikten
-                </Heading>
-                <BodyShort size="small">Følgende bruker(e) ble tildelt veileder:</BodyShort>
-                <FnrList listeMedFnr={fnr} />
-            </div>
-            <Button size="small" type="submit" onClick={onRequestClose}>
+            <BodyShort size="small">Følgende bruker(e) ble tildelt veileder:</BodyShort>
+            <FnrList listeMedFnr={fnr} />
+            <Button
+                size="small"
+                type="submit"
+                onClick={onRequestClose}
+                className="tildeling-veileder-modal__lukk-knapp"
+            >
                 Lukk
             </Button>
         </VarselModal>

--- a/src/components/modal/server-feil-modal.tsx
+++ b/src/components/modal/server-feil-modal.tsx
@@ -25,7 +25,7 @@ export default function ServerFeilModal({isOpen, onClose}: ServerFeilModalProps)
             type={VarselModalType.FEIL}
         >
             <BodyShort size="small">Noe gikk feil, prøv igjen senere.</BodyShort>
-            <Button variant="secondary" size="small" className="server-feil-modal__ok-knapp" onClick={lukkModal}>
+            <Button variant="secondary" size="small" onClick={lukkModal}>
                 Ok
             </Button>
         </VarselModal>

--- a/src/components/modal/server-feil-modal.tsx
+++ b/src/components/modal/server-feil-modal.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {useState} from 'react';
 import {VarselModal, VarselModalType} from './varselmodal/varselmodal';
 import './feilmelding-brukere.css';
-import {BodyShort, Button, Heading} from '@navikt/ds-react';
+import {BodyShort, Button} from '@navikt/ds-react';
 
 interface ServerFeilModalProps {
     isOpen: boolean;
@@ -19,20 +19,15 @@ export default function ServerFeilModal({isOpen, onClose}: ServerFeilModalProps)
 
     return (
         <VarselModal
+            overskrift="Handlingen kan ikke utføres"
             isOpen={erAapen}
             onClose={lukkModal}
             type={VarselModalType.FEIL}
-            portalClassName="tildeling-veileder-modal"
         >
-            <div className="server-feil-modal">
-                <Heading size="small" level="1">
-                    Handlingen kan ikke utføres
-                </Heading>
-                <BodyShort size="small">Noe gikk feil, prøv igjen senere.</BodyShort>
-                <Button size="small" className="knapp knapp--hoved " onClick={lukkModal}>
-                    Ok
-                </Button>
-            </div>
+            <BodyShort size="small">Noe gikk feil, prøv igjen senere.</BodyShort>
+            <Button variant="secondary" size="small" className="server-feil-modal__ok-knapp" onClick={lukkModal}>
+                Ok
+            </Button>
         </VarselModal>
     );
 }

--- a/src/components/modal/varselmodal/bekreft-sletting-modal.tsx
+++ b/src/components/modal/varselmodal/bekreft-sletting-modal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {VarselModal, VarselModalType} from './varselmodal';
-import {BodyShort, Button, Heading} from '@navikt/ds-react';
+import {BodyShort, Button} from '@navikt/ds-react';
 import {Delete} from '@navikt/ds-icons';
+import {VarselModal, VarselModalType} from './varselmodal';
 import './varsel-modal.css';
 
 interface BekreftSlettingModalProps {
@@ -21,15 +21,13 @@ function BekreftSlettingModal({isOpen, onRequestClose, onSubmit, tittel, infoTek
 
     return (
         <VarselModal
+            overskrift={tittel}
             isOpen={isOpen}
             onClose={onRequestClose}
             className="bekreft-sletting-modal"
             type={VarselModalType.ADVARSEL}
         >
             <div className="bekreft-sletting-modal__tekstgruppe">
-                <Heading size="large" level="1">
-                    {tittel}
-                </Heading>
                 {infoTekst && <BodyShort size="small">{infoTekst}</BodyShort>}
                 <BodyShort size="small">
                     Er du sikker på at du vil slette <b>{navn}</b>?

--- a/src/components/modal/varselmodal/varsel-modal.css
+++ b/src/components/modal/varselmodal/varsel-modal.css
@@ -44,10 +44,9 @@
     justify-content: center;
     gap: 1rem;
 }
-.server-feil-modal__ok-knapp,
-.feilmelding-tildeling-modal__lukk-knapp,
-.tildeling-veileder-modal__lukk-knapp,
-.veiledergruppe-feilet-modal_ok-knapp {
+
+/* Midtstiller lukk- og ok-knappar */
+.varsel-modal .varsel-modal__innhold button:only-of-type {
     align-self: center;
     min-width: 4rem;
 }

--- a/src/components/modal/varselmodal/varsel-modal.css
+++ b/src/components/modal/varselmodal/varsel-modal.css
@@ -44,3 +44,10 @@
     justify-content: center;
     gap: 1rem;
 }
+.server-feil-modal__ok-knapp,
+.feilmelding-tildeling-modal__lukk-knapp,
+.tildeling-veileder-modal__lukk-knapp,
+.veiledergruppe-feilet-modal_ok-knapp {
+    align-self: center;
+    min-width: 4rem;
+}

--- a/src/components/modal/varselmodal/varsel-modal.css
+++ b/src/components/modal/varselmodal/varsel-modal.css
@@ -3,16 +3,6 @@
     flex-direction: column;
     gap: 1rem;
 }
-.varsel-modal__innhold .error-knapp {
-    margin-top: 1rem;
-}
-.varsel-modal__innhold .typo-normal {
-    word-break: break-word;
-}
-.varsel-modal__ikon {
-    display: flex;
-    justify-content: center;
-}
 .varsel-modal__header .varsel-modal__ikon {
     display: flex;
     justify-content: center;
@@ -28,13 +18,13 @@
     height: auto;
 }
 .varsel-modal__ikon .warning-icon {
-    color: #ff9100;
+    color: var(--a-surface-warning);
 }
 .varsel-modal__ikon .error-icon {
-    color: #ba3a26;
+    color: var(--a-surface-danger);
 }
 .varsel-modal__ikon .success-icon {
-    color: green;
+    color: var(--a-surface-success);
 }
 .varsel-modal .bekreft-sletting-modal__tekstgruppe {
     margin-bottom: 1rem;

--- a/src/components/modal/varselmodal/varsel-modal.css
+++ b/src/components/modal/varselmodal/varsel-modal.css
@@ -1,9 +1,7 @@
 .varsel-modal__innhold {
     display: flex;
     flex-direction: column;
-    align-items: center;
     gap: 1rem;
-    text-align: center;
 }
 .varsel-modal__innhold .error-knapp {
     margin-top: 1rem;
@@ -14,6 +12,16 @@
 .varsel-modal__ikon {
     display: flex;
     justify-content: center;
+}
+.varsel-modal__header .varsel-modal__ikon {
+    display: flex;
+    justify-content: center;
+
+    /* Breidda av lukk-knappen (margin-left, padding i knapp x2, breidd på svg)*/
+    padding-left: calc(var(--a-spacing-4) + var(--a-spacing-1) + 1em + var(--a-spacing-1));
+
+    margin-top: -0.75rem; /* Trekk ikonet litt høgare opp i modalen for å spare plass */
+    margin-bottom: 1rem;
 }
 .varsel-modal__ikon svg {
     width: 4rem;

--- a/src/components/modal/varselmodal/varselmodal.tsx
+++ b/src/components/modal/varselmodal/varselmodal.tsx
@@ -48,6 +48,7 @@ export function VarselModal({
                 </Modal.Header>
             )}
             <Modal.Body>
+                {/*Flytt .varsel-modal__innhold-klassen til body  når migrering er ferdig */}
                 <div className={classNames('varsel-modal__innhold', className)}>
                     {!overskrift && <div className="varsel-modal__ikon">{getIkon(type)}</div>}
                     {children}

--- a/src/components/modal/varselmodal/varselmodal.tsx
+++ b/src/components/modal/varselmodal/varselmodal.tsx
@@ -13,7 +13,7 @@ export enum VarselModalType {
 interface VarselModalProps {
     isOpen: boolean;
     onClose: () => void;
-    overskrift?: string;
+    overskrift: string;
     className?: string;
     portalClassName?: string;
     type: VarselModalType;
@@ -37,23 +37,11 @@ export function VarselModal({
             className={classNames('varsel-modal', portalClassName, dataTestClass)}
             closeOnBackdropClick={true}
         >
-            {overskrift && ( // denne sjekken er berre medan eg migrerer ting
-                <Modal.Header className="varsel-modal__header">
-                    <div className="varsel-modal__ikon">{getIkon(type)}</div>
-                    <Heading size="medium">{overskrift}</Heading>
-                    {/*Til testing:*/}
-                    {/*<Heading size="medium">*/}
-                    {/*    {overskrift || "Overskrift :))"}*/}
-                    {/*</Heading>*/}
-                </Modal.Header>
-            )}
-            <Modal.Body>
-                {/*Flytt .varsel-modal__innhold-klassen til body  når migrering er ferdig */}
-                <div className={classNames('varsel-modal__innhold', className)}>
-                    {!overskrift && <div className="varsel-modal__ikon">{getIkon(type)}</div>}
-                    {children}
-                </div>
-            </Modal.Body>
+            <Modal.Header className="varsel-modal__header">
+                <div className="varsel-modal__ikon">{getIkon(type)}</div>
+                <Heading size="medium">{overskrift}</Heading>
+            </Modal.Header>
+            <Modal.Body className={classNames('varsel-modal__innhold', className)}>{children}</Modal.Body>
         </Modal>
     );
 }

--- a/src/components/modal/varselmodal/varselmodal.tsx
+++ b/src/components/modal/varselmodal/varselmodal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import './varsel-modal.css';
 import {ErrorFilled, SuccessFilled, WarningFilled} from '@navikt/ds-icons';
-import {Modal} from '@navikt/ds-react';
+import {Heading, Modal} from '@navikt/ds-react';
 
 export enum VarselModalType {
     ADVARSEL,
@@ -13,6 +13,7 @@ export enum VarselModalType {
 interface VarselModalProps {
     isOpen: boolean;
     onClose: () => void;
+    overskrift?: string;
     className?: string;
     portalClassName?: string;
     type: VarselModalType;
@@ -23,6 +24,7 @@ export function VarselModal({
     type,
     isOpen,
     onClose,
+    overskrift,
     children,
     className,
     dataTestClass,
@@ -35,9 +37,19 @@ export function VarselModal({
             className={classNames('varsel-modal', portalClassName, dataTestClass)}
             closeOnBackdropClick={true}
         >
+            {overskrift && ( // denne sjekken er berre medan eg migrerer ting
+                <Modal.Header className="varsel-modal__header">
+                    <div className="varsel-modal__ikon">{getIkon(type)}</div>
+                    <Heading size="medium">{overskrift}</Heading>
+                    {/*Til testing:*/}
+                    {/*<Heading size="medium">*/}
+                    {/*    {overskrift || "Overskrift :))"}*/}
+                    {/*</Heading>*/}
+                </Modal.Header>
+            )}
             <Modal.Body>
                 <div className={classNames('varsel-modal__innhold', className)}>
-                    <div className="varsel-modal__ikon">{getIkon(type)}</div>
+                    {!overskrift && <div className="varsel-modal__ikon">{getIkon(type)}</div>}
                     {children}
                 </div>
             </Modal.Body>

--- a/src/components/modal/veiledergruppe/ulagrede-endringer-modal.tsx
+++ b/src/components/modal/veiledergruppe/ulagrede-endringer-modal.tsx
@@ -12,29 +12,25 @@ interface EndringerIkkeLagretModalProps {
 function EndringerIkkeLagretModal({isOpen, onRequestClose, onSubmit}: EndringerIkkeLagretModalProps) {
     return (
         <VarselModal
+            overskrift="Endringene er ikke lagret"
             isOpen={isOpen}
             onClose={onRequestClose}
-            className="endringer-ikke-lagret-modal"
+            className="endringer-ikke-lagret-modal__knappegruppe"
             type={VarselModalType.ADVARSEL}
         >
-            <Heading size="large" level="1" className="endringer-ikke-lagret-modal__innholdstittel">
-                Endringene er ikke lagret
-            </Heading>
-            <div className="endringer-ikke-lagret-modal__knappegruppe">
-                <Button size="small" type="button" onClick={onRequestClose}>
-                    Gå tilbake til redigering
-                </Button>
-                <Button
-                    size="small"
-                    variant="danger"
-                    type="submit"
-                    onClick={() => {
-                        onSubmit();
-                    }}
-                >
-                    Lukk uten å lagre
-                </Button>
-            </div>
+            <Button size="small" type="button" onClick={onRequestClose}>
+                Gå tilbake til redigering
+            </Button>
+            <Button
+                size="small"
+                variant="danger"
+                type="submit"
+                onClick={() => {
+                    onSubmit();
+                }}
+            >
+                Lukk uten å lagre
+            </Button>
         </VarselModal>
     );
 }

--- a/src/components/modal/veiledergruppe/veiledergruppe-modal.css
+++ b/src/components/modal/veiledergruppe/veiledergruppe-modal.css
@@ -141,10 +141,6 @@
     max-width: 448px;
 }
 
-.endringer-ikke-lagret-modal {
-    text-align: center;
-}
-
 .endringer-ikke-lagret-modal__knappegruppe {
     display: flex;
     justify-content: space-evenly;

--- a/src/components/modal/veiledergruppe/veiledergruppe-modal.css
+++ b/src/components/modal/veiledergruppe/veiledergruppe-modal.css
@@ -121,22 +121,6 @@
     margin-left: auto !important;
 }
 
-.veiledergruppe-modal .veiledergruppe-feilet-modal {
-    text-align: center;
-    padding: 2rem;
-}
-
-.veiledergruppe-modal .veiledergruppe-feilet-modal__tekstgruppe {
-    margin: 1rem 0 2rem 0 !important;
-}
-
-.veiledergruppe-modal .veiledergruppe-feilet-modal__knappegruppe {
-    display: flex;
-    justify-content: space-evenly;
-    flex-direction: column;
-    margin: 0.5rem 5rem 0;
-}
-
 .advarsel-modal .modal__overlay .ReactModal__Content {
     max-width: 448px;
 }

--- a/src/components/modal/veiledergruppe/veiledergruppeendring-feilet-modal.tsx
+++ b/src/components/modal/veiledergruppe/veiledergruppeendring-feilet-modal.tsx
@@ -19,12 +19,7 @@ function VeiledergruppeendringFeiletModal({
     return (
         <VarselModal overskrift={innholdstittel} isOpen={isOpen} onClose={onRequestClose} type={VarselModalType.FEIL}>
             <BodyShort size="small">{tekst}</BodyShort>
-            <Button
-                size="small"
-                type="submit"
-                onClick={onRequestClose}
-                className="veiledergruppe-feilet-modal_ok-knapp"
-            >
+            <Button size="small" type="submit" onClick={onRequestClose}>
                 Ok
             </Button>
         </VarselModal>

--- a/src/components/modal/veiledergruppe/veiledergruppeendring-feilet-modal.tsx
+++ b/src/components/modal/veiledergruppe/veiledergruppeendring-feilet-modal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {VarselModal, VarselModalType} from '../varselmodal/varselmodal';
 import './veiledergruppe-modal.css';
-import {BodyShort, Button, Heading} from '@navikt/ds-react';
+import {BodyShort, Button} from '@navikt/ds-react';
 
 interface VeiledergruppeendringFeiletProps {
     isOpen: boolean;
@@ -17,23 +17,16 @@ function VeiledergruppeendringFeiletModal({
     tekst
 }: VeiledergruppeendringFeiletProps) {
     return (
-        <VarselModal
-            isOpen={isOpen}
-            onClose={onRequestClose}
-            className="veiledergruppe-feilet-modal"
-            type={VarselModalType.FEIL}
-        >
-            <div className="veiledergruppe-feilet-modal__tekstgruppe">
-                <Heading size="large" level="1">
-                    {innholdstittel}
-                </Heading>
-                <BodyShort size="small">{tekst}</BodyShort>
-            </div>
-            <div className="veiledergruppe-feilet-modal__knappegruppe">
-                <Button size="small" type="submit" onClick={onRequestClose}>
-                    Ok
-                </Button>
-            </div>
+        <VarselModal overskrift={innholdstittel} isOpen={isOpen} onClose={onRequestClose} type={VarselModalType.FEIL}>
+            <BodyShort size="small">{tekst}</BodyShort>
+            <Button
+                size="small"
+                type="submit"
+                onClick={onRequestClose}
+                className="veiledergruppe-feilet-modal_ok-knapp"
+            >
+                Ok
+            </Button>
         </VarselModal>
     );
 }


### PR DESCRIPTION
Alle varselmodalane brukar no header frå designsystemet. Det betyr at dei har fått lukkeknapp igjen etter oppdateringa frå v4 til v5 av designsystemet.

Eg har også gått over stylinga på modalane og venstrejustert all tekst. Spesielt dei stadane ein hadde fleire linjer tekst vil dette forhåpentlegvis gje eit litt ryddigare uttrykk, sidan alt no ligg langs same marg.