### PR TITLE
Bytt til å bruke contextholder i gcp

### DIFF
--- a/.nais/obo-nais-dev.yaml
+++ b/.nais/obo-nais-dev.yaml
@@ -51,12 +51,13 @@ spec:
           namespace: obo
         - application: endringslogg
           namespace: pto
+        - application: modiacontextholder
+          namespace: personoversikt
       external:
         - host: veilarbportefolje.dev-fss-pub.nais.io
         - host: veilarbvedtaksstotte.dev-fss-pub.nais.io
         - host: veilarbveileder.dev-fss-pub.nais.io
         - host: veilarboppfolging.dev-fss-pub.nais.io
-        - host: modiacontextholder-q1.dev-fss-pub.nais.io
   env:
     - name: JSON_CONFIG
       value: >
@@ -149,12 +150,12 @@ spec:
             },
             {
               "fromPath": "/modiacontextholder",
-              "toUrl": "https://modiacontextholder-q1.dev-fss-pub.nais.io",
-              "preserveFromPath": true,
+              "toUrl": "http://modiacontextholder.personoversikt",
+              "preserveFromPath": false,
               "toApp": {
-                "name": "modiacontextholder-q1",
+                "name": "modiacontextholder",
                 "namespace": "personoversikt",
-                "cluster": "dev-fss"
+                "cluster": "dev-gcp"
               }
             }
           ]

--- a/.nais/obo-nais-prod.yaml
+++ b/.nais/obo-nais-prod.yaml
@@ -49,12 +49,13 @@ spec:
           namespace: obo
         - application: endringslogg
           namespace: pto
+        - application: modiacontextholder
+          namespace: personoversikt
       external:
         - host: veilarbportefolje.prod-fss-pub.nais.io
         - host: veilarbvedtaksstotte.prod-fss-pub.nais.io
         - host: veilarbveileder.prod-fss-pub.nais.io
         - host: veilarboppfolging.prod-fss-pub.nais.io
-        - host: modiacontextholder.prod-fss-pub.nais.io
   env:
     - name: JSON_CONFIG
       value: >
@@ -147,12 +148,12 @@ spec:
             },
             {
               "fromPath": "/modiacontextholder",
-              "toUrl": "https://modiacontextholder.prod-fss-pub.nais.io",
-              "preserveFromPath": true,
+              "toUrl": "http://modiacontextholder.personoversikt",
+              "preserveFromPath": false,
               "toApp": {
                 "name": "modiacontextholder",
                 "namespace": "personoversikt",
-                "cluster": "prod-fss"
+                "cluster": "prod-gcp"
               }
             }
           ]


### PR DESCRIPTION
Modiacontextholder er migrert til gcp. Fss varianten fungerer kun midlertidig for å støtte i migrasjon.