### PR TITLE
Gjer styling av tiltakshendelse-lenke litt betre

### DIFF
--- a/src/components/tabell/brukernavn.tsx
+++ b/src/components/tabell/brukernavn.tsx
@@ -41,7 +41,7 @@ const BrukerNavn = ({className, bruker, enhetId}: BrukerNavnProps) => {
                 <AksjonKnappMedPopoverFeilmelding
                     klikkAksjon={handterKlikk}
                     ctrlklikkAksjon={handterKlikkNyFane}
-                    knappStil="juster-tekst-venstre"
+                    knappStil="juster-tekst-venstre knapp-uten-padding"
                     knappTekst={navn}
                 />
             )}

--- a/src/components/tabell/kolonner/tiltakshendelse-lenke-kolonne.tsx
+++ b/src/components/tabell/kolonner/tiltakshendelse-lenke-kolonne.tsx
@@ -33,7 +33,7 @@ export const TiltakshendelseLenkeKolonne = ({bruker, skalVises, enhetId, classNa
                 <AksjonKnappMedPopoverFeilmelding
                     klikkAksjon={handterKlikk}
                     ctrlklikkAksjon={handterKlikkNyFane}
-                    knappStil="juster-tekst-venstre"
+                    knappStil="juster-tekst-venstre knapp-uten-padding"
                     knappTekst={tiltakshendelse.tekst}
                 />
             )}

--- a/src/enhetsportefolje/brukerliste.css
+++ b/src/enhetsportefolje/brukerliste.css
@@ -74,7 +74,7 @@
     align-items: center;
 }
 
-.veilarbportefoljeflatefs .brukerliste__innhold .brukernavn button {
+.veilarbportefoljeflatefs .brukerliste__innhold .knapp-uten-padding {
     padding-left: 0;
     padding-right: 0;
 }

--- a/src/enhetsportefolje/enhet-kolonner.tsx
+++ b/src/enhetsportefolje/enhet-kolonner.tsx
@@ -131,7 +131,7 @@ function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKolonner, 
 
     return (
         <div className={className}>
-            <BrukerNavn className="brukernavn col col-xs-2" bruker={bruker} enhetId={enhetId} />
+            <BrukerNavn className="col col-xs-2" bruker={bruker} enhetId={enhetId} />
             <BrukerFnr className="col col-xs-2-5 fnr-kolonne" bruker={bruker} />
             <TekstKolonne
                 className="col col-xs-2"

--- a/src/minoversikt/minoversikt-kolonner.tsx
+++ b/src/minoversikt/minoversikt-kolonner.tsx
@@ -134,7 +134,7 @@ function MinoversiktDatokolonner({className, bruker, enhetId, filtervalg, valgte
 
     return (
         <div className={className}>
-            <BrukerNavn className="brukernavn col col-xs-2" bruker={bruker} enhetId={enhetId} />
+            <BrukerNavn className="col col-xs-2" bruker={bruker} enhetId={enhetId} />
             <BrukerFnr className="col col-xs-2-5 fnr-kolonne" bruker={bruker} />
 
             <TekstKolonne


### PR DESCRIPTION
- Ta bort padding på tiltakshendelse-lenke.
- Bruk same klasse til andre knappar i brukarliste som skal vere utan padding.
- Flytt "utan padding"-klassenamn inn i komponent i staden for å sende den med via props.