### PR TITLE
Populerer filter med data fra nytt arbeidssøkerregister

### DIFF
--- a/src/components/toolbar/listevisning/listevisning-utils.ts
+++ b/src/components/toolbar/listevisning/listevisning-utils.ts
@@ -51,6 +51,6 @@ alternativerConfig.set(Kolonne.ENSLIGE_FORSORGERE_AKIVITETSPLIKT, {tekstlabel: '
 alternativerConfig.set(Kolonne.ENSLIGE_FORSORGERE_VEDTAKSPERIODE, {tekstlabel: 'Type vedtaksperiode overgangsstønad'});
 alternativerConfig.set(Kolonne.ENSLIGE_FORSORGERE_OM_BARNET, {tekstlabel: 'Om barnet'});
 alternativerConfig.set(Kolonne.HAR_BARN_UNDER_18, {tekstlabel: 'Barn under 18 år'});
-alternativerConfig.set(Kolonne.BRUKERS_SITUASJON_SIST_ENDRET, {tekstlabel: 'Dato endret situasjon'});
+alternativerConfig.set(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET, {tekstlabel: 'Dato sist endret'});
 alternativerConfig.set(Kolonne.HUSKELAPP_KOMMENTAR, {tekstlabel: 'Huskelapp'});
 alternativerConfig.set(Kolonne.HUSKELAPP_FRIST, {tekstlabel: 'Frist huskelapp'});

--- a/src/ducks/ui/listevisning-selectors.ts
+++ b/src/ducks/ui/listevisning-selectors.ts
@@ -10,7 +10,6 @@ import {
     DAGPENGER_YTELSE_ORDINARE,
     DAGPENGER_YTELSE_PERMITTERING,
     DAGPENGER_YTELSE_PERMITTERING_FISKEINDUSTRI,
-    endringISituasjon,
     HAR_AVVIK,
     HUSKELAPP,
     I_AVTALT_AKTIVITET,
@@ -223,8 +222,11 @@ export function getMuligeKolonner(filtervalg: FiltervalgModell, oversiktType: Ov
         )
         .concat(
             addHvis(
-                Kolonne.BRUKERS_SITUASJON_SIST_ENDRET,
-                filtervalg.registreringstype.some(regType => endringISituasjon[regType])
+                Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET,
+                filtervalg.registreringstype?.length > 0 ||
+                    filtervalg.utdanning.length > 0 ||
+                    filtervalg.utdanningGodkjent.length > 0 ||
+                    filtervalg.utdanningBestatt.length > 0
             )
         )
         .concat(addHvis(Kolonne.HUSKELAPP_KOMMENTAR, filtervalg.ferdigfilterListe.includes(HUSKELAPP)))

--- a/src/ducks/ui/listevisning.ts
+++ b/src/ducks/ui/listevisning.ts
@@ -56,7 +56,7 @@ export enum Kolonne {
     ENSLIGE_FORSORGERE_OM_BARNET = 'om_barnet',
 
     HAR_BARN_UNDER_18 = 'har_barn_under_18',
-    BRUKERS_SITUASJON_SIST_ENDRET = 'brukers_situasjon_sist_endret',
+    UTDANNING_OG_SITUASJON_SIST_ENDRET = 'utdanning_og_situasjon_sist_endret',
     HUSKELAPP_FRIST = 'huskelapp_frist',
     HUSKELAPP_KOMMENTAR = 'huskelapp_kommentar'
 }

--- a/src/enhetsportefolje/enhet-kolonner.tsx
+++ b/src/enhetsportefolje/enhet-kolonner.tsx
@@ -91,8 +91,8 @@ function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKolonner, 
     const overgangsstonadUtlopsdato = bruker.ensligeForsorgereOvergangsstonad?.utlopsDato
         ? new Date(bruker.ensligeForsorgereOvergangsstonad?.utlopsDato)
         : null;
-    const brukersSituasjonSistEndret = bruker.brukersSituasjonSistEndret
-        ? new Date(bruker.brukersSituasjonSistEndret)
+    const brukersUtdanningOgSituasjonSistEndret = bruker.utdanningOgSituasjonSistEndret
+        ? new Date(bruker.utdanningOgSituasjonSistEndret)
         : null;
     const iAvtaltAktivitet: boolean =
         !!ferdigfilterListe?.includes(I_AVTALT_AKTIVITET) && valgteKolonner.includes(Kolonne.AVTALT_AKTIVITET);
@@ -381,8 +381,8 @@ function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKolonner, 
                 tekst={brukerBarnUnder18AarInfo(bruker.barnUnder18AarData)}
             />
             <DatoKolonne
-                dato={brukersSituasjonSistEndret}
-                skalVises={valgteKolonner.includes(Kolonne.BRUKERS_SITUASJON_SIST_ENDRET)}
+                dato={brukersUtdanningOgSituasjonSistEndret}
+                skalVises={valgteKolonner.includes(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET)}
                 className="col col-xs-2"
             />
         </div>

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -544,14 +544,14 @@ function EnhetListehode({
                     skalVises={valgteKolonner.includes(Kolonne.HAR_BARN_UNDER_18)}
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.BRUKERS_SITUASJON_SIST_ENDRET}
+                    sortering={Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
                     onClick={sorteringOnClick}
                     rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.BRUKERS_SITUASJON_SIST_ENDRET}
-                    tekst="Dato endret situasjon"
+                    erValgt={sorteringsfelt === Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
+                    tekst="Dato sist endret"
                     className="col col-xs-2"
-                    headerId="dato-endret-situasjon"
-                    skalVises={valgteKolonner.includes(Kolonne.BRUKERS_SITUASJON_SIST_ENDRET)}
+                    headerId="dato-sist-endret-utdanning-og-situasjon"
+                    skalVises={valgteKolonner.includes(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET)}
                 />
             </div>
             <div className="brukerliste__gutter-right" />

--- a/src/filtrering/filter-konstanter.ts
+++ b/src/filtrering/filter-konstanter.ts
@@ -321,28 +321,19 @@ export const stillingFraNavFilter = {
 export const registreringstype = {
     ER_PERMITTERT: {label: 'Er permittert eller kommer til å bli permittert'},
     USIKKER_JOBBSITUASJON: {label: 'Er usikker på jobbsituasjonen min'},
-    MISTET_JOBBEN: {label: 'Har mistet eller kommer til å miste jobben'},
-    VIL_FORTSETTE_I_JOBB: {label: 'Har jobb og ønsker å fortsette i den jobben jeg har'},
+    HAR_BLITT_SAGT_OPP: {label: 'Jeg har blitt sagt opp av arbeidsgiver'},
     DELTIDSJOBB_VIL_MER: {label: 'Har deltidsjobb, men vil jobbe mer'},
     VIL_BYTTE_JOBB: {label: 'Har jobb, men vil bytte'},
     AKKURAT_FULLFORT_UTDANNING: {label: 'Har akkurat fullført utdanning, militærtjeneste eller annet'},
     HAR_SAGT_OPP: {label: 'Har sagt opp eller kommer til å si opp'},
     ALDRI_HATT_JOBB: {label: 'Har aldri vært i jobb'},
-    JOBB_OVER_2_AAR: {label: 'Har ikke vært i jobb de 2 siste årene'},
+    IKKE_VAERT_I_JOBB_SISTE_2_AAR: {label: 'Har ikke vært i jobb de siste 2 årene'},
+    KONKURS: {label: 'Arbeidsgiveren min er konkurs'},
+    MIDLERTIDIG_JOBB: {label: 'Jeg har fått midlertidig jobb hos en annen arbeidsgiver'},
+    NY_JOBB: {label: 'Jeg skal begynne å jobbe hos en annen arbeidsgiver'},
+    ANNET: {label: 'Ingen av situasjonene passer for meg'},
     INGEN_DATA: {label: 'Ingen registreringsinformasjon'}
 };
-
-export const endringISituasjon = {
-    OPPSIGELSE: {label: 'Jeg har blitt sagt opp av arbeidsgiver'},
-    ENDRET_PERMITTERINGSPROSENT: {label: 'Arbeidsgiver har endret permitteringen min'},
-    TILBAKE_TIL_JOBB: {label: 'Jeg skal tilbake i jobb hos min nåværende arbeidsgiver'},
-    NY_JOBB: {label: 'Jeg skal begynne å jobbe hos en annen arbeidsgiver'},
-    MIDLERTIDIG_JOBB: {label: 'Jeg har fått midlertidig jobb hos en annen arbeidsgiver'},
-    KONKURS: {label: 'Arbeidsgiveren min er konkurs'},
-    SAGT_OPP: {label: 'Jeg har sagt opp jobben min'},
-    ANNET: {label: 'Situasjonen min har endret seg, men ingen av valgene passet'}
-};
-
 export const landgruppe = {
     LANDGRUPPE_0: 'Landgruppe 0',
     LANDGRUPPE_1: 'Landgruppe 1',
@@ -476,7 +467,6 @@ const filterKonstanter = {
     ytelseAapSortering,
     manuellBrukerStatus,
     registreringstype,
-    endringISituasjon,
     arbeidslisteKategori,
     arbeidslisteKategoriGammel,
     cvJobbprofil,

--- a/src/filtrering/filtrering-filter/filtrering-filter.tsx
+++ b/src/filtrering/filtrering-filter/filtrering-filter.tsx
@@ -8,7 +8,6 @@ import {
     avvik14aVedtakAvhengigeFilter,
     barnUnder18Aar,
     cvJobbprofil,
-    endringISituasjon,
     ensligeForsorgere,
     fodselsdagIMnd,
     formidlingsgruppe,
@@ -41,9 +40,8 @@ import GeografiskbostedFilterform from './filterform/geografiskbosted-filterform
 import FoedelandFilterform from './filterform/foedeland-filterform';
 import TolkebehovFilterform from './filterform/tolkebehov-filterform';
 import {useFeatureSelector} from '../../hooks/redux/use-feature-selector';
-import {FILTER_FOR_PERSONER_MED_BARN_UNDER_18, NASJONAL_OPPFOLGINGSENHET} from '../../konstanter';
+import {FILTER_FOR_PERSONER_MED_BARN_UNDER_18} from '../../konstanter';
 import BarnUnder18FilterForm from './filterform/barn-under-18-filterform';
-import {usePortefoljeSelector} from '../../hooks/redux/use-portefolje-selector';
 
 interface FiltreringFilterProps {
     filtervalg: FiltervalgModell;
@@ -55,7 +53,6 @@ interface FiltreringFilterProps {
 type FilterEndring = 'FJERNET' | 'LAGT_TIL' | 'UENDRET';
 
 function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktType}: FiltreringFilterProps) {
-    const {enhetId} = usePortefoljeSelector(oversiktType);
     const avvik14aVedtakValg = () => {
         const erIndeterminate = () => {
             return () => {
@@ -223,14 +220,15 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                 />
             </div>
             <div className="filtrering-filter__kolonne">
-                <Label>Svar fra registrering</Label>
+                <Label>Siste svar fra registrering</Label>
                 <Dropdown
                     name="Situasjon"
                     id="situasjon"
                     render={() => (
                         <>
                             <Alert variant="info" size="small" className="registrering-alert">
-                                Svar bruker oppga ved registrering. Det finnes ikke svar for alle, f.eks. sykmeldte.
+                                Siste svar bruker oppga via arbeidssøkerregistreringen. Det finnes ikke svar for alle,
+                                f.eks. sykmeldte.
                             </Alert>
                             <CheckboxFilterform
                                 form="registreringstype"
@@ -242,26 +240,6 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                         </>
                     )}
                 />
-                {NASJONAL_OPPFOLGINGSENHET === enhetId && (
-                    <Dropdown
-                        name="Endring i situasjon"
-                        id="endring-i-situasjon"
-                        render={() => (
-                            <>
-                                <Alert variant="info" size="small" className="registrering-alert">
-                                    Svar bruker oppga ved endring i brukers situasjon
-                                </Alert>
-                                <CheckboxFilterform
-                                    form="registreringstype"
-                                    valg={endringISituasjon}
-                                    filtervalg={filtervalg}
-                                    endreFiltervalg={endreFiltervalg}
-                                    className="registreringstype"
-                                />
-                            </>
-                        )}
-                    />
-                )}
                 <Dropdown
                     name="Høyeste fullførte utdanning"
                     id="hoyeste-fullforte-utdanning"

--- a/src/filtrering/filtrering-label-container.tsx
+++ b/src/filtrering/filtrering-label-container.tsx
@@ -110,12 +110,10 @@ function FiltreringLabelContainer({
                             />
                         );
                     }
-                    const label =
-                        FilterKonstanter['endringISituasjon'][singleValue] ?? FilterKonstanter[key][singleValue];
                     return (
                         <FiltreringLabel
                             key={`situasjon-${singleValue}`}
-                            label={label}
+                            label={FilterKonstanter[key][singleValue]}
                             slettFilter={() => slettEnkelt(key, singleValue)}
                         />
                     );

--- a/src/filtrering/filtrering-label.tsx
+++ b/src/filtrering/filtrering-label.tsx
@@ -15,7 +15,7 @@ interface FiltreringLabelProps {
 }
 
 function FiltreringLabel({label, slettFilter, skalHaKryssIkon = true}: Readonly<FiltreringLabelProps>) {
-    const ariaLabel = skalHaKryssIkon ? `Fjern filtervalg "${lagConfig(label).label}"` : 'Nullstill filtervalg';
+    const ariaLabel = skalHaKryssIkon ? `Fjern filtervalg "${lagConfig(label)?.label}"` : 'Nullstill filtervalg';
     const slettAlleFiltervalg = ariaLabel === 'Nullstill filtervalg';
     const buttonClassnames = classNames('filtreringlabel', {'filtreringlabel--slett-alle': slettAlleFiltervalg});
 

--- a/src/konstanter.ts
+++ b/src/konstanter.ts
@@ -7,8 +7,6 @@ export const IKKE_SATT = 'ikke_satt';
 export const DEFAULT_PAGINERING_STORRELSE = 50;
 export const SE_FLERE_PAGINERING_STORRELSE = 200;
 
-export const NASJONAL_OPPFOLGINGSENHET = '4154';
-
 export const SPOR_OM_TILBAKEMELDING = 'veilarbportefoljeflatefs.spor_om_tilbakemelding';
 export const VEDTAKSTOTTE = 'pto.vedtaksstotte.pilot';
 export const DARKMODE = 'veilarbportefoljeflatefs.darkmode';

--- a/src/minoversikt/minoversikt-kolonner.tsx
+++ b/src/minoversikt/minoversikt-kolonner.tsx
@@ -92,8 +92,9 @@ function MinoversiktDatokolonner({className, bruker, enhetId, filtervalg, valgte
     const overgangsstonadUtlopsdato = bruker.ensligeForsorgereOvergangsstonad?.utlopsDato
         ? new Date(bruker.ensligeForsorgereOvergangsstonad?.utlopsDato)
         : null;
-    const brukersSituasjonSistEndret = bruker.brukersSituasjonSistEndret
-        ? new Date(bruker.brukersSituasjonSistEndret)
+
+    const brukersUtdanningOgSituasjonSistEndret = bruker.utdanningOgSituasjonSistEndret
+        ? new Date(bruker.utdanningOgSituasjonSistEndret)
         : null;
 
     const huskeLappFrist = bruker.huskelapp?.frist ? new Date(bruker.huskelapp.frist) : null;
@@ -404,8 +405,8 @@ function MinoversiktDatokolonner({className, bruker, enhetId, filtervalg, valgte
                 tekst={bruker.barnUnder18AarData ? brukerBarnUnder18AarInfo(bruker.barnUnder18AarData) : '-'}
             />
             <DatoKolonne
-                dato={brukersSituasjonSistEndret}
-                skalVises={valgteKolonner.includes(Kolonne.BRUKERS_SITUASJON_SIST_ENDRET)}
+                dato={brukersUtdanningOgSituasjonSistEndret}
+                skalVises={valgteKolonner.includes(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET)}
                 className="col col-xs-2"
             />
             <TekstKolonne

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -645,14 +645,14 @@ function MinOversiktListeHode({
                     skalVises={valgteKolonner.includes(Kolonne.HAR_BARN_UNDER_18)}
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.BRUKERS_SITUASJON_SIST_ENDRET}
+                    sortering={Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
                     onClick={sorteringOnClick}
                     rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.BRUKERS_SITUASJON_SIST_ENDRET}
-                    tekst="Dato endret situasjon"
+                    erValgt={sorteringsfelt === Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
+                    tekst="Dato sist endret"
                     className="col col-xs-2"
-                    headerId="dato-endret-situasjon"
-                    skalVises={valgteKolonner.includes(Kolonne.BRUKERS_SITUASJON_SIST_ENDRET)}
+                    headerId="dato-sist-endret-utdanning-situasjon"
+                    skalVises={valgteKolonner.includes(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET)}
                 />
                 <SorteringHeader
                     sortering={Sorteringsfelt.HUSKELAPP_KOMMENTAR}

--- a/src/mocks/data/portefolje.ts
+++ b/src/mocks/data/portefolje.ts
@@ -275,7 +275,7 @@ function lagBruker(sikkerhetstiltak = []) {
         avvik14aVedtak: randomAvvik14aVedtak(),
         ensligeForsorgereOvergangsstonad: lagRandomOvergangsstonadForEnsligForsorger(),
         barnUnder18AarData: hentBarnUnder18Aar(),
-        brukersSituasjonSistEndret: randomDate({past: false}),
+        utdanningOgSituasjonSistEndret: randomDate({past: false}),
         fargekategori: lagFargekategori(),
         huskelapp
     };

--- a/src/model-interfaces.ts
+++ b/src/model-interfaces.ts
@@ -56,7 +56,7 @@ export enum Sorteringsfelt {
     ENSLIGE_FORSORGERE_OM_BARNET = 'enslige_forsorgere_om_barnet',
 
     BARN_UNDER_18_AAR = 'barn_under_18_aar',
-    BRUKERS_SITUASJON_SIST_ENDRET = 'brukersSituasjonSistEndret',
+    UTDANNING_OG_SITUASJON_SIST_ENDRET = 'utdanningOgSituasjonSistEndret',
     HUSKELAPP_KOMMENTAR = 'huskelapp_kommentar',
     HUSKELAPP_FRIST = 'huskelapp_frist',
     HUSKELAPP = 'huskelapp'
@@ -207,6 +207,7 @@ export interface BrukerModell {
     brukersSituasjonSistEndret: string;
     fargekategori: FargekategoriModell | null;
     huskelapp?: HuskelappModell;
+    utdanningOgSituasjonSistEndret: string;
 }
 
 export interface EnsligeForsorgereOvergangsstonad {


### PR DESCRIPTION
* Bytte ut alternativer for situasjon (de gamle vil komme inn under noen av de nye som f.eks "Mistet jobben", vil nå gå under "Jeg har blitt sagt opp av arbeidsgiver"

* Endre tittel på filter fra Svar fra registrering til Siste svar fra registrering og lagt til en "Sist endret dato"- kolonne slik at det enda tydligere kommer frem at bruker kan endre disse dataene.