### PR TITLE
Vis huskelappikon både når personen har huskelapp og arbeidsliste

### DIFF
--- a/src/minoversikt/huskelapp/HuskelappIkonInngang.tsx
+++ b/src/minoversikt/huskelapp/HuskelappIkonInngang.tsx
@@ -10,6 +10,9 @@ export const HuskelappIkonInngang = ({bruker}: {bruker: BrukerModell}) => {
     const [skalLagEllerEndreHuskelappModalVises, setSkalLagEllerEndreHuskelappModalVises] = useState<boolean>(false);
     const [modalVisHuskelappSkalVises, setModalVisHuskelappSkalVises] = useState<boolean>(false);
 
+    const arbeidslisteAktiv = bruker.arbeidsliste?.arbeidslisteAktiv;
+    const harHuskelappEllerArbeidsliste = !!bruker.huskelapp || arbeidslisteAktiv;
+
     function visEllerRedigerHuskelapp() {
         bruker.huskelapp ? setModalVisHuskelappSkalVises(true) : setSkalLagEllerEndreHuskelappModalVises(true);
     }
@@ -33,7 +36,7 @@ export const HuskelappIkonInngang = ({bruker}: {bruker: BrukerModell}) => {
                 variant="tertiary"
                 onClick={visEllerRedigerHuskelapp}
                 icon={
-                    bruker.huskelapp ? (
+                    harHuskelappEllerArbeidsliste ? (
                         <HuskelappIkon className="huskelappikon" />
                     ) : (
                         <HuskelappIkonTomt className="huskelappikon" />


### PR DESCRIPTION
Dette gjer at ikonet vert brukt likt som i veilarbvisittkort.


Mål:
Skal ha ikon for huskelapp både når personen har huskelapp og når dei har arbeidsliste.
Frå før hadde dei "tomt ikon" når dei hadde arbeidsliste.