### PR TITLE
Gjer huskelappmodal litt finare å sjå på

### DIFF
--- a/src/minoversikt/huskelapp/redigering/HuskelappModal.tsx
+++ b/src/minoversikt/huskelapp/redigering/HuskelappModal.tsx
@@ -82,7 +82,11 @@ export const HuskelappModal = ({isModalOpen, onModalClose, huskelapp, bruker, ar
 
     return (
         <Modal
-            className={classNames('rediger-huskelapp-modal', {'med-eksisterende-arbeidsliste': harArbeidsliste})}
+            className={classNames(
+                'rediger-huskelapp-modal',
+                {'med-eksisterende-arbeidsliste': harArbeidsliste},
+                'fiks-for-gammel-datovelger'
+            )}
             open={isModalOpen}
             onClose={onModalClose}
             onBeforeClose={handleHuskelappEndret}
@@ -93,10 +97,7 @@ export const HuskelappModal = ({isModalOpen, onModalClose, huskelapp, bruker, ar
                     <span className="rediger-huskelapp-modal-header-ikon">
                         <HuskelappIkon aria-hidden />
                     </span>
-                    <Heading
-                        size="small"
-                        className="rediger-huskelapp-modal-header-tekst"
-                    >
+                    <Heading size="small" className="rediger-huskelapp-modal-header-tekst">
                         {modalNavn}
                     </Heading>
                 </div>

--- a/src/minoversikt/huskelapp/redigering/HuskelappModal.tsx
+++ b/src/minoversikt/huskelapp/redigering/HuskelappModal.tsx
@@ -101,13 +101,14 @@ export const HuskelappModal = ({isModalOpen, onModalClose, huskelapp, bruker, ar
                         {modalNavn}
                     </Heading>
                 </div>
-                <div className="rediger-huskelapp-modal-header">
+                <div className="rediger-huskelapp-modal-personinfo">
                     <BodyShort weight="semibold">{`${bruker.fornavn} ${bruker.etternavn}`}</BodyShort>
                     <CopyButton
-                        className="rediger-huskelapp-modal-header-copybutton"
-                        iconPosition="right"
                         copyText={bruker.fnr}
                         text={`F.nr.: ${bruker.fnr}`}
+                        iconPosition="right"
+                        size="xsmall"
+                        className="rediger-huskelapp-modal-header-copybutton"
                     />
                 </div>
             </Modal.Header>

--- a/src/minoversikt/huskelapp/redigering/rediger-huskelapp.css
+++ b/src/minoversikt/huskelapp/redigering/rediger-huskelapp.css
@@ -104,3 +104,9 @@
     /* !important er brukt for å overskrive hardkodinga av alle labels til 0.875rem i style.css */
     font-size: var(--a-font-size-medium) !important;
 }
+
+.rediger-huskelapp-modal.fiks-for-gammel-datovelger {
+    /* Fiks som gjer heile datovelgaren synleg sjølv om han flyt ut over grensene til foreldremodalen. */
+    /* Denne kan fjernast når vi ikkje bruker Datepicker frå nav-datovelger meir */
+    overflow: visible;
+}

--- a/src/minoversikt/huskelapp/redigering/rediger-huskelapp.css
+++ b/src/minoversikt/huskelapp/redigering/rediger-huskelapp.css
@@ -19,9 +19,16 @@
     margin-right: 0.3rem;
 }
 
-.rediger-huskelapp-modal-header-copybutton.navds-copybutton--neutral {
+.rediger-huskelapp-modal-personinfo {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    column-gap: 0.5rem;
+    row-gap: 0.1rem;
+}
+
+.rediger-huskelapp-modal-personinfo .rediger-huskelapp-modal-header-copybutton {
     color: var(--a-text-default);
-    padding-right: 0;
 }
 
 .rediger-huskelapp-modal-header-tekst {


### PR DESCRIPTION
### Datovelgar
Gjer heile datovelgar synleg i redigeringsmodal, også når den flyt ut over grensene til forelderen.


### Personinfo i huskelappmodal
#### Før, hover på knapp:

<img width="300" alt="Skjermbilete av kopierknapp, før endring" src="https://github.com/user-attachments/assets/3694c5ab-63a6-436e-a0b2-288baef16f3e">


#### Etter, hover på knapp:

<img width="300" alt="Skjermbilete av kopierknapp, etter endring" src="https://github.com/user-attachments/assets/02959250-788b-48b3-9308-eb15cddc0e71">


#### Før, person med veldig langt namn:

<img width="300" alt="Skjermbilete av kopierknapp, namn og knapp wrappar teksten i kvar si kolonne" src="https://github.com/user-attachments/assets/52979c12-07e1-4845-a4a5-aa528612bf7b">

#### Etter, person med veldig langt namn:

<img width="300" alt="Skjermbilete av kopierknapp, namn og knapp på kvar si rad" src="https://github.com/user-attachments/assets/235c95ef-abd9-494c-87dd-9ffeabc256e1">



