### PR TITLE
Ikke slette fargekategori om du sletter arbeidsliste ved migrering til huskelapp

### DIFF
--- a/cypress/e2e/arbeidsliste_spec.js
+++ b/cypress/e2e/arbeidsliste_spec.js
@@ -8,113 +8,12 @@ before('Start server', () => {
 });
 
 describe('Arbeidsliste', () => {
-    it('Lag én ny arbeidsliste og sjekk validering', () => {
-        // Vel fyrste brukar i lista
-        cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
-        cy.checkboxFirst('min-oversikt_brukerliste-checkbox');
-
-        // Opne legg-i-arbeidsliste_modal
-        cy.get('.testid_legg-i-arbeidsliste_modal').should('not.exist');
-        cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled').click();
-        cy.get('.testid_legg-i-arbeidsliste_modal').should('be.visible');
-
-        // Testar validering av tittel-input
-        cy.getByTestId('modal_arbeidsliste_tittel').type('valideringstest på at det ikke er lov med tegn mer enn 30');
-        cy.getByTestId('modal_arbeidsliste_lagre-knapp').click();
-        cy.getByTestId('modal_arbeidsliste_form').contains('Tittelen kan ikke være lenger enn 30 tegn.');
-        cy.getByTestId('modal_arbeidsliste_form').should('not.contain', 'Du må fylle ut en tittel');
-
-        // Testar validering av kommentar-input
-        cy.getByTestId('modal_arbeidsliste_kommentar').type('valideringskommentar skal ikke være lengre enn 500 tegn, så her kommer litt lorum ipsum: Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release...');
-        cy.getByTestId('modal_arbeidsliste_form').contains('Du må korte ned teksten til 500 tegn');
-        cy.getByTestId('modal_arbeidsliste_form').should('not.contain', 'Du må fylle ut en kommentar');
-
-        cy.getByTestId('modal_arbeidsliste_avbryt-knapp').click();
-    });
-
-    it('Lagre ny arbeidsliste', () => {
-        // Opnar "Legg i arbeidsliste"-modal igjen
-        cy.checkboxFirst('min-oversikt_brukerliste-checkbox');
-        cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled').click();
-
-        // Nullstillar tittel og kommentar og skriv inn gyldig input
-        cy.getByTestId('modal_arbeidsliste_tittel').type('validering');
-        cy.getByTestId('modal_arbeidsliste_kommentar').type('valideringskommentar');
-
-        // Set ein frist og kategori
-        cy.get('#fristDatovelger').type('01.03.2066');
-        cy.getByTestId('modal_arbeidslistekategori_GUL').click();
-
-        cy.getByTestId('modal_legg-i-arbeidsliste_navn').then(($navn) => {
-            // Hugsar fornamnet til brukaren vi har valgt
-            const fornavn = $navn.text().split(' ')[0];
-
-            // Lagre innholdet som vart skrive inn i test "Lag én ny arbeidsliste og sjekk validering"
-            cy.getByTestId('modal_arbeidsliste_lagre-knapp').click();
-
-            // Desse testane er litt ustabile så vi kommenterer dei ut. 2024-04-19 Ingrid og Klara
-            // // Laster-modal
-            // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('be.visible');
-            // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('not.exist');
-            cy.wait(300); // Ventar på at laster-modalen skal forsvinne
-
-            // Sjekk at brukaren er i lista
-            cy.get('.testid_legg-i-arbeidsliste_modal').should('not.exist');
-            cy.getByTestId('brukerliste_element_arbeidsliste-GUL').contains(fornavn).first();
-        });
-    });
-
-    it('Lag to nye arbeidslister', () => {
-        // Finn alle brukarar som har arbeidslister frå før
-        cy.get('[data-cy=brukerliste_element_arbeidsliste]').as('elementIArbeidsliste').then(elementIArbeidslisteFor => {
-            // Sjekk at vi fann nokon element
-            expect(elementIArbeidslisteFor.length).to.be.greaterThan(0);
-
-            // Vel fyrste og siste brukar i arbeidslista
-            cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
-            cy.checkboxFirst('min-oversikt_brukerliste-checkbox');
-            cy.checkboxLast('min-oversikt_brukerliste-checkbox');
-
-            // Opne legg-til-i-arbeidsliste_modal
-            cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
-            cy.get('.testid_legg-i-arbeidsliste_modal').should('not.exist');
-            cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled').click();
-            cy.get('.testid_legg-i-arbeidsliste_modal').should('be.visible');
-
-            // Fyll ut innhald for fyrste brukar
-            cy.getByTestId('modal_arbeidsliste_tittel').type('arbeidslistetittel');
-            cy.getByTestId('modal_arbeidsliste_kommentar').type('arbeidslistekommentar');
-            cy.getByTestId('modal_arbeidslistekategori_LILLA').click();
-
-            // Fyll ut innhald for andre brukar
-            cy.getByTestId('modal_arbeidsliste_tittel_1').type('heiheihei hallå');
-            cy.getByTestId('modal_arbeidsliste_kommentar_1').type('Team Voff er best i test hehehe');
-
-            // Lagre arbeidslistene
-            cy.getByTestId('modal_arbeidsliste_lagre-knapp').click();
-
-            // Sjekk at modal er lukka og laster-modal fungerer
-            cy.get('.testid_legg-i-arbeidsliste_modal').should('not.exist');
-            // Testinga av laster-modal er litt ustabil så vi kommenterer den ut. 2024-04-19 Ingrid og Klara
-            // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('be.visible');
-            // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('not.exist');
-            cy.wait(400); // Ventar på at laster-modalen skal forsvinne
-
-            // Samanlikn talet på brukarar med arbeidslister før og etter at ein har oppretta nye
-            cy.get('@elementIArbeidsliste')
-                .then((elementIArbeidslisteEtter) => {
-                    expect(elementIArbeidslisteEtter.length).to.equal(elementIArbeidslisteFor.length + 2);
-                });
-        });
-    });
-
     it('Sjekker åpning og lukking av arbeidslistepanel i oversikten', () => {
         cy.apneForsteArbeidslistepanelOgValiderApning();
         cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_tittel').should('be.visible');
 
         cy.lukkForsteArbeidslistepanelOgValiderLukking();
     });
-
 
     it('Rediger arbeidsliste', () => {
         const redigertTittel = 'Redigering av tittel';
@@ -128,8 +27,7 @@ describe('Arbeidsliste', () => {
         cy.getByTestId('min-oversikt_arbeidslistepanel-arbeidsliste_rediger-knapp').should('be.visible').click();
 
         // Modalen viser rett ting
-        cy.getByTestId('arbeidsliste-rediger-modal').should('be.visible')
-            .contains('Rediger arbeidsliste');
+        cy.getByTestId('arbeidsliste-rediger-modal').should('be.visible').contains('Rediger arbeidsliste');
 
         // Skriv inn ny tekst for tittel og kommentar
         cy.getByTestId('modal_arbeidsliste_tittel').clear().type(redigertTittel);
@@ -146,63 +44,69 @@ describe('Arbeidsliste', () => {
 
     it('Slett arbeidsliste via fjern-knapp', () => {
         // Tel kor mange arbeidslister det er
-        cy.get('[data-cy=brukerliste_element_arbeidsliste]').as('elementIArbeidsliste').then(antallArbeidslisterForSletting => {
-            // Finn checkboksen til den fyrste personen med arbeidsliste
-            cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
-            cy.checkboxFirst('min-oversikt_brukerliste-checkbox_arbeidsliste');
+        cy.get('[data-cy=brukerliste_element_arbeidsliste]')
+            .as('elementIArbeidsliste')
+            .then(antallArbeidslisterForSletting => {
+                // Finn checkboksen til den fyrste personen med arbeidsliste
+                cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
+                cy.checkboxFirst('min-oversikt_brukerliste-checkbox_arbeidsliste');
 
-            // Fjern personen frå arbeidslista
-            cy.getByTestId('fjern-fra-arbeidsliste_knapp').should('be.enabled').click();
-            cy.getByTestId('modal_varsel_fjern-fra-arbeidsliste_bekreft-knapp').should('be.visible').click();
+                // Fjern personen frå arbeidslista
+                cy.getByTestId('fjern-fra-arbeidsliste_knapp').should('be.enabled').click();
+                cy.getByTestId('modal_varsel_fjern-fra-arbeidsliste_bekreft-knapp').should('be.visible').click();
 
-            // Laster-modal oppfører seg som venta
-            // Testinga av laster-modal er litt ustabil så vi kommenterer den ut. 2024-04-19 Ingrid og Klara
-            // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('be.visible');
-            // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('not.exist');
-            cy.wait(300); // Ventar på at laster-modalen skal forsvinne
-            cy.getByTestId('modal_varsel_fjern-fra-arbeidsliste_bekreft-knapp').should('not.exist');
+                // Laster-modal oppfører seg som venta
+                // Testinga av laster-modal er litt ustabil så vi kommenterer den ut. 2024-04-19 Ingrid og Klara
+                // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('be.visible');
+                // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('not.exist');
+                cy.wait(300); // Ventar på at laster-modalen skal forsvinne
+                cy.getByTestId('modal_varsel_fjern-fra-arbeidsliste_bekreft-knapp').should('not.exist');
 
-            // Sjekk at det er 1 færre arbeidslister no enn før slettinga
-            cy.get('@elementIArbeidsliste')
-                .should('be.visible')
-                .then(antallArbeidslisterEtterSletting => {
-                    expect(antallArbeidslisterEtterSletting.length)
-                        .to.equal(antallArbeidslisterForSletting.length - 1);
-                });
-        });
+                // Sjekk at det er 1 færre arbeidslister no enn før slettinga
+                cy.get('@elementIArbeidsliste')
+                    .should('be.visible')
+                    .then(antallArbeidslisterEtterSletting => {
+                        expect(antallArbeidslisterEtterSletting.length).to.equal(
+                            antallArbeidslisterForSletting.length - 1
+                        );
+                    });
+            });
     });
 
     it('Slett arbeidsliste via rediger-modal', () => {
         // Hentar brukarane med arbeidslister før sletting
-        cy.get('[data-cy=brukerliste_element_arbeidsliste]').as('elementIArbeidsliste').then(antallArbeidslisterForSletting => {
-            // Opne arbeidslistepanel for den fyrste brukaren som har arbeidsliste
-            cy.apneForsteArbeidslistepanel();
-            cy.getByTestId('arbeidsliste-rediger-modal').should('not.exist');
+        cy.get('[data-cy=brukerliste_element_arbeidsliste]')
+            .as('elementIArbeidsliste')
+            .then(antallArbeidslisterForSletting => {
+                // Opne arbeidslistepanel for den fyrste brukaren som har arbeidsliste
+                cy.apneForsteArbeidslistepanel();
+                cy.getByTestId('arbeidsliste-rediger-modal').should('not.exist');
 
-            // Trykk på redigeringsknapp
-            cy.getByTestId('min-oversikt_arbeidslistepanel-arbeidsliste_rediger-knapp').click();
-            cy.getByTestId('arbeidsliste-rediger-modal').should('be.visible');
+                // Trykk på redigeringsknapp
+                cy.getByTestId('min-oversikt_arbeidslistepanel-arbeidsliste_rediger-knapp').click();
+                cy.getByTestId('arbeidsliste-rediger-modal').should('be.visible');
 
-            // Fjern arbeidslista
-            cy.getByTestId('modal_rediger-arbeidsliste_fjern-knapp').click();
-            cy.getByTestId('modal_varsel_fjern-fra-arbeidsliste_bekreft-knapp').should('be.visible').click();
+                // Fjern arbeidslista
+                cy.getByTestId('modal_rediger-arbeidsliste_fjern-knapp').click();
+                cy.getByTestId('modal_varsel_fjern-fra-arbeidsliste_bekreft-knapp').should('be.visible').click();
 
-            // Laster-modal oppfører seg som venta
-            // Testinga av laster-modal er litt ustabil så vi kommenterer den ut. 2024-04-19 Ingrid og Klara
-            // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('be.visible');
-            // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('not.exist');
-            cy.wait(300); // Ventar på at laster-modalen skal forsvinne
-            cy.getByTestId('modal_varsel_fjern-fra-arbeidsliste_bekreft-knapp').should('not.exist');
+                // Laster-modal oppfører seg som venta
+                // Testinga av laster-modal er litt ustabil så vi kommenterer den ut. 2024-04-19 Ingrid og Klara
+                // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('be.visible');
+                // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('not.exist');
+                cy.wait(300); // Ventar på at laster-modalen skal forsvinne
+                cy.getByTestId('modal_varsel_fjern-fra-arbeidsliste_bekreft-knapp').should('not.exist');
 
-            // Sjekk at det er 1 færre arbeidslister no enn før slettinga
-            cy.get('@elementIArbeidsliste')
-                .should('be.visible')
-                .wait(200)
-                .then(antallArbeidslisterEtterSletting => {
-                    expect(antallArbeidslisterEtterSletting.length)
-                        .to.equal(antallArbeidslisterForSletting.length - 1);
-                });
-        });
+                // Sjekk at det er 1 færre arbeidslister no enn før slettinga
+                cy.get('@elementIArbeidsliste')
+                    .should('be.visible')
+                    .wait(200)
+                    .then(antallArbeidslisterEtterSletting => {
+                        expect(antallArbeidslisterEtterSletting.length).to.equal(
+                            antallArbeidslisterForSletting.length - 1
+                        );
+                    });
+            });
     });
 
     it('Sjekk validering i rediger arbeidsliste-modal', () => {
@@ -260,30 +164,136 @@ describe('Arbeidsliste', () => {
         cy.apneForsteArbeidslistepanel();
 
         // Finn tittel-elementet
-        cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_tittel').as('tittel').then(tittelForRedigering => {
-            // Finn kommentar-elementet også
-            cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_kommentar').as('kommentar').then(kommentarForRedigering => {
-                const nyTittel = 'Skal ikke lagres';
-                const nyKommentar = 'Kommentar skal heller ikke lagres';
+        cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_tittel')
+            .as('tittel')
+            .then(tittelForRedigering => {
+                // Finn kommentar-elementet også
+                cy.getByTestId('arbeidslistepanel_arbeidslisteinnhold_kommentar')
+                    .as('kommentar')
+                    .then(kommentarForRedigering => {
+                        const nyTittel = 'Skal ikke lagres';
+                        const nyKommentar = 'Kommentar skal heller ikke lagres';
 
-                // Trykkar på rediger-knapp
-                cy.getByTestId('arbeidsliste-rediger-modal').should('not.exist');
-                cy.getByTestId('min-oversikt_arbeidslistepanel-arbeidsliste_rediger-knapp').click();
-                cy.getByTestId('arbeidsliste-rediger-modal').should('be.visible');
+                        // Trykkar på rediger-knapp
+                        cy.getByTestId('arbeidsliste-rediger-modal').should('not.exist');
+                        cy.getByTestId('min-oversikt_arbeidslistepanel-arbeidsliste_rediger-knapp').click();
+                        cy.getByTestId('arbeidsliste-rediger-modal').should('be.visible');
 
-                // Skriv inn ny tekst i modalen
-                cy.getByTestId('modal_arbeidsliste_tittel').clear().type(nyTittel);
-                cy.getByTestId('modal_arbeidsliste_kommentar').clear().type(nyKommentar);
+                        // Skriv inn ny tekst i modalen
+                        cy.getByTestId('modal_arbeidsliste_tittel').clear().type(nyTittel);
+                        cy.getByTestId('modal_arbeidsliste_kommentar').clear().type(nyKommentar);
 
-                // Trykkar "Avbryt"
-                cy.getByTestId('modal_rediger-arbeidsliste_avbryt-knapp').click();
+                        // Trykkar "Avbryt"
+                        cy.getByTestId('modal_rediger-arbeidsliste_avbryt-knapp').click();
 
-                // Sjekkar at teksten ikkje vart endra
-                cy.get('@tittel').should('contain', tittelForRedigering.text());
-                cy.get('@kommentar').should('contain', kommentarForRedigering.text());
+                        // Sjekkar at teksten ikkje vart endra
+                        cy.get('@tittel').should('contain', tittelForRedigering.text());
+                        cy.get('@kommentar').should('contain', kommentarForRedigering.text());
+                    });
             });
-        });
 
         cy.lukkForsteArbeidslistepanel();
+    });
+    it('Lag én ny arbeidsliste og sjekk validering', () => {
+        // Vel fyrste brukar i lista
+        cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
+        cy.checkboxFirst('min-oversikt_brukerliste-checkbox');
+
+        // Opne legg-i-arbeidsliste_modal
+        cy.get('.testid_legg-i-arbeidsliste_modal').should('not.exist');
+        cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled').click();
+        cy.get('.testid_legg-i-arbeidsliste_modal').should('be.visible');
+
+        // Testar validering av tittel-input
+        cy.getByTestId('modal_arbeidsliste_tittel').type('valideringstest på at det ikke er lov med tegn mer enn 30');
+        cy.getByTestId('modal_arbeidsliste_lagre-knapp').click();
+        cy.getByTestId('modal_arbeidsliste_form').contains('Tittelen kan ikke være lenger enn 30 tegn.');
+        cy.getByTestId('modal_arbeidsliste_form').should('not.contain', 'Du må fylle ut en tittel');
+
+        // Testar validering av kommentar-input
+        cy.getByTestId('modal_arbeidsliste_kommentar').type(
+            "valideringskommentar skal ikke være lengre enn 500 tegn, så her kommer litt lorum ipsum: Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release..."
+        );
+        cy.getByTestId('modal_arbeidsliste_form').contains('Du må korte ned teksten til 500 tegn');
+        cy.getByTestId('modal_arbeidsliste_form').should('not.contain', 'Du må fylle ut en kommentar');
+
+        cy.getByTestId('modal_arbeidsliste_avbryt-knapp').click();
+    });
+
+    it('Lagre ny arbeidsliste', () => {
+        // Opnar "Legg i arbeidsliste"-modal igjen
+        cy.checkboxFirst('min-oversikt_brukerliste-checkbox');
+        cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled').click();
+
+        // Nullstillar tittel og kommentar og skriv inn gyldig input
+        cy.getByTestId('modal_arbeidsliste_tittel').type('validering');
+        cy.getByTestId('modal_arbeidsliste_kommentar').type('valideringskommentar');
+
+        // Set ein frist og kategori
+        cy.get('#fristDatovelger').type('01.03.2066');
+        cy.getByTestId('modal_arbeidslistekategori_GUL').click();
+
+        cy.getByTestId('modal_legg-i-arbeidsliste_navn').then($navn => {
+            // Hugsar fornamnet til brukaren vi har valgt
+            const fornavn = $navn.text().split(' ')[0];
+
+            // Lagre innholdet som vart skrive inn i test "Lag én ny arbeidsliste og sjekk validering"
+            cy.getByTestId('modal_arbeidsliste_lagre-knapp').click();
+
+            // Desse testane er litt ustabile så vi kommenterer dei ut. 2024-04-19 Ingrid og Klara
+            // // Laster-modal
+            // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('be.visible');
+            // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('not.exist');
+            cy.wait(300); // Ventar på at laster-modalen skal forsvinne
+
+            // Sjekk at brukaren er i lista
+            cy.get('.testid_legg-i-arbeidsliste_modal').should('not.exist');
+            cy.getByTestId('brukerliste_element_arbeidsliste-GUL').contains(fornavn).first();
+        });
+    });
+
+    it('Lag to nye arbeidslister', () => {
+        // Finn alle brukarar som har arbeidslister frå før
+        cy.get('[data-cy=brukerliste_element_arbeidsliste]')
+            .as('elementIArbeidsliste')
+            .then(elementIArbeidslisteFor => {
+                // Sjekk at vi fann nokon element
+                expect(elementIArbeidslisteFor.length).to.be.greaterThan(0);
+
+                // Vel fyrste og siste brukar i arbeidslista
+                cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
+                cy.checkboxFirst('min-oversikt_brukerliste-checkbox');
+                cy.checkboxLast('min-oversikt_brukerliste-checkbox');
+
+                // Opne legg-til-i-arbeidsliste_modal
+                cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled');
+                cy.get('.testid_legg-i-arbeidsliste_modal').should('not.exist');
+                cy.getByTestId('legg-i-arbeidsliste_knapp').should('be.enabled').click();
+                cy.get('.testid_legg-i-arbeidsliste_modal').should('be.visible');
+
+                // Fyll ut innhald for fyrste brukar
+                cy.getByTestId('modal_arbeidsliste_tittel').type('arbeidslistetittel');
+                cy.getByTestId('modal_arbeidsliste_kommentar').type('arbeidslistekommentar');
+                cy.getByTestId('modal_arbeidslistekategori_LILLA').click();
+
+                // Fyll ut innhald for andre brukar
+                cy.getByTestId('modal_arbeidsliste_tittel_1').type('heiheihei hallå');
+                cy.getByTestId('modal_arbeidsliste_kommentar_1').type('Team Voff er best i test hehehe');
+
+                // Lagre arbeidslistene
+                cy.getByTestId('modal_arbeidsliste_lagre-knapp').click();
+
+                // Sjekk at modal er lukka og laster-modal fungerer
+                cy.get('.testid_legg-i-arbeidsliste_modal').should('not.exist');
+                // Testinga av laster-modal er litt ustabil så vi kommenterer den ut. 2024-04-19 Ingrid og Klara
+                // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('be.visible');
+                // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('not.exist');
+                cy.wait(400); // Ventar på at laster-modalen skal forsvinne
+
+                // Samanlikn talet på brukarar med arbeidslister før og etter at ein har oppretta nye
+                cy.get('@elementIArbeidsliste').then(elementIArbeidslisteEtter => {
+                    expect(elementIArbeidslisteEtter.length).to.equal(elementIArbeidslisteFor.length + 2);
+                });
+            });
     });
 });

--- a/cypress/e2e/arbeidsliste_spec.js
+++ b/cypress/e2e/arbeidsliste_spec.js
@@ -98,7 +98,7 @@ describe('Arbeidsliste', () => {
             // Testinga av laster-modal er litt ustabil så vi kommenterer den ut. 2024-04-19 Ingrid og Klara
             // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('be.visible');
             // cy.getByTestId('veilarbportefoljeflatefs-laster-modal').should('not.exist');
-            cy.wait(300); // Ventar på at laster-modalen skal forsvinne
+            cy.wait(400); // Ventar på at laster-modalen skal forsvinne
 
             // Samanlikn talet på brukarar med arbeidslister før og etter at ein har oppretta nye
             cy.get('@elementIArbeidsliste')
@@ -197,6 +197,7 @@ describe('Arbeidsliste', () => {
             // Sjekk at det er 1 færre arbeidslister no enn før slettinga
             cy.get('@elementIArbeidsliste')
                 .should('be.visible')
+                .wait(200)
                 .then(antallArbeidslisterEtterSletting => {
                     expect(antallArbeidslisterEtterSletting.length)
                         .to.equal(antallArbeidslisterForSletting.length - 1);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -137,12 +137,12 @@ Cypress.Commands.add('apneForsteArbeidslistepanelOgValiderApning', () => {
     cy.getByTestId('min-oversikt_brukerliste-arbeidslistepanel_arbeidsliste')
         .children()
         .first()
-        .as('btn')
+        .as('arbeidsliste-chevron')
         .children()
         .first()
         .should('have.class', 'expand-testid');
 
-    cy.get('@btn').click();
+    cy.get('@arbeidsliste-chevron').click();
 
     cy.getByTestId('min-oversikt_brukerliste-arbeidslistepanel_arbeidsliste')
         .children()
@@ -156,12 +156,12 @@ Cypress.Commands.add('apneForsteArbeidslistepanel', () => {
     cy.getByTestId('min-oversikt_brukerliste-arbeidslistepanel_arbeidsliste')
         .children()
         .first()
-        .as('btn')
+        .as('arbeidsliste-chevron')
         .children()
         .first()
         .should('have.class', 'expand-testid');
 
-    cy.get('@btn').click();
+    cy.get('@arbeidsliste-chevron').click();
 });
 
 Cypress.Commands.add('lukkForsteArbeidslistepanelOgValiderLukking', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -137,9 +137,12 @@ Cypress.Commands.add('apneForsteArbeidslistepanelOgValiderApning', () => {
     cy.getByTestId('min-oversikt_brukerliste-arbeidslistepanel_arbeidsliste')
         .children()
         .first()
+        .as('btn')
         .children()
-        .should('have.class', 'expand-testid')
-        .click();
+        .first()
+        .should('have.class', 'expand-testid');
+
+    cy.get('@btn').click();
 
     cy.getByTestId('min-oversikt_brukerliste-arbeidslistepanel_arbeidsliste')
         .children()
@@ -153,9 +156,12 @@ Cypress.Commands.add('apneForsteArbeidslistepanel', () => {
     cy.getByTestId('min-oversikt_brukerliste-arbeidslistepanel_arbeidsliste')
         .children()
         .first()
+        .as('btn')
         .children()
-        .should('have.class', 'expand-testid')
-        .click();
+        .first()
+        .should('have.class', 'expand-testid');
+
+    cy.get('@btn').click();
 });
 
 Cypress.Commands.add('lukkForsteArbeidslistepanelOgValiderLukking', () => {
@@ -182,4 +188,3 @@ Cypress.Commands.add('lukkForsteArbeidslistepanel', () => {
         .should('have.class', 'collapse-testid')
         .click();
 });
-

--- a/src/components/tabell/arbeidslisteikon.tsx
+++ b/src/components/tabell/arbeidslisteikon.tsx
@@ -10,9 +10,14 @@ import {KategoriModell} from '../../model-interfaces';
 interface ArbeidslistekategoriProps {
     kategori: KategoriModell;
     dataTestid?: string;
+    skalVises?: boolean;
 }
 
-export default function ArbeidslistekategoriVisning({kategori, dataTestid}: ArbeidslistekategoriProps) {
+export default function ArbeidslistekategoriVisning({
+    kategori,
+    skalVises = true,
+    dataTestid
+}: ArbeidslistekategoriProps) {
     const velgArbeidslistekategori = () => {
         switch (kategori) {
             case KategoriModell.BLA:
@@ -30,7 +35,7 @@ export default function ArbeidslistekategoriVisning({kategori, dataTestid}: Arbe
 
     return (
         <span className="arbeidsliste--ikon" data-testid="brukerliste_span_arbeidslisteikon">
-            {velgArbeidslistekategori()}
+            {skalVises ? velgArbeidslistekategori() : <div className="tomt-arbeidslisteikon" />}
         </span>
     );
 }

--- a/src/components/toolbar/legg-til-arbeidsliste-knapp.tsx
+++ b/src/components/toolbar/legg-til-arbeidsliste-knapp.tsx
@@ -39,7 +39,8 @@ function ArbeidslisteKnapp() {
         return null;
     }
 
-    const klikk = () => {
+    const klikk = e => {
+        e.preventDefault();
         if (valgteBrukere.length === 0) {
             dispatch(oppdaterBrukerfeil());
         } else {
@@ -55,7 +56,7 @@ function ArbeidslisteKnapp() {
                 className="toolbar_btn"
                 icon={<Bookmark className="toolbar-knapp__ikon" id="arbeidsliste-svg" />}
                 iconPosition="left"
-                onClick={() => klikk()}
+                onClick={klikk}
                 data-testid={
                     inneholderBrukerMedOgUtenArbeidsliste ? 'fjern-fra-arbeidsliste_knapp' : 'legg-i-arbeidsliste_knapp'
                 }

--- a/src/middleware/api.ts
+++ b/src/middleware/api.ts
@@ -231,7 +231,7 @@ export function slettArbeidsliste(arbeidsliste) {
     return fetchToJson(url, config);
 }
 
-export function slettArbeidslisteUtenFargekategori(fnr: string) {
+export function slettArbeidslisteMenIkkeFargekategori(fnr: string) {
     const url = `${VEILARBPORTEFOLJE_URL}/v2/arbeidsliste?slettFargekategori=false`;
     const config = {...MED_CREDENTIALS, method: 'delete', body: JSON.stringify({fnr})};
     return fetchToJson(url, config);

--- a/src/middleware/api.ts
+++ b/src/middleware/api.ts
@@ -231,6 +231,12 @@ export function slettArbeidsliste(arbeidsliste) {
     return fetchToJson(url, config);
 }
 
+export function slettArbeidslisteUtenFargekategori(fnr: string) {
+    const url = `${VEILARBPORTEFOLJE_URL}/v2/arbeidsliste?slettFargekategori=false`;
+    const config = {...MED_CREDENTIALS, method: 'delete', body: JSON.stringify({fnr})};
+    return fetchToJson(url, config);
+}
+
 export function oppdaterFargekategori(fnrlisteOgFargekategori: FargekategoriDataModell) {
     const url = `${VEILARBPORTEFOLJE_URL}/v1/fargekategorier`;
     const config = {...MED_CREDENTIALS, method: 'put', body: JSON.stringify(fnrlisteOgFargekategori)};

--- a/src/minoversikt/huskelapp/redigering/LagEllerEndreHuskelappModal.tsx
+++ b/src/minoversikt/huskelapp/redigering/LagEllerEndreHuskelappModal.tsx
@@ -61,14 +61,14 @@ export const LagEllerEndreHuskelappModal = ({isModalOpen, onModalClose, huskelap
                                         'Du må legge til enten frist eller kommentar for å kunne lagre huskelappen'
                                 });
                             }
-                            const arbeidslisteArray: ArbeidslisteDataModell[] = arbeidsliste
-                                ? [bruker].map(bruker => ({
+                            const arbeidslisteSomSkalSlettes: ArbeidslisteDataModell | null = arbeidsliste
+                                ? {
                                       fnr: bruker.fnr,
                                       kommentar: bruker.arbeidsliste.kommentar ?? null,
                                       frist: bruker.arbeidsliste.frist,
                                       kategori: bruker.arbeidsliste.kategori
-                                  }))
-                                : [];
+                                  }
+                                : null;
                             try {
                                 if (huskelapp?.huskelappId) {
                                     await endreHuskelapp(
@@ -86,7 +86,7 @@ export const LagEllerEndreHuskelappModal = ({isModalOpen, onModalClose, huskelap
                                         bruker,
                                         enhetId!!,
                                         onModalClose,
-                                        arbeidslisteArray
+                                        arbeidslisteSomSkalSlettes
                                     );
                                 }
                             } catch (error) {

--- a/src/minoversikt/huskelapp/redigering/lagreHuskelapp.ts
+++ b/src/minoversikt/huskelapp/redigering/lagreHuskelapp.ts
@@ -6,8 +6,7 @@ import {AppState} from '../../../reducer';
 import {AnyAction} from 'redux';
 import {ArbeidslisteDataModell, BrukerModell} from '../../../model-interfaces';
 import {FormikValues} from 'formik';
-import {slettArbeidslisteAction} from '../../../ducks/arbeidsliste';
-import {oppdaterStateVedSlettArbeidsliste} from './slettEksisterendeArbeidsliste';
+import {slettArbeidslisteUtenFargekategoriOgOppdaterRedux} from './slettEksisterendeArbeidsliste';
 
 export const lagreHuskelapp = async (
     dispatch: ThunkDispatch<AppState, any, AnyAction>,
@@ -15,7 +14,7 @@ export const lagreHuskelapp = async (
     bruker: BrukerModell,
     enhetId: string,
     onModalClose: () => void,
-    arbeidsliste: ArbeidslisteDataModell[]
+    arbeidsliste: ArbeidslisteDataModell | null
 ) => {
     await dispatch(
         lagreHuskelappAction({
@@ -25,11 +24,10 @@ export const lagreHuskelapp = async (
             kommentar: values.kommentar
         })
     );
-    await dispatch(hentHuskelappForBruker(bruker.fnr, enhetId!!));
+    dispatch(hentHuskelappForBruker(bruker.fnr, enhetId!!));
     await dispatch(leggTilStatustall('mineHuskelapper', 1));
-    if (!!arbeidsliste.length) {
-        const res = await dispatch(slettArbeidslisteAction(arbeidsliste));
-        await oppdaterStateVedSlettArbeidsliste(res, arbeidsliste, dispatch);
+    if (!!arbeidsliste) {
+        await slettArbeidslisteUtenFargekategoriOgOppdaterRedux(bruker, dispatch);
     }
-    await onModalClose();
+    onModalClose();
 };

--- a/src/minoversikt/huskelapp/redigering/lagreHuskelapp.ts
+++ b/src/minoversikt/huskelapp/redigering/lagreHuskelapp.ts
@@ -6,7 +6,7 @@ import {AppState} from '../../../reducer';
 import {AnyAction} from 'redux';
 import {ArbeidslisteDataModell, BrukerModell} from '../../../model-interfaces';
 import {FormikValues} from 'formik';
-import {slettArbeidslisteUtenFargekategoriOgOppdaterRedux} from './slettEksisterendeArbeidsliste';
+import {slettArbeidslisteMenIkkeFargekategoriOgOppdaterRedux} from './slettEksisterendeArbeidsliste';
 
 export const lagreHuskelapp = async (
     dispatch: ThunkDispatch<AppState, any, AnyAction>,
@@ -19,15 +19,15 @@ export const lagreHuskelapp = async (
     await dispatch(
         lagreHuskelappAction({
             brukerFnr: bruker.fnr,
-            enhetId: enhetId!!,
+            enhetId: enhetId,
             frist: values.frist?.toString(),
             kommentar: values.kommentar
         })
     );
-    dispatch(hentHuskelappForBruker(bruker.fnr, enhetId!!));
+    dispatch(hentHuskelappForBruker(bruker.fnr, enhetId));
     await dispatch(leggTilStatustall('mineHuskelapper', 1));
     if (!!arbeidsliste) {
-        await slettArbeidslisteUtenFargekategoriOgOppdaterRedux(bruker, dispatch);
+        await slettArbeidslisteMenIkkeFargekategoriOgOppdaterRedux(bruker, dispatch);
     }
     onModalClose();
 };

--- a/src/minoversikt/huskelapp/redigering/slettEksisterendeArbeidsliste.ts
+++ b/src/minoversikt/huskelapp/redigering/slettEksisterendeArbeidsliste.ts
@@ -5,15 +5,15 @@ import {oppdaterArbeidslisteForBruker} from '../../../ducks/portefolje';
 import {ThunkDispatch} from 'redux-thunk';
 import {AppState} from '../../../reducer';
 import {AnyAction} from 'redux';
-import {slettArbeidslisteUtenFargekategori} from '../../../middleware/api';
+import {slettArbeidslisteMenIkkeFargekategori} from '../../../middleware/api';
 
-export const slettArbeidslisteUtenFargekategoriOgOppdaterRedux = async (
+export const slettArbeidslisteMenIkkeFargekategoriOgOppdaterRedux = async (
     bruker: BrukerModell,
     dispatch: ThunkDispatch<AppState, any, AnyAction>
 ) => {
     try {
-        const arbeidslisteUtenFargekategori = await slettArbeidslisteUtenFargekategori(bruker.fnr);
-        const ikkeAktivArbeidsliste = {...arbeidslisteUtenFargekategori, arbeidslisteAktiv: false, fnr: bruker.fnr};
+        const slettetArbeidsliste = await slettArbeidslisteMenIkkeFargekategori(bruker.fnr);
+        const ikkeAktivArbeidsliste = {...slettetArbeidsliste, arbeidslisteAktiv: false, fnr: bruker.fnr};
         leggTilStatustall('minArbeidsliste', -1)(dispatch);
         oppdaterArbeidslisteForBruker([ikkeAktivArbeidsliste])(dispatch);
     } catch (error) {

--- a/src/minoversikt/huskelapp/redigering/slettEksisterendeArbeidsliste.ts
+++ b/src/minoversikt/huskelapp/redigering/slettEksisterendeArbeidsliste.ts
@@ -1,31 +1,22 @@
-import {ArbeidslisteDataModell} from '../../../model-interfaces';
+import {BrukerModell} from '../../../model-interfaces';
 import {visServerfeilModal} from '../../../ducks/modal-serverfeil';
-import {FJERN_FRA_ARBEIDSLISTE_FEILET, visFeiletModal} from '../../../ducks/modal-feilmelding-brukere';
 import {leggTilStatustall} from '../../../ducks/statustall-veileder';
 import {oppdaterArbeidslisteForBruker} from '../../../ducks/portefolje';
+import {ThunkDispatch} from 'redux-thunk';
+import {AppState} from '../../../reducer';
+import {AnyAction} from 'redux';
+import {slettArbeidslisteUtenFargekategori} from '../../../middleware/api';
 
-export const oppdaterStateVedSlettArbeidsliste = (res, arbeidsliste: ArbeidslisteDataModell[], dispatch) => {
-    if (!res) {
+export const slettArbeidslisteUtenFargekategoriOgOppdaterRedux = async (
+    bruker: BrukerModell,
+    dispatch: ThunkDispatch<AppState, any, AnyAction>
+) => {
+    try {
+        const arbeidslisteUtenFargekategori = await slettArbeidslisteUtenFargekategori(bruker.fnr);
+        const ikkeAktivArbeidsliste = {...arbeidslisteUtenFargekategori, arbeidslisteAktiv: false, fnr: bruker.fnr};
+        leggTilStatustall('minArbeidsliste', -1)(dispatch);
+        oppdaterArbeidslisteForBruker([ikkeAktivArbeidsliste])(dispatch);
+    } catch (error) {
         return visServerfeilModal()(dispatch);
     }
-    const brukereOK = res.data.data;
-    const brukereError = res.data.error;
-
-    const arbeidslisteToDispatch = arbeidsliste
-        .map(a => ({
-            ...a,
-            arbeidslisteAktiv: false
-        }))
-        .filter(bruker => brukereOK.includes(bruker.fnr));
-
-    if (brukereError.length > 0) {
-        visFeiletModal({
-            aarsak: FJERN_FRA_ARBEIDSLISTE_FEILET,
-            brukereError
-        })(dispatch);
-    }
-
-    leggTilStatustall('minArbeidsliste', -brukereOK.length)(dispatch);
-
-    return oppdaterArbeidslisteForBruker(arbeidslisteToDispatch)(dispatch);
 };

--- a/src/minoversikt/minoversikt-bruker-panel.tsx
+++ b/src/minoversikt/minoversikt-bruker-panel.tsx
@@ -110,6 +110,7 @@ function MinoversiktBrukerPanel({
                 </Checkbox>
                 {!erHuskelappFeatureTogglePa && (
                     <ArbeidslistekategoriVisning
+                        skalVises={arbeidslisteAktiv}
                         kategori={bruker.arbeidsliste?.kategori}
                         dataTestid={`brukerliste-arbeidslisteikon_${bruker.arbeidsliste?.kategori}`}
                     />

--- a/src/mocks/data/portefolje.ts
+++ b/src/mocks/data/portefolje.ts
@@ -138,7 +138,8 @@ export const tomArbeidsliste = {
     isOppfolgendeVeileder: null,
     arbeidslisteAktiv: false,
     sistEndretAv: {},
-    kategori: null
+    kategori: null,
+    hentetKommentarOgTittel: true
 };
 
 function lagArbeidsliste(aktoerid, fnr) {
@@ -166,7 +167,8 @@ function lagArbeidsliste(aktoerid, fnr) {
         isOppfolgendeVeileder: true,
         arbeidslisteAktiv: true,
         sistEndretAv: {veilederId: innloggetVeileder.ident},
-        kategori
+        kategori,
+        hentetKommentarOgTittel: true
     };
 
     arbeidsliste.push({


### PR DESCRIPTION
Må ha to forskjellige kall mot endepunkt "slett arbeidsliste" så lenge vi fortsatt støtter arbeidslistefunksjon i oversikten. 
1. Slett arbeidsliste med tilhørende fargekategori (slett fra arbeidsliste modal)
2. Slett arbeidsliste uten å slette fargekategori (slett fra migreringsmodal: arbeidsliste til huskelapp) 

erstatter for #950