### PR TITLE
Rendre whitespace i huskelapp-visning, bryt lange ord

### DIFF
--- a/src/components/toolbar/fargekategori-toolbar-knapp.tsx
+++ b/src/components/toolbar/fargekategori-toolbar-knapp.tsx
@@ -24,7 +24,7 @@ export default function FargekategoriToolbarKnapp({valgteBrukereFnrs}: Fargekate
                 size="small"
                 variant="tertiary"
                 icon={<FargekategoriIkonBokmerke />}
-                title="Sett fargekategori for alle valgte brukere"
+                title="Endre kategori for alle valgte brukere"
                 ref={buttonRef}
                 onClick={() => {
                     if (valgteBrukereFnrs.length === 0) {
@@ -36,7 +36,7 @@ export default function FargekategoriToolbarKnapp({valgteBrukereFnrs}: Fargekate
                 }}
                 className="toolbar_btn"
             >
-                Fargekategori
+                Endre kategori
             </Button>
             <FargekategoriPopover
                 valgteBrukereFnrs={valgteBrukereFnrs}

--- a/src/minoversikt/huskelapp/huskelapp-wrapper/huskelapp-postitstyling.css
+++ b/src/minoversikt/huskelapp/huskelapp-wrapper/huskelapp-postitstyling.css
@@ -7,6 +7,10 @@
     word-wrap: break-word;
 }
 
+.huskelapp-visning__kommentar {
+    white-space: pre-wrap;
+}
+
 .huskelapp__postit {
     position: relative;
     background-color: var(--a-limegreen-100);

--- a/src/minoversikt/huskelapp/modalvisning/HuskelappForModal.tsx
+++ b/src/minoversikt/huskelapp/modalvisning/HuskelappForModal.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import {BodyShort, Detail, Heading} from '@navikt/ds-react';
 import {toDatePrettyPrint} from '../../../utils/dato-utils';
 import {HuskelappModell} from '../../../model-interfaces';
-import '../huskelapp-wrapper/huskelapp-postitstyling.css';
 import {HuskelappPostitWrapper} from '../huskelapp-wrapper/HuskelappPostitWrapper';
+import '../huskelapp-wrapper/huskelapp-postitstyling.css';
 
 interface Props {
     huskelapp: HuskelappModell;
@@ -16,7 +16,7 @@ export const HuskelappForModal = ({huskelapp}: Props) => {
                 <Heading level="3" size="xsmall" spacing>
                     {huskelapp?.frist ? `Frist: ${toDatePrettyPrint(huskelapp.frist)}` : 'Ingen frist satt'}
                 </Heading>
-                <BodyShort size="small" spacing>
+                <BodyShort size="small" spacing className="huskelapp-visning__kommentar">
                     {huskelapp?.kommentar}
                 </BodyShort>
             </HuskelappPostitWrapper>

--- a/src/minoversikt/huskelapp/panelvisning/HuskelappForPanel.tsx
+++ b/src/minoversikt/huskelapp/panelvisning/HuskelappForPanel.tsx
@@ -17,7 +17,7 @@ export const HuskelappForPanel = ({huskelapp, bruker, onEndreHuskelapp}: Props) 
         <Heading level="3" size="xsmall" spacing>
             {huskelapp?.frist ? `Frist: ${toDatePrettyPrint(huskelapp.frist)}` : 'Ingen frist satt'}
         </Heading>
-        <BodyShort size="small" spacing>
+        <BodyShort size="small" spacing className="huskelapp-visning__kommentar">
             {huskelapp?.kommentar}
         </BodyShort>
         <Detail spacing>

--- a/src/mocks/data/portefolje.ts
+++ b/src/mocks/data/portefolje.ts
@@ -422,7 +422,8 @@ export function hentHuskelappForBruker(fnr: string, enhetId: string) {
     return {
         huskelappId: lagOverskrift(),
         brukerFnr: fnr,
-        kommentar: lagOverskrift(),
+        kommentar:
+            '\n\n\n\n   HEIII   \nasdfølkjasdølfkajsdøflkajsdølfjaksdfølajskdøflajsdølfkjasødlfjaøsldjfølasjdølfjasøjldfjaøldf',
         frist: moment().add(rnd(0, 20), 'days').add(rnd(0, 23), 'hours').format('YYYY-MM-DD')
     };
 }


### PR DESCRIPTION
Gjør det lettere å lese og strukturere informasjonen. [Trello-kort](https://trello.com/c/3rJAGBW4)
\+ endre navn på fargekategori-knappen i toolbar til "endre kategori"