### PR TITLE
Fiks feil hvor appen ikke ville laste pga. at vi ikke fant internarbeidsflatedecorator-assets

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,8 +7,8 @@
         <link rel="icon" href="/favicon.ico" sizes="any"> <!-- localhost -->
         <link rel="icon" href="/favicon.svg" type="image/svg+xml"> <!-- AzureAd kommer fra internarbeidsflatedecorator -->
         <link rel="icon" href="/veilarbportefoljeflatefs/favicon.ico" type="image/x-icon" /> <!-- openAm -->
-        <script src="/internarbeidsflatedecorator/v2.1/static/js/head.v2.min.js"></script>
-        <link rel="stylesheet" href="/internarbeidsflatedecorator/v2.1/static/css/main.css" />
+        <script src="%PUBLIC_URL%/internarbeidsflatedecorator/v2.1/static/js/head.v2.min.js"></script>
+        <link rel="stylesheet" href="%PUBLIC_URL%/internarbeidsflatedecorator/v2.1/static/css/main.css" />
         <link
                 rel="preload"
                 href="https://cdn.nav.no/aksel/fonts/SourceSans3-normal.woff2"

--- a/src/mocks/api/modiacontextholder.ts
+++ b/src/mocks/api/modiacontextholder.ts
@@ -51,6 +51,17 @@ export const modiacontextholderHandlers: RequestHandler[] = [
             });
         })
     ),
+    http.get('https://app.adeo.no/modiacontextholder/api/decorator', async () => {
+        await delay(DEFAULT_DELAY_MILLISECONDS);
+
+        return HttpResponse.json({
+            enheter: innloggetVeileder.enheter,
+            etternavn: innloggetVeileder.etternavn,
+            fornavn: innloggetVeileder.fornavn,
+            ident: innloggetVeileder.ident,
+            navn: innloggetVeileder.navn
+        });
+    }),
     http.post(
         '/modiacontextholder/api/context',
         withAuth(async () => {


### PR DESCRIPTION
Det var noe kluss der vi forsøkte å hente internarbeidsflatedecorator-assets fra feil path (`https://navikt.github.io/internarbeidsflatedecorator/**` i stedet for `https://navikt.github.io/veilarbportefoljeflatefs/internarbeidsflatedecorator/**`).

Fikset dette ved å inkludere `%PUBLIC_URL%` i `index.html` hvor vi inkluderer filene.

Måtte også mocke ut `https://app.adeo.no/modiacontextholder/api/decorator`. Vet ikke helt hvorfor. Ser også at det er noen andre `https://app.adeo.no/*`-URLer som feiler i network tab-en, men disse var ikke nødvendig å mocke for å få demoen til å kjøre. Mulig det er noe logikk i [/public/internarbeidsflatedecorator](https://github.com/navikt/veilarbportefoljeflatefs/tree/master/public/internarbeidsflatedecorator) som forventer en miljøvariabel eller noe for å bruke riktig path (dvs: den burde jo pekt på base path `https://navikt.github.no` slik som de andre kallene gjør). 

![Screenshot 2024-05-10 at 12 48 41](https://github.com/navikt/veilarbportefoljeflatefs/assets/111113539/44409b8b-5147-4786-ba00-1cc781db1f10)

---

For å teste PR-en kan man deploye denne branchen (`fiks-gh-pages`) [her](https://github.com/navikt/veilarbportefoljeflatefs/actions/workflows/update-github-pages.yaml).