### PR TITLE
Ikkje vis liste av brukarar som feila når det berre var éin

### DIFF
--- a/src/components/fargekategori/FargekategoriFeilhandtering.tsx
+++ b/src/components/fargekategori/FargekategoriFeilhandtering.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Alert, List, useId} from '@navikt/ds-react';
+import {Alert, BodyShort, List, useId} from '@navikt/ds-react';
 import {Status} from '../../model-interfaces';
 
 interface Props {
@@ -12,20 +12,24 @@ function isString(data: string | {data: string[]; errors: string[]}): data is st
 }
 
 const mapErrorToText = (okFnrs: string[], errorFnrs: string[], status: number | undefined) => {
-    if (!okFnrs?.length) {
+    const ingenGikkBra = !okFnrs?.length;
+    const bareEnFeilet = errorFnrs.length == 1;
+
+    if (ingenGikkBra) {
         if (status === 400) return `Kunne ikke oppdatere kategori. Fødselsnummer er ugyldig.`;
         if (status === 403) return `Du har ikke tilgang til å oppdatere kategori.`;
         if (status === 500) return `Noe gikk galt, prøv igjen senere.`;
+    } else if (bareEnFeilet) {
+        return <BodyShort>Kunne ikke oppdatere kategori for person med fødselsnummer '{errorFnrs[0]}'</BodyShort>;
     }
 
     return (
         <List as="ul" size="small" title="Kunne ikke oppdatere kategori på følgende personer:">
-            {errorFnrs?.map(fnr => (
-                <List.Item key={useId()}>{fnr}</List.Item>
-            ))}
+            {errorFnrs?.map(fnr => <List.Item key={useId()}>{fnr}</List.Item>)}
         </List>
     );
 };
+
 export const FargekategoriFeilhandtering = ({children, apiResponse}: Props) => {
     const responseJson =
         apiResponse.status === Status.ERROR && isString(apiResponse.data.data)


### PR DESCRIPTION
Før viste vi ei liste over personar som feila uavhengig av om det var éin eller mange personar oppdateringa feila for. No viser vi ikkje lista om berre ei oppdatering feila.

