### PR TITLE
Destrukturer props og rydd i kolonnevalg

### DIFF
--- a/src/components/toolbar/listevisning/listevisning.css
+++ b/src/components/toolbar/listevisning/listevisning.css
@@ -20,29 +20,3 @@
     background-color: #a0a0a0;
     border-color: #a0a0a0;
 }
-
-.veilarbportefoljeflatefs .toolbar__velg-kolonner {
-    margin-right: 1rem;
-    min-width: 11rem;
-}
-.veilarbportefoljeflatefs .toolbar__velg-kolonner .dropdown {
-    margin-bottom: 0;
-}
-.veilarbportefoljeflatefs .toolbar__velg-kolonner .dropdown__btnwrapper--disabled svg {
-    opacity: 0.4;
-}
-.veilarbportefoljeflatefs .toolbar__velg-kolonner .dropdown__btnwrapper--disabled:hover {
-    border: none;
-}
-.veilarbportefoljeflatefs .toolbar__velg-kolonner .dropdown__btn {
-    background-color: var(--a-bg-subtle);
-    border: 1px solid transparent;
-    padding: 0.5rem 0.5rem 0 0.5rem !important;
-}
-.veilarbportefoljeflatefs .toolbar__velg-kolonner svg {
-    margin-right: 0.2rem;
-}
-.veilarbportefoljeflatefs .toolbar__velg-kolonner .velg-kolonner__tekst {
-    position: absolute;
-    top: 10px;
-}

--- a/src/components/toolbar/listevisning/listevisning.tsx
+++ b/src/components/toolbar/listevisning/listevisning.tsx
@@ -35,7 +35,6 @@ function Listevisning({oversiktType}: ListevisningProps) {
 
     return (
         <VelgKolonner
-            className="dropdown--toolbar toolbar__velg-kolonner"
             render={() => (
                 <ul className="ustilet">
                     {muligeAlternativer.map(kolonne => (

--- a/src/components/toolbar/listevisning/listevisning.tsx
+++ b/src/components/toolbar/listevisning/listevisning.tsx
@@ -1,11 +1,10 @@
-import * as React from 'react';
+import React from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {avvelgAlternativ, Kolonne, OversiktType, velgAlternativ} from '../../../ducks/ui/listevisning';
 import {selectMuligeAlternativer, selectValgteAlternativer} from '../../../ducks/ui/listevisning-selectors';
 import ListevisningRad from './listevisning-rad';
-import './listevisning.css';
 import {AppState} from '../../../reducer';
-import VelgKolonner from '../velg-kolonner';
+import './listevisning.css';
 
 interface ListevisningProps {
     oversiktType: OversiktType;
@@ -34,21 +33,17 @@ function Listevisning({oversiktType}: ListevisningProps) {
     }
 
     return (
-        <VelgKolonner
-            render={() => (
-                <ul className="ustilet">
-                    {muligeAlternativer.map(kolonne => (
-                        <ListevisningRad
-                            key={kolonne}
-                            kolonne={kolonne}
-                            valgt={erValgt(kolonne)}
-                            disabled={valgteAlternativ.length >= 3 && !erValgt(kolonne)}
-                            onChange={handleChange}
-                        />
-                    ))}
-                </ul>
-            )}
-        />
+        <ul className="ustilet">
+            {muligeAlternativer.map(kolonne => (
+                <ListevisningRad
+                    key={kolonne}
+                    kolonne={kolonne}
+                    valgt={erValgt(kolonne)}
+                    disabled={valgteAlternativ.length >= 3 && !erValgt(kolonne)}
+                    onChange={handleChange}
+                />
+            ))}
+        </ul>
     );
 }
 

--- a/src/components/toolbar/toolbar.css
+++ b/src/components/toolbar/toolbar.css
@@ -21,31 +21,6 @@
     border-color: #a0a0a0;
 }
 
-.veilarbportefoljeflatefs .toolbar__velg-kolonner {
-    margin-right: 1rem;
-    min-width: 11rem;
-}
-.veilarbportefoljeflatefs .toolbar__velg-kolonner .dropdown {
-    margin-bottom: 0;
-}
-.veilarbportefoljeflatefs .toolbar__velg-kolonner .dropdown__btnwrapper--disabled svg {
-    opacity: 0.4;
-}
-.veilarbportefoljeflatefs .toolbar__velg-kolonner .dropdown__btnwrapper--disabled:hover {
-    border: none;
-}
-.veilarbportefoljeflatefs .toolbar__velg-kolonner .dropdown__btn {
-    background-color: var(--a-bg-subtle);
-    border: 1px solid transparent;
-    padding: 0.5rem 0.5rem 0 0.5rem !important;
-}
-.veilarbportefoljeflatefs .toolbar__velg-kolonner svg {
-    margin-right: 0.2rem;
-}
-.veilarbportefoljeflatefs .toolbar__velg-kolonner .velg-kolonner__tekst {
-    position: absolute;
-    top: 10px;
-}
 .veilarbportefoljeflatefs .dropdown {
     position: relative;
     margin-bottom: 0.5rem;
@@ -252,72 +227,6 @@
     padding: 1rem 0.7rem;
     z-index: 2000;
     position: absolute;
-}
-.veilarbportefoljeflatefs .dropdown--toolbar {
-    border-radius: 4px;
-    width: auto;
-    min-width: 11rem;
-    height: 100%;
-    margin: 0 1rem 0 0 !important;
-}
-.veilarbportefoljeflatefs .dropdown--toolbar .dropdown__btn {
-    border: 1px solid #6a6a6a;
-    padding: 0.5rem;
-    cursor: pointer;
-}
-.veilarbportefoljeflatefs .dropdown--toolbar .dropdown__btn:hover {
-    border-color: #0067c5;
-}
-.veilarbportefoljeflatefs .dropdown--toolbar .dropdown__btn:disabled {
-    color: #c9c9c9;
-}
-.veilarbportefoljeflatefs .dropdown--toolbar .dropdown__btn:disabled:hover {
-    border-color: transparent;
-    cursor: default;
-}
-.veilarbportefoljeflatefs .dropdown--toolbar .dropdown__btnwrapper:before,
-.veilarbportefoljeflatefs .dropdown--toolbar .dropdown__btnwrapper:after {
-    pointer-events: none;
-    content: '';
-    background: currentColor;
-    height: 2px;
-    width: 10px;
-    border-radius: 10px;
-    right: 0.75rem;
-    top: 0.75rem;
-    position: absolute;
-    transition: transform 0.2s;
-    top: 50%;
-}
-.veilarbportefoljeflatefs .dropdown--toolbar .dropdown__innhold {
-    width: 286px;
-}
-.veilarbportefoljeflatefs .dropdown--toolbar .sokfilter {
-    text-align: center;
-}
-.veilarbportefoljeflatefs .dropdown--toolbar .sokfilter .skjemaelement {
-    margin-bottom: 0;
-}
-.veilarbportefoljeflatefs .dropdown--toolbar .sokfilter .skjemaelement__label {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    padding: 0;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    border: 0;
-    white-space: nowrap;
-}
-.veilarbportefoljeflatefs .dropdown--toolbar .sokfilter .skjemaelement__input {
-    height: 1.8rem;
-    width: 90%;
-    margin-top: 10px;
-    margin-bottom: 10px;
-    background: no-repeat 99% 130%;
-}
-.veilarbportefoljeflatefs .dropdown--toolbar .sokfilter .skjemaelement__input::-ms-clear {
-    display: none;
 }
 .veilarbportefoljeflatefs .toolbar_btn {
     height: 2.5rem;

--- a/src/components/toolbar/toolbar.tsx
+++ b/src/components/toolbar/toolbar.tsx
@@ -1,20 +1,20 @@
-import * as React from 'react';
-import Paginering from './paginering/paginering';
-import Listevisning from './listevisning/listevisning';
-import {OversiktType} from '../../ducks/ui/listevisning';
-import './toolbar.css';
-import '../../style.css';
+import React from 'react';
 import {useSelector} from 'react-redux';
+import classNames from 'classnames';
+import {AddPerson, Search} from '@navikt/ds-icons';
+import {Alert, Heading} from '@navikt/ds-react';
+import Paginering from './paginering/paginering';
+import {OversiktType} from '../../ducks/ui/listevisning';
 import ArbeidslisteKnapp from './legg-til-arbeidsliste-knapp';
 import {AppState} from '../../reducer';
 import ToolbarKnapp from './toolbar-knapp';
-import classNames from 'classnames';
 import {useWindowWidth} from '../../hooks/use-window-width';
-import {AddPerson, Search} from '@navikt/ds-icons';
-import {Alert, Heading} from '@navikt/ds-react';
 import FargekategoriToolbarKnapp from './fargekategori-toolbar-knapp';
 import {useFeatureSelector} from '../../hooks/redux/use-feature-selector';
 import {HUSKELAPP} from '../../konstanter';
+import VelgKolonner from './velg-kolonner';
+import './toolbar.css';
+import '../../style.css';
 
 interface ToolbarProps {
     oversiktType: OversiktType;
@@ -114,7 +114,7 @@ function Toolbar({
                     {oversikt(oversiktType)}
                 </div>
                 <div className="toolbar__element">
-                    <Listevisning oversiktType={oversiktType} />
+                    <VelgKolonner oversiktType={oversiktType} />
                     <Paginering onPaginering={onPaginering} antallTotalt={antallTotalt} />
                 </div>
             </div>

--- a/src/components/toolbar/velg-kolonner.tsx
+++ b/src/components/toolbar/velg-kolonner.tsx
@@ -2,13 +2,15 @@ import React, {useEffect, useRef, useState} from 'react';
 import {Button} from '@navikt/ds-react';
 import {Table} from '@navikt/ds-icons';
 import {useFocus} from '../../hooks/use-focus';
+import Listevisning from './listevisning/listevisning';
+import {OversiktType} from '../../ducks/ui/listevisning';
 import './toolbar.css';
 
 interface VelgKolonnerProps {
-    render: (lukkDropdown: () => void) => React.ReactChild;
+    oversiktType: OversiktType;
 }
 
-function VelgKolonner({render}: VelgKolonnerProps) {
+function VelgKolonner({oversiktType}: VelgKolonnerProps) {
     const [apen, setApen] = useState(false);
     const btnRef = useRef<HTMLButtonElement>(null);
     const divRef = useRef<HTMLDivElement>(null);
@@ -56,7 +58,7 @@ function VelgKolonner({render}: VelgKolonnerProps) {
                         id="velg-kolonner"
                         ref={inputRef => (focusRef.current = inputRef)}
                     >
-                        {render(lukkVelgKolonner)}
+                        <Listevisning oversiktType={oversiktType} />
                     </div>
                     <Button
                         size="small"

--- a/src/components/toolbar/velg-kolonner.tsx
+++ b/src/components/toolbar/velg-kolonner.tsx
@@ -1,20 +1,15 @@
 import React, {useEffect, useRef, useState} from 'react';
-import './toolbar.css';
-import {useFocus} from '../../hooks/use-focus';
 import {Button} from '@navikt/ds-react';
 import {Table} from '@navikt/ds-icons';
+import {useFocus} from '../../hooks/use-focus';
+import './toolbar.css';
 
 interface VelgKolonnerProps {
-    apen?: boolean;
     render: (lukkDropdown: () => void) => React.ReactChild;
-    className?: string;
-    onLukk?: () => void;
-    hidden?: boolean;
 }
 
-function VelgKolonner(props: VelgKolonnerProps) {
-    const {render, hidden} = props;
-    const [apen, setApen] = useState(props.apen || false);
+function VelgKolonner({render}: VelgKolonnerProps) {
+    const [apen, setApen] = useState(false);
     const btnRef = useRef<HTMLButtonElement>(null);
     const divRef = useRef<HTMLDivElement>(null);
     const {focusRef} = useFocus();
@@ -31,43 +26,12 @@ function VelgKolonner(props: VelgKolonnerProps) {
     });
 
     function toggleVelgKolonner() {
-        const {onLukk = () => void 0} = props;
-        if (apen) {
-            onLukk();
-        }
-        setApen(!apen);
+        setApen(prevState => !prevState);
     }
 
     function lukkVelgKolonner() {
-        const {onLukk = () => void 0} = props;
         setApen(false);
-
-        onLukk();
     }
-
-    if (hidden) {
-        return null;
-    }
-
-    const innhold = !apen ? null : (
-        <div className="toolbar_btn__dropdown">
-            <div
-                className="checkbox-filterform__valg"
-                id="velg-kolonner"
-                ref={inputRef => (focusRef.current = inputRef)}
-            >
-                {render(lukkVelgKolonner)}
-            </div>
-            <Button
-                size="small"
-                className="velg-kolonner__lukk-knapp"
-                onClick={lukkVelgKolonner}
-                data-testid={'lukk-velg-kolonner-knapp'}
-            >
-                Lukk
-            </Button>
-        </div>
-    );
 
     return (
         <div className="sok-veileder-wrapper" ref={divRef}>
@@ -85,7 +49,25 @@ function VelgKolonner(props: VelgKolonnerProps) {
                 Velg kolonner
             </Button>
 
-            {innhold}
+            {apen && (
+                <div className="toolbar_btn__dropdown">
+                    <div
+                        className="checkbox-filterform__valg"
+                        id="velg-kolonner"
+                        ref={inputRef => (focusRef.current = inputRef)}
+                    >
+                        {render(lukkVelgKolonner)}
+                    </div>
+                    <Button
+                        size="small"
+                        className="velg-kolonner__lukk-knapp"
+                        onClick={lukkVelgKolonner}
+                        data-testid={'lukk-velg-kolonner-knapp'}
+                    >
+                        Lukk
+                    </Button>
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## Mål:
Ryddigare og meir oversiktleg kode å jobbe vidare med. Unngå ubrukte props som gjer komponentane tyngre å lese.

### Destrukturerar props og fjernar dei som ikkje er brukt

Tek bort props dersom:
- Dei ikkje vert brukt i komponenten
- Dei aldri vert brukt der komponenten vert rendra

Fjernar også styling for klassenamn som ikkje vart sendt vidare frå props


### "Vrengar" ein komponent slik at koden betre viser kva som er ytst og inst i komponenttreet

Før:
Listevisning rendra VelgKolonner som igjen rendra sjølve listevisninga av kolonnevalg.

No:
VelgKolonner rendrer Listevisning og kolonnevalga.