### PR TITLE
La xy scroll position til localstorage

### DIFF
--- a/src/components/aksjon-knapp-med-popover-feilmelding/aksjon-knapp-med-popover-feilmelding.tsx
+++ b/src/components/aksjon-knapp-med-popover-feilmelding/aksjon-knapp-med-popover-feilmelding.tsx
@@ -32,7 +32,13 @@ export const AksjonKnappMedPopoverFeilmelding = ({
         })
     );
 
+    const setXYScrollPosition = () => {
+        localStorage.setItem('xScrollPos', window.scrollX.toString());
+        localStorage.setItem('yScrollPos', window.scrollY.toString());
+    };
+
     const handterKlikkAksjon = async (e: React.MouseEvent<HTMLButtonElement>) => {
+        setXYScrollPosition();
         setHarFeilAksjon(false);
         setLasterAksjon(true);
 

--- a/src/enhetsportefolje/enhet-brukerpanel.tsx
+++ b/src/enhetsportefolje/enhet-brukerpanel.tsx
@@ -34,8 +34,8 @@ function EnhetBrukerpanel({
     const erVedtaksStotteFeatureTogglePa = useFeatureSelector()(VEDTAKSTOTTE);
 
     const scrollToLastPos = () => {
-        const xPos = parseInt(localStorage.getItem('xPos') || '0');
-        const yPos = parseInt(localStorage.getItem('yPos') || '0');
+        const xPos = parseInt(localStorage.getItem('xScrollPos') || '0');
+        const yPos = parseInt(localStorage.getItem('yScrollPos') || '0');
         window.scrollTo(xPos, yPos);
     };
 


### PR DESCRIPTION
La XY scroll position av valgte person fra liste til localstorage slik at den kan hentes tilbake fra localstorage når veileder nevigerer seg tilbake til portefolje fra personflate. Denne XY scroll posisjon skal brukes til å skrolle automatisk til valgte personen.