### PR TITLE
Vis kun tekst før første linjeskift som overskrift i huskelappkolonne

### DIFF
--- a/src/minoversikt/huskelapp/HuskelappIkonInngang.tsx
+++ b/src/minoversikt/huskelapp/HuskelappIkonInngang.tsx
@@ -48,7 +48,7 @@ export const HuskelappIkonInngang = ({bruker, innloggetVeileder}: Props) => {
         if (bruker.huskelapp) {
             return 'Endre huskelapp';
         }
-        return arbeidslisteAktiv ? 'Migrer arbeidsliste' : 'Opprett huskelapp';
+        return arbeidslisteAktiv ? 'Bytt fra arbeidsliste til huskelapp' : 'Opprett huskelapp';
     };
 
     return (

--- a/src/minoversikt/minoversikt-kolonner.tsx
+++ b/src/minoversikt/minoversikt-kolonner.tsx
@@ -412,7 +412,12 @@ function MinoversiktDatokolonner({className, bruker, enhetId, filtervalg, valgte
             <TekstKolonne
                 className="col col-xs-2"
                 skalVises={valgteKolonner.includes(Kolonne.HUSKELAPP_KOMMENTAR)}
-                tekst={bruker.huskelapp?.kommentar ? truncateTekst(bruker.huskelapp.kommentar) : ' '}
+                tekst={
+                    bruker.huskelapp?.kommentar
+                        ? // Fjerner eventuelle linjeskift før teksten og viser kun tekst fram til første linjeskift eller maks 30 tegn, ref. truncateTekst()
+                          truncateTekst(bruker.huskelapp.kommentar.trimStart().split('\n')[0])
+                        : ' '
+                }
             />
             <DatoKolonne
                 dato={huskeLappFrist}

--- a/src/mocks/data/portefolje.ts
+++ b/src/mocks/data/portefolje.ts
@@ -191,7 +191,7 @@ const lagHuskelapp = fnr => {
     return {
         huskelappId: lagOverskrift(),
         brukerFnr: fnr,
-        kommentar: lagOverskrift(),
+        kommentar: '\n\n' + lagOverskrift() + '\n\nDette skal bort ',
         frist: moment().add(rnd(0, 20), 'days').add(rnd(0, 23), 'hours').format('YYYY-MM-DD'),
         enhetId: maybeHuskelapp > 0.7 ? '0220' : '1234'
     };

--- a/src/model-interfaces.ts
+++ b/src/model-interfaces.ts
@@ -206,7 +206,7 @@ export interface BrukerModell {
     barnUnder18AarData: BarnUnder18Aar[];
     brukersSituasjonSistEndret: string;
     fargekategori: FargekategoriModell | null;
-    fargekategoriEnhetId: String | null;
+    fargekategoriEnhetId: string | null;
     huskelapp?: HuskelappModell;
     utdanningOgSituasjonSistEndret: string;
 }


### PR DESCRIPTION
Fjerner eventuelle linjeskift før huskelappteksten og viser kun tekst fram til første linjeskift, eller maks 30 tegn, i huskelapp-kolonnen