### PR TITLE
Lag småkomponentar for header-celler

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -124,18 +124,18 @@ Cypress.Commands.add('klikkTab', tab => {
 });
 
 Cypress.Commands.add('checkbox', testid => {
-    cy.getByTestId(testid).should('not.be.checked').check({force: true});
-    cy.getByTestId(testid).should('be.checked');
+    cy.getByTestId(testid).as('checkbox').should('not.be.checked').check({force: true});
+    cy.get('@checkbox').should('be.checked');
 });
 
 Cypress.Commands.add('checkboxFirst', testid => {
-    cy.getByTestId(testid).first().should('not.be.checked').check({force: true});
-    cy.getByTestId(testid).first().should('be.checked');
+    cy.getByTestId(testid).first().as('first-checkbox').should('not.be.checked').check({force: true});
+    cy.get('@first-checkbox').should('be.checked');
 });
 
 Cypress.Commands.add('checkboxLast', testid => {
-    cy.getByTestId(testid).last().should('not.be.checked').check({force: true});
-    cy.getByTestId(testid).last().should('be.checked');
+    cy.getByTestId(testid).last().as('last-checkbox').should('not.be.checked').check({force: true});
+    cy.get('@last-checkbox').should('be.checked');
 });
 
 Cypress.Commands.add('apneLukkeFilterDropdown', filternavn => {

--- a/src/components/tabell/headerceller/BarnUnder18Ar.tsx
+++ b/src/components/tabell/headerceller/BarnUnder18Ar.tsx
@@ -4,7 +4,6 @@ import {Kolonne} from '../../../ducks/ui/listevisning';
 import SorteringHeader from '../sortering-header';
 
 export const BarnUnder18Aar = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
-    // TODO: Sjå over titteltekst. Kan vi seie noko her om kva type informasjon vi viser i kolonna? Er det eit tal, namna på ungane, noko heilt anna?
     <SorteringHeader
         skalVises={valgteKolonner.includes(Kolonne.BARN_UNDER_18_AAR)}
         sortering={Sorteringsfelt.BARN_UNDER_18_AAR}
@@ -12,7 +11,7 @@ export const BarnUnder18Aar = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefo
         rekkefolge={rekkefolge}
         onClick={onClick}
         tekst="Barn under 18 år"
-        title="Barn under 18 år"
+        title="Antall og alder på barn under 18 år"
         headerId="barn_under_18"
         className="col col-xs-2"
     />

--- a/src/components/tabell/headerceller/BarnUnder18Ar.tsx
+++ b/src/components/tabell/headerceller/BarnUnder18Ar.tsx
@@ -1,0 +1,19 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const BarnUnder18Aar = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
+    // TODO: Sjå over titteltekst. Kan vi seie noko her om kva type informasjon vi viser i kolonna? Er det eit tal, namna på ungane, noko heilt anna?
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.BARN_UNDER_18_AAR)}
+        sortering={Sorteringsfelt.BARN_UNDER_18_AAR}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.BARN_UNDER_18_AAR}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Barn under 18 år"
+        title="Barn under 18 år"
+        headerId="barn_under_18"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/Bosted.tsx
+++ b/src/components/tabell/headerceller/Bosted.tsx
@@ -3,8 +3,7 @@ import {Sorteringsfelt} from '../../../model-interfaces';
 import {Kolonne} from '../../../ducks/ui/listevisning';
 import SorteringHeader from '../sortering-header';
 
-export const BostedKommune = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
-    // TODO: Sjå over titteltekst
+export const Bosted = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
     <SorteringHeader
         skalVises={valgteKolonner.includes(Kolonne.BOSTED_KOMMUNE)}
         sortering={Sorteringsfelt.BOSTED_KOMMUNE}
@@ -12,7 +11,7 @@ export const BostedKommune = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefol
         rekkefolge={rekkefolge}
         onClick={onClick}
         tekst="Bosted"
-        title="Kommunen personen bor i"
+        title="Stedet personen bor, oftest kommunenummer"
         headerId="bosted_kommune"
         className="col col-xs-2"
     />

--- a/src/components/tabell/headerceller/Bosted.tsx
+++ b/src/components/tabell/headerceller/Bosted.tsx
@@ -11,7 +11,7 @@ export const Bosted = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onC
         rekkefolge={rekkefolge}
         onClick={onClick}
         tekst="Bosted"
-        title="Stedet personen bor, oftest kommunenummer"
+        title="Kommunen personen bor i"
         headerId="bosted_kommune"
         className="col col-xs-2"
     />

--- a/src/components/tabell/headerceller/BostedBydel.tsx
+++ b/src/components/tabell/headerceller/BostedBydel.tsx
@@ -1,0 +1,19 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const BostedBydel = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
+    // TODO: Sjå over titteltekst og sjekk at det faktisk er "bydel" som vert vist for alle innbyggarar
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.BOSTED_BYDEL)}
+        sortering={Sorteringsfelt.BOSTED_BYDEL}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.BOSTED_BYDEL}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Bosted detaljer"
+        title="Bydelen personen bor i"
+        headerId="bosted_bydel"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/BostedDetaljer.tsx
+++ b/src/components/tabell/headerceller/BostedDetaljer.tsx
@@ -11,7 +11,7 @@ export const BostedDetaljer = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefo
         rekkefolge={rekkefolge}
         onClick={onClick}
         tekst="Bosted detaljer"
-        title="Detaljer om hvor personen bor, for eksempel bydel"
+        title="Bydelen personen bor i (om det finnes en)"
         headerId="bosted_bydel"
         className="col col-xs-2"
     />

--- a/src/components/tabell/headerceller/BostedDetaljer.tsx
+++ b/src/components/tabell/headerceller/BostedDetaljer.tsx
@@ -3,8 +3,7 @@ import {Sorteringsfelt} from '../../../model-interfaces';
 import {Kolonne} from '../../../ducks/ui/listevisning';
 import SorteringHeader from '../sortering-header';
 
-export const BostedBydel = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
-    // TODO: Sjå over titteltekst og sjekk at det faktisk er "bydel" som vert vist for alle innbyggarar
+export const BostedDetaljer = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
     <SorteringHeader
         skalVises={valgteKolonner.includes(Kolonne.BOSTED_BYDEL)}
         sortering={Sorteringsfelt.BOSTED_BYDEL}
@@ -12,7 +11,7 @@ export const BostedBydel = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge
         rekkefolge={rekkefolge}
         onClick={onClick}
         tekst="Bosted detaljer"
-        title="Bydelen personen bor i"
+        title="Detaljer om hvor personen bor, for eksempel bydel"
         headerId="bosted_bydel"
         className="col col-xs-2"
     />

--- a/src/components/tabell/headerceller/BostedKommune.tsx
+++ b/src/components/tabell/headerceller/BostedKommune.tsx
@@ -1,0 +1,19 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const BostedKommune = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
+    // TODO: Sjå over titteltekst
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.BOSTED_KOMMUNE)}
+        sortering={Sorteringsfelt.BOSTED_KOMMUNE}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.BOSTED_KOMMUNE}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Bosted"
+        title="Kommunen personen bor i"
+        headerId="bosted_kommune"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/BostedSistOppdatert.tsx
+++ b/src/components/tabell/headerceller/BostedSistOppdatert.tsx
@@ -1,0 +1,24 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const BostedSistOppdatert = ({
+    gjeldendeSorteringsfelt,
+    valgteKolonner,
+    rekkefolge,
+    onClick
+}: HeadercelleProps) => (
+    // TODO: Sjå over titteltekst
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.BOSTED_SIST_OPPDATERT)}
+        sortering={Sorteringsfelt.BOSTED_SIST_OPPDATERT}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.BOSTED_SIST_OPPDATERT}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Bosted sist oppdatert"
+        title="Tidspunkt for siste oppdatering av bosted"
+        headerId="bosted_sist_oppdatert"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/BostedSistOppdatert.tsx
+++ b/src/components/tabell/headerceller/BostedSistOppdatert.tsx
@@ -9,15 +9,14 @@ export const BostedSistOppdatert = ({
     rekkefolge,
     onClick
 }: HeadercelleProps) => (
-    // TODO: Sjå over titteltekst
     <SorteringHeader
         skalVises={valgteKolonner.includes(Kolonne.BOSTED_SIST_OPPDATERT)}
         sortering={Sorteringsfelt.BOSTED_SIST_OPPDATERT}
         erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.BOSTED_SIST_OPPDATERT}
         rekkefolge={rekkefolge}
         onClick={onClick}
-        tekst="Bosted sist oppdatert"
-        title="Tidspunkt for siste oppdatering av bosted"
+        tekst="Bosted oppdatert"
+        title="Dato for siste oppdatering av bosted"
         headerId="bosted_sist_oppdatert"
         className="col col-xs-2"
     />

--- a/src/components/tabell/headerceller/Fnr.tsx
+++ b/src/components/tabell/headerceller/Fnr.tsx
@@ -1,0 +1,16 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import SorteringHeader from '../sortering-header';
+
+export const Fnr = ({gjeldendeSorteringsfelt, rekkefolge, onClick}: HeadercelleProps) => (
+    <SorteringHeader
+        sortering={Sorteringsfelt.FODSELSNUMMER}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.FODSELSNUMMER}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Fødselsnr."
+        title="Fødselsnummer"
+        headerId="fnr"
+        className="col col-xs-2-5"
+    />
+);

--- a/src/components/tabell/headerceller/Fodeland.tsx
+++ b/src/components/tabell/headerceller/Fodeland.tsx
@@ -1,0 +1,18 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const Fodeland = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.FODELAND)}
+        sortering={Sorteringsfelt.FODELAND}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.FODELAND}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Fødeland"
+        title="Fødeland"
+        headerId="fodeland"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/Fodeland.tsx
+++ b/src/components/tabell/headerceller/Fodeland.tsx
@@ -11,7 +11,7 @@ export const Fodeland = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, o
         rekkefolge={rekkefolge}
         onClick={onClick}
         tekst="Fødeland"
-        title="Fødeland"
+        title="Landet personen er født i"
         headerId="fodeland"
         className="col col-xs-2"
     />

--- a/src/components/tabell/headerceller/HeadercelleProps.ts
+++ b/src/components/tabell/headerceller/HeadercelleProps.ts
@@ -1,0 +1,10 @@
+import {Sorteringsfelt, Sorteringsrekkefolge} from '../../../model-interfaces';
+import {OrNothing} from '../../../utils/types/types';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+
+export interface HeadercelleProps {
+    valgteKolonner: Kolonne[];
+    gjeldendeSorteringsfelt: OrNothing<Sorteringsfelt>;
+    rekkefolge: OrNothing<Sorteringsrekkefolge>;
+    onClick: (sortering: string) => void;
+}

--- a/src/components/tabell/headerceller/HuskelappFrist.tsx
+++ b/src/components/tabell/headerceller/HuskelappFrist.tsx
@@ -11,7 +11,7 @@ export const HuskelappFrist = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefo
         rekkefolge={rekkefolge}
         onClick={onClick}
         tekst="Frist huskelapp"
-        title="Frist huskelapp"
+        title="Fristen som er satt på huskelappen"
         headerId="huskelapp-frist"
         className="col col-xs-2"
     />

--- a/src/components/tabell/headerceller/HuskelappFrist.tsx
+++ b/src/components/tabell/headerceller/HuskelappFrist.tsx
@@ -1,0 +1,18 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const HuskelappFrist = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.HUSKELAPP_FRIST)}
+        sortering={Sorteringsfelt.HUSKELAPP_FRIST}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.HUSKELAPP_FRIST}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Frist huskelapp"
+        title="Frist huskelapp"
+        headerId="huskelapp-frist"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/HuskelappKommentar.tsx
+++ b/src/components/tabell/headerceller/HuskelappKommentar.tsx
@@ -1,0 +1,23 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const HuskelappKommentar = ({
+    gjeldendeSorteringsfelt,
+    valgteKolonner,
+    rekkefolge,
+    onClick
+}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.HUSKELAPP_KOMMENTAR)}
+        sortering={Sorteringsfelt.HUSKELAPP_KOMMENTAR}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.HUSKELAPP_KOMMENTAR}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Huskelapp"
+        title="Huskelapp"
+        headerId="huskelapp"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/Navn.tsx
+++ b/src/components/tabell/headerceller/Navn.tsx
@@ -1,0 +1,16 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import SorteringHeader from '../sortering-header';
+
+export const Navn = ({gjeldendeSorteringsfelt, rekkefolge, onClick}: HeadercelleProps) => (
+    <SorteringHeader
+        sortering={Sorteringsfelt.ETTERNAVN}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.ETTERNAVN}
+        onClick={onClick}
+        rekkefolge={rekkefolge}
+        tekst="Etternavn"
+        title="Etternavn"
+        headerId="etternavn"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/OppfolgingStartet.tsx
+++ b/src/components/tabell/headerceller/OppfolgingStartet.tsx
@@ -4,7 +4,6 @@ import {Kolonne} from '../../../ducks/ui/listevisning';
 import SorteringHeader from '../sortering-header';
 
 export const OppfolgingStartet = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
-    // TODO: Sjå over titteltekst
     <SorteringHeader
         skalVises={valgteKolonner.includes(Kolonne.OPPFOLGING_STARTET)}
         sortering={Sorteringsfelt.OPPFOLGING_STARTET}

--- a/src/components/tabell/headerceller/OppfolgingStartet.tsx
+++ b/src/components/tabell/headerceller/OppfolgingStartet.tsx
@@ -1,0 +1,19 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const OppfolgingStartet = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
+    // TODO: Sjå over titteltekst
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.OPPFOLGING_STARTET)}
+        sortering={Sorteringsfelt.OPPFOLGING_STARTET}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.OPPFOLGING_STARTET}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Oppfølging startet"
+        title="Startdato for pågående oppfølgingsperiode"
+        headerId="oppfolging-startet"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/Statsborgerskap.tsx
+++ b/src/components/tabell/headerceller/Statsborgerskap.tsx
@@ -1,0 +1,18 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const Statsborgerskap = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.STATSBORGERSKAP)}
+        sortering={Sorteringsfelt.STATSBORGERSKAP}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.STATSBORGERSKAP}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Statsborgerskap"
+        title="Statsborgerskap"
+        headerId="statsborgerskap"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/Statsborgerskap.tsx
+++ b/src/components/tabell/headerceller/Statsborgerskap.tsx
@@ -11,7 +11,7 @@ export const Statsborgerskap = ({gjeldendeSorteringsfelt, valgteKolonner, rekkef
         rekkefolge={rekkefolge}
         onClick={onClick}
         tekst="Statsborgerskap"
-        title="Statsborgerskap"
+        title="Statsborgerskap personen har"
         headerId="statsborgerskap"
         className="col col-xs-2"
     />

--- a/src/components/tabell/headerceller/StatsborgerskapGyldigFra.tsx
+++ b/src/components/tabell/headerceller/StatsborgerskapGyldigFra.tsx
@@ -16,7 +16,7 @@ export const StatsborgerskapGyldigFra = ({
         rekkefolge={rekkefolge}
         onClick={onClick}
         tekst="Gyldig fra"
-        title="Statsborgerskap gyldig fra"
+        title="Dato statsborgerskapet er gyldig fra"
         headerId="statsborgerskap_gyldig_fra"
         className="col col-xs-2"
     />

--- a/src/components/tabell/headerceller/StatsborgerskapGyldigFra.tsx
+++ b/src/components/tabell/headerceller/StatsborgerskapGyldigFra.tsx
@@ -1,0 +1,23 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const StatsborgerskapGyldigFra = ({
+    gjeldendeSorteringsfelt,
+    valgteKolonner,
+    rekkefolge,
+    onClick
+}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.STATSBORGERSKAP_GYLDIG_FRA)}
+        sortering={Sorteringsfelt.STATSBORGERSKAP_GYLDIG_FRA}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.STATSBORGERSKAP_GYLDIG_FRA}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Gyldig fra"
+        title="Statsborgerskap gyldig fra"
+        headerId="statsborgerskap_gyldig_fra"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/Status14AVedtak.tsx
+++ b/src/components/tabell/headerceller/Status14AVedtak.tsx
@@ -1,0 +1,15 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import Header from '../header';
+import * as React from 'react';
+
+export const Status14AVedtak = ({valgteKolonner}: HeadercelleProps) => (
+    <Header
+        skalVises={valgteKolonner.includes(Kolonne.AVVIK_14A_VEDTAK)}
+        title="Status §14a-vedtak"
+        headerId="status-14a-vedtak-kolonne-header"
+        className="col col-xs-2"
+    >
+        Status §14a-vedtak
+    </Header>
+);

--- a/src/components/tabell/headerceller/Status14AVedtak.tsx
+++ b/src/components/tabell/headerceller/Status14AVedtak.tsx
@@ -4,9 +4,10 @@ import Header from '../header';
 import * as React from 'react';
 
 export const Status14AVedtak = ({valgteKolonner}: HeadercelleProps) => (
+    // Dette er den som samanliknar gjeldande vedtak og "den i Arena". Viser om det er skilnad mellom kjeldene.
     <Header
         skalVises={valgteKolonner.includes(Kolonne.AVVIK_14A_VEDTAK)}
-        title="Status §14a-vedtak"
+        title="Status for §14a-vedtak (sammenligning mellom Arena og ny løsning)"
         headerId="status-14a-vedtak-kolonne-header"
         className="col col-xs-2"
     >

--- a/src/components/tabell/headerceller/SvarfristCv.tsx
+++ b/src/components/tabell/headerceller/SvarfristCv.tsx
@@ -1,0 +1,19 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const SvarfristCv = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
+    // TODO: Sjå over "tekst", burde det vore "Svarfrist CV" i staden?
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.CV_SVARFRIST)}
+        sortering={Sorteringsfelt.CV_SVARFRIST}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.CV_SVARFRIST}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="CV svarfrist"
+        title="Svarfrist for å svare ja til deling av CV"
+        headerId="cv-svarfrist"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/SvarfristCv.tsx
+++ b/src/components/tabell/headerceller/SvarfristCv.tsx
@@ -4,15 +4,14 @@ import {Kolonne} from '../../../ducks/ui/listevisning';
 import SorteringHeader from '../sortering-header';
 
 export const SvarfristCv = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
-    // TODO: Sjå over "tekst", burde det vore "Svarfrist CV" i staden?
     <SorteringHeader
         skalVises={valgteKolonner.includes(Kolonne.CV_SVARFRIST)}
         sortering={Sorteringsfelt.CV_SVARFRIST}
         erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.CV_SVARFRIST}
         rekkefolge={rekkefolge}
         onClick={onClick}
-        tekst="CV svarfrist"
-        title="Svarfrist for å svare ja til deling av CV"
+        tekst="Frist deling av CV"
+        title="Frist for at personen skal svare ja til deling av CV"
         headerId="cv-svarfrist"
         className="col col-xs-2"
     />

--- a/src/components/tabell/headerceller/SvarfristCv.tsx
+++ b/src/components/tabell/headerceller/SvarfristCv.tsx
@@ -11,7 +11,7 @@ export const SvarfristCv = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge
         rekkefolge={rekkefolge}
         onClick={onClick}
         tekst="Frist deling av CV"
-        title="Frist for at personen skal svare ja til deling av CV"
+        title="Frist for at personen skal svare ja til deling av CV med arbeidsgiver"
         headerId="cv-svarfrist"
         className="col col-xs-2"
     />

--- a/src/components/tabell/headerceller/Tolkebehov.tsx
+++ b/src/components/tabell/headerceller/Tolkebehov.tsx
@@ -1,0 +1,14 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import Header from '../header';
+
+export const Tolkebehov = ({valgteKolonner}: HeadercelleProps) => (
+    <Header
+        skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV)}
+        title="Tolkebehov"
+        headerId="tolkebehov"
+        className="col col-xs-2"
+    >
+        Tolkebehov
+    </Header>
+);

--- a/src/components/tabell/headerceller/Tolkebehov.tsx
+++ b/src/components/tabell/headerceller/Tolkebehov.tsx
@@ -5,7 +5,7 @@ import Header from '../header';
 export const Tolkebehov = ({valgteKolonner}: HeadercelleProps) => (
     <Header
         skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV)}
-        title="Tolkebehov"
+        title="Hvilke tolkebehov personen har"
         headerId="tolkebehov"
         className="col col-xs-2"
     >

--- a/src/components/tabell/headerceller/TolkebehovSistOppdatert.tsx
+++ b/src/components/tabell/headerceller/TolkebehovSistOppdatert.tsx
@@ -9,15 +9,14 @@ export const TolkebehovSistOppdatert = ({
     rekkefolge,
     onClick
 }: HeadercelleProps) => (
-    // TODO: Sjå over titteltekst
     <SorteringHeader
         skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SIST_OPPDATERT)}
         sortering={Sorteringsfelt.TOLKEBEHOV_SIST_OPPDATERT}
         erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.TOLKEBEHOV_SIST_OPPDATERT}
         rekkefolge={rekkefolge}
         onClick={onClick}
-        tekst="Sist oppdatert"
-        title="Tolkebehov sist oppdatert"
+        tekst="Tolkebehov oppdatert"
+        title="Dato for siste oppdatering av tolkebehov"
         headerId="tolkbehovsistoppdatert"
         className="col col-xs-2"
     />

--- a/src/components/tabell/headerceller/TolkebehovSistOppdatert.tsx
+++ b/src/components/tabell/headerceller/TolkebehovSistOppdatert.tsx
@@ -1,0 +1,24 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const TolkebehovSistOppdatert = ({
+    gjeldendeSorteringsfelt,
+    valgteKolonner,
+    rekkefolge,
+    onClick
+}: HeadercelleProps) => (
+    // TODO: Sjå over titteltekst
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SIST_OPPDATERT)}
+        sortering={Sorteringsfelt.TOLKEBEHOV_SIST_OPPDATERT}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.TOLKEBEHOV_SIST_OPPDATERT}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Sist oppdatert"
+        title="Tolkebehov sist oppdatert"
+        headerId="tolkbehovsistoppdatert"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/Tolkesprak.tsx
+++ b/src/components/tabell/headerceller/Tolkesprak.tsx
@@ -1,0 +1,18 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const Tolkesprak = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.TOLKESPRAK)}
+        sortering={Sorteringsfelt.TOLKESPRAK}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.TOLKESPRAK}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Språk"
+        title="Tolkespråk"
+        headerId="tolkespraak"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/Tolkesprak.tsx
+++ b/src/components/tabell/headerceller/Tolkesprak.tsx
@@ -10,8 +10,8 @@ export const Tolkesprak = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge,
         erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.TOLKESPRAK}
         rekkefolge={rekkefolge}
         onClick={onClick}
-        tekst="Språk"
-        title="Tolkespråk"
+        tekst="Tolkespråk"
+        title="Hvilket språk tolken må kunne"
         headerId="tolkespraak"
         className="col col-xs-2"
     />

--- a/src/components/tabell/headerceller/UtdanningOgSituasjonSistEndret.tsx
+++ b/src/components/tabell/headerceller/UtdanningOgSituasjonSistEndret.tsx
@@ -9,7 +9,6 @@ export const UtdanningOgSituasjonSistEndret = ({
     rekkefolge,
     onClick
 }: HeadercelleProps) => (
-    // TODO: Sjå over titteltekst
     <SorteringHeader
         skalVises={valgteKolonner.includes(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET)}
         sortering={Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
@@ -17,7 +16,7 @@ export const UtdanningOgSituasjonSistEndret = ({
         rekkefolge={rekkefolge}
         onClick={onClick}
         tekst="Dato sist endret"
-        title="Dato for siste endring av utdanning og situasjon"
+        title="Dato da personen ga informasjon om situasjon eller utdanning"
         headerId="dato-sist-endret-utdanning-og-situasjon"
         className="col col-xs-2"
     />

--- a/src/components/tabell/headerceller/UtdanningOgSituasjonSistEndret.tsx
+++ b/src/components/tabell/headerceller/UtdanningOgSituasjonSistEndret.tsx
@@ -16,7 +16,7 @@ export const UtdanningOgSituasjonSistEndret = ({
         rekkefolge={rekkefolge}
         onClick={onClick}
         tekst="Dato sist endret"
-        title="Dato da personen ga informasjon om situasjon eller utdanning"
+        title="Dato personen sist ga informasjon om situasjon eller utdanning"
         headerId="dato-sist-endret-utdanning-og-situasjon"
         className="col col-xs-2"
     />

--- a/src/components/tabell/headerceller/UtdanningOgSituasjonSistEndret.tsx
+++ b/src/components/tabell/headerceller/UtdanningOgSituasjonSistEndret.tsx
@@ -1,0 +1,24 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const UtdanningOgSituasjonSistEndret = ({
+    gjeldendeSorteringsfelt,
+    valgteKolonner,
+    rekkefolge,
+    onClick
+}: HeadercelleProps) => (
+    // TODO: Sjå over titteltekst
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET)}
+        sortering={Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Dato sist endret"
+        title="Dato for siste endring av utdanning og situasjon"
+        headerId="dato-sist-endret-utdanning-og-situasjon"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/toolbar/listevisning/listevisning-utils.ts
+++ b/src/components/toolbar/listevisning/listevisning-utils.ts
@@ -5,7 +5,7 @@ export interface Alternativ {
 }
 
 export const alternativerConfig = new Map<Kolonne, Alternativ>();
-alternativerConfig.set(Kolonne.OPPFOLGINGSTARTET, {tekstlabel: 'Oppfølging startet'});
+alternativerConfig.set(Kolonne.OPPFOLGING_STARTET, {tekstlabel: 'Oppfølging startet'});
 alternativerConfig.set(Kolonne.VEILEDER, {tekstlabel: 'Veileder'});
 alternativerConfig.set(Kolonne.NAVIDENT, {tekstlabel: 'NAV-ident'});
 alternativerConfig.set(Kolonne.VENTER_SVAR, {tekstlabel: 'Dato på melding'});

--- a/src/components/toolbar/listevisning/listevisning-utils.ts
+++ b/src/components/toolbar/listevisning/listevisning-utils.ts
@@ -50,7 +50,7 @@ alternativerConfig.set(Kolonne.ENSLIGE_FORSORGERE_UTLOP_OVERGANGSSTONAD, {tekstl
 alternativerConfig.set(Kolonne.ENSLIGE_FORSORGERE_AKIVITETSPLIKT, {tekstlabel: 'Om aktivitetsplikt overgangsstønad'});
 alternativerConfig.set(Kolonne.ENSLIGE_FORSORGERE_VEDTAKSPERIODE, {tekstlabel: 'Type vedtaksperiode overgangsstønad'});
 alternativerConfig.set(Kolonne.ENSLIGE_FORSORGERE_OM_BARNET, {tekstlabel: 'Om barnet'});
-alternativerConfig.set(Kolonne.HAR_BARN_UNDER_18, {tekstlabel: 'Barn under 18 år'});
+alternativerConfig.set(Kolonne.BARN_UNDER_18_AAR, {tekstlabel: 'Barn under 18 år'});
 alternativerConfig.set(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET, {tekstlabel: 'Dato sist endret'});
 alternativerConfig.set(Kolonne.HUSKELAPP_KOMMENTAR, {tekstlabel: 'Huskelapp'});
 alternativerConfig.set(Kolonne.HUSKELAPP_FRIST, {tekstlabel: 'Frist huskelapp'});

--- a/src/components/toolbar/listevisning/listevisning-utils.ts
+++ b/src/components/toolbar/listevisning/listevisning-utils.ts
@@ -31,10 +31,14 @@ alternativerConfig.set(Kolonne.MOTER_VARIGHET, {tekstlabel: 'Varighet møte'});
 alternativerConfig.set(Kolonne.MOTE_ER_AVTALT, {tekstlabel: 'Møte er avtalt med NAV'});
 alternativerConfig.set(Kolonne.ARBEIDSLISTE_FRIST, {tekstlabel: 'Arbeidsliste frist'});
 alternativerConfig.set(Kolonne.ARBEIDSLISTE_OVERSKRIFT, {tekstlabel: 'Arbeidsliste tittel'});
-alternativerConfig.set(Kolonne.VEDTAKSTATUS, {tekstlabel: 'Status oppfølgingsvedtak'});
-alternativerConfig.set(Kolonne.VEDTAKSTATUS_ENDRET, {tekstlabel: 'Oppfølgingsvedtak status tidspunkt'});
-alternativerConfig.set(Kolonne.SISTE_ENDRING, {tekstlabel: 'Siste endring'});
-alternativerConfig.set(Kolonne.SISTE_ENDRING_DATO, {tekstlabel: 'Siste endring dato'});
+alternativerConfig.set(Kolonne.VEDTAKSTATUS, {tekstlabel: 'Status § 14 a-vedtak (ny løsning)'});
+alternativerConfig.set(Kolonne.VEDTAKSTATUS_ENDRET, {
+    tekstlabel: 'Tidspunkt for endring av status § 14 a-vedtak (ny løsning)'
+});
+alternativerConfig.set(Kolonne.SISTE_ENDRING, {tekstlabel: 'Siste endring personen har gjort på aktivitet/mål'});
+alternativerConfig.set(Kolonne.SISTE_ENDRING_DATO, {
+    tekstlabel: 'Dato for siste endring personen har gjort på aktivitet/mål'
+});
 alternativerConfig.set(Kolonne.FODELAND, {tekstlabel: 'Fødeland'});
 alternativerConfig.set(Kolonne.STATSBORGERSKAP, {tekstlabel: 'Statsborgerskap'});
 alternativerConfig.set(Kolonne.STATSBORGERSKAP_GYLDIG_FRA, {tekstlabel: 'Statsborgerskap gyldig fra'});
@@ -42,16 +46,18 @@ alternativerConfig.set(Kolonne.BOSTED_KOMMUNE, {tekstlabel: 'Geografisk bosted'}
 alternativerConfig.set(Kolonne.BOSTED_BYDEL, {tekstlabel: 'Bosted detaljer'});
 alternativerConfig.set(Kolonne.BOSTED_SIST_OPPDATERT, {tekstlabel: 'Bosted sist oppdatert'});
 alternativerConfig.set(Kolonne.TOLKEBEHOV, {tekstlabel: 'Tolkebehov'});
-alternativerConfig.set(Kolonne.TOLKESPRAK, {tekstlabel: 'Språk'});
-alternativerConfig.set(Kolonne.TOLKEBEHOV_SIST_OPPDATERT, {tekstlabel: 'Sist oppdatert'});
-alternativerConfig.set(Kolonne.CV_SVARFRIST, {tekstlabel: 'CV svarfrist'});
-alternativerConfig.set(Kolonne.AVVIK_14A_VEDTAK, {tekstlabel: 'Status § 14 a-vedtak'});
+alternativerConfig.set(Kolonne.TOLKESPRAK, {tekstlabel: 'Tolkespråk'});
+alternativerConfig.set(Kolonne.TOLKEBEHOV_SIST_OPPDATERT, {tekstlabel: 'Tolkebehov sist oppdatert'});
+alternativerConfig.set(Kolonne.CV_SVARFRIST, {tekstlabel: 'Frist deling av CV'});
+alternativerConfig.set(Kolonne.AVVIK_14A_VEDTAK, {
+    tekstlabel: 'Status § 14 a-vedtak (sammenligning mellom Arena og ny løsning)'
+});
 alternativerConfig.set(Kolonne.ENSLIGE_FORSORGERE_UTLOP_OVERGANGSSTONAD, {tekstlabel: 'Utløp overgangsstønad'});
 alternativerConfig.set(Kolonne.ENSLIGE_FORSORGERE_AKIVITETSPLIKT, {tekstlabel: 'Om aktivitetsplikt overgangsstønad'});
 alternativerConfig.set(Kolonne.ENSLIGE_FORSORGERE_VEDTAKSPERIODE, {tekstlabel: 'Type vedtaksperiode overgangsstønad'});
 alternativerConfig.set(Kolonne.ENSLIGE_FORSORGERE_OM_BARNET, {tekstlabel: 'Om barnet'});
 alternativerConfig.set(Kolonne.BARN_UNDER_18_AAR, {tekstlabel: 'Barn under 18 år'});
-alternativerConfig.set(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET, {tekstlabel: 'Dato sist endret'});
+alternativerConfig.set(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET, {tekstlabel: 'Situasjon/utdanning sist endret'});
 alternativerConfig.set(Kolonne.HUSKELAPP_KOMMENTAR, {tekstlabel: 'Huskelapp'});
 alternativerConfig.set(Kolonne.HUSKELAPP_FRIST, {tekstlabel: 'Frist huskelapp'});
 alternativerConfig.set(Kolonne.TILTAKSHENDELSE_LENKE, {tekstlabel: 'Tiltakshendelse lenke'});

--- a/src/components/toolbar/listevisning/listevisning-utils.ts
+++ b/src/components/toolbar/listevisning/listevisning-utils.ts
@@ -42,7 +42,7 @@ alternativerConfig.set(Kolonne.BOSTED_KOMMUNE, {tekstlabel: 'Geografisk bosted'}
 alternativerConfig.set(Kolonne.BOSTED_BYDEL, {tekstlabel: 'Bosted detaljer'});
 alternativerConfig.set(Kolonne.BOSTED_SIST_OPPDATERT, {tekstlabel: 'Bosted sist oppdatert'});
 alternativerConfig.set(Kolonne.TOLKEBEHOV, {tekstlabel: 'Tolkebehov'});
-alternativerConfig.set(Kolonne.TOLKEBEHOV_SPRAAK, {tekstlabel: 'Språk'});
+alternativerConfig.set(Kolonne.TOLKESPRAK, {tekstlabel: 'Språk'});
 alternativerConfig.set(Kolonne.TOLKEBEHOV_SIST_OPPDATERT, {tekstlabel: 'Sist oppdatert'});
 alternativerConfig.set(Kolonne.CV_SVARFRIST, {tekstlabel: 'CV svarfrist'});
 alternativerConfig.set(Kolonne.AVVIK_14A_VEDTAK, {tekstlabel: 'Status § 14 a-vedtak'});

--- a/src/ducks/ui/listevisning-selectors.ts
+++ b/src/ducks/ui/listevisning-selectors.ts
@@ -192,5 +192,5 @@ export function getMuligeKolonner(filtervalg: FiltervalgModell, oversiktType: Ov
         .concat(addHvis(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET, filtrertPaUtdanningEllerSituasjonSomKanHaEndring))
         .concat(addHvis(Kolonne.HUSKELAPP_KOMMENTAR, filtrertPaHuskelapp))
         .concat(addHvis(Kolonne.HUSKELAPP_FRIST, filtrertPaHuskelapp))
-        .concat([Kolonne.OPPFOLGINGSTARTET]);
+        .concat([Kolonne.OPPFOLGING_STARTET]);
 }

--- a/src/ducks/ui/listevisning-selectors.ts
+++ b/src/ducks/ui/listevisning-selectors.ts
@@ -188,7 +188,7 @@ export function getMuligeKolonner(filtervalg: FiltervalgModell, oversiktType: Ov
         .concat(addHvis(Kolonne.NAVIDENT, oversiktType === OversiktType.enhetensOversikt))
         .concat(addHvis(Kolonne.CV_SVARFRIST, filtervalg.stillingFraNavFilter.length !== 0))
         .concat(addHvis(Kolonne.BOSTED_SIST_OPPDATERT, filtrertPaGeografiskBosted))
-        .concat(addHvis(Kolonne.HAR_BARN_UNDER_18, filtrertPaBarnUnder18Ar))
+        .concat(addHvis(Kolonne.BARN_UNDER_18_AAR, filtrertPaBarnUnder18Ar))
         .concat(addHvis(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET, filtrertPaUtdanningEllerSituasjonSomKanHaEndring))
         .concat(addHvis(Kolonne.HUSKELAPP_KOMMENTAR, filtrertPaHuskelapp))
         .concat(addHvis(Kolonne.HUSKELAPP_FRIST, filtrertPaHuskelapp))

--- a/src/ducks/ui/listevisning-selectors.ts
+++ b/src/ducks/ui/listevisning-selectors.ts
@@ -170,7 +170,7 @@ export function getMuligeKolonner(filtervalg: FiltervalgModell, oversiktType: Ov
         .concat(addHvis(Kolonne.ARBEIDSLISTE_FRIST, filtrertPaArbeidslisteIMinOversikt))
         .concat(addHvis(Kolonne.ARBEIDSLISTE_OVERSKRIFT, filtrertPaArbeidslisteIMinOversikt))
         .concat(addHvis(Kolonne.TOLKEBEHOV, filtrertPaTolkBehov))
-        .concat(addHvis(Kolonne.TOLKEBEHOV_SPRAAK, filtrertPaTolkBehov))
+        .concat(addHvis(Kolonne.TOLKESPRAK, filtrertPaTolkBehov))
         .concat(addHvis(Kolonne.TOLKEBEHOV_SIST_OPPDATERT, filtrertPaTolkBehov))
         .concat(addHvis(Kolonne.AVVIK_14A_VEDTAK, filtrertPaAvvik14aVedtak))
         .concat(addHvis(Kolonne.VURDERINGSFRIST_YTELSE, filtrertPaYtelseMedVurderingsfrist))

--- a/src/ducks/ui/listevisning.ts
+++ b/src/ducks/ui/listevisning.ts
@@ -46,7 +46,7 @@ export enum Kolonne {
     BOSTED_BYDEL = 'bosted_bydel',
     BOSTED_SIST_OPPDATERT = 'bosted_sist_oppdatert',
     TOLKEBEHOV = 'tolkebehov',
-    TOLKEBEHOV_SPRAAK = 'tolkebehov_spraak',
+    TOLKESPRAK = 'tolkebehov_spraak',
     TOLKEBEHOV_SIST_OPPDATERT = 'tolkebehov_sist_oppdatert',
     CV_SVARFRIST = 'cv_svarfrist',
     AVVIK_14A_VEDTAK = 'avvik_14a_vedtak',

--- a/src/ducks/ui/listevisning.ts
+++ b/src/ducks/ui/listevisning.ts
@@ -12,7 +12,7 @@ export enum ActionTypeKeys {
 }
 
 export enum Kolonne {
-    OPPFOLGINGSTARTET = 'oppfolgingstartet',
+    OPPFOLGING_STARTET = 'oppfolgingstartet',
     VEILEDER = 'veileder',
     NAVIDENT = 'navident',
     UTLOPTE_AKTIVITETER = 'utlopteaktiviteter',

--- a/src/ducks/ui/listevisning.ts
+++ b/src/ducks/ui/listevisning.ts
@@ -55,7 +55,7 @@ export enum Kolonne {
     ENSLIGE_FORSORGERE_AKIVITETSPLIKT = 'om_aktivitetsplikt',
     ENSLIGE_FORSORGERE_OM_BARNET = 'om_barnet',
 
-    HAR_BARN_UNDER_18 = 'har_barn_under_18',
+    BARN_UNDER_18_AAR = 'har_barn_under_18',
     UTDANNING_OG_SITUASJON_SIST_ENDRET = 'utdanning_og_situasjon_sist_endret',
     HUSKELAPP_FRIST = 'huskelapp_frist',
     HUSKELAPP_KOMMENTAR = 'huskelapp_kommentar',

--- a/src/enhetsportefolje/enhet-kolonner.tsx
+++ b/src/enhetsportefolje/enhet-kolonner.tsx
@@ -179,7 +179,7 @@ function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKolonner, 
             <TekstKolonne
                 className="col col-xs-2"
                 tekst={tolkBehovSpraak(filtervalg, bruker, tolkbehovSpraakData)}
-                skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SPRAAK)}
+                skalVises={valgteKolonner.includes(Kolonne.TOLKESPRAK)}
             />
             <TekstKolonne
                 className="col col-xs-2"

--- a/src/enhetsportefolje/enhet-kolonner.tsx
+++ b/src/enhetsportefolje/enhet-kolonner.tsx
@@ -188,7 +188,7 @@ function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKolonner, 
             />
             <DatoKolonne
                 className="col col-xs-2"
-                skalVises={valgteKolonner.includes(Kolonne.OPPFOLGINGSTARTET)}
+                skalVises={valgteKolonner.includes(Kolonne.OPPFOLGING_STARTET)}
                 dato={oppfolgingStartetDato(bruker.oppfolgingStartdato)}
             />
             <VeilederNavn

--- a/src/enhetsportefolje/enhet-kolonner.tsx
+++ b/src/enhetsportefolje/enhet-kolonner.tsx
@@ -398,7 +398,7 @@ function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKolonner, 
             />
             <TekstKolonne
                 className="col col-xs-2"
-                skalVises={valgteKolonner.includes(Kolonne.HAR_BARN_UNDER_18)}
+                skalVises={valgteKolonner.includes(Kolonne.BARN_UNDER_18_AAR)}
                 tekst={brukerBarnUnder18AarInfo(bruker.barnUnder18AarData)}
             />
             <DatoKolonne

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -26,6 +26,7 @@ import './brukerliste.css';
 import {OrNothing} from '../utils/types/types';
 import {useFeatureSelector} from '../hooks/redux/use-feature-selector';
 import {VIS_AAP_VURDERINGSFRISTKOLONNER} from '../konstanter';
+import {Navn} from '../components/tabell/headerceller/Navn';
 
 function harValgteAktiviteter(aktiviteter) {
     if (aktiviteter && Object.keys(aktiviteter).length > 0) {
@@ -80,27 +81,25 @@ function EnhetListehode({
     const tiltaksType =
         harValgteAktiviteter(filtervalg.tiltakstyper) && valgteKolonner.includes(Kolonne.UTLOP_AKTIVITET);
 
+    const sorteringTilHeadercelle = {
+        gjeldendeSorteringsfelt: sorteringsfelt,
+        valgteKolonner: valgteKolonner,
+        rekkefolge: sorteringsrekkefolge,
+        onClick: sorteringOnClick
+    };
+
     return (
         <div className="brukerliste__header brukerliste__sorteringheader">
             <VelgalleCheckboks />
             <div className="brukerliste__innhold" data-testid="brukerliste_innhold">
+                <Navn {...sorteringTilHeadercelle} />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.ETTERNAVN}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ETTERNAVN}
-                    tekst="Etternavn"
-                    className="col col-xs-2"
-                    title="Etternavn"
-                    headerId="etternavn"
-                />
-                <SorteringHeader
+                    className="col col-xs-2-5"
                     sortering={Sorteringsfelt.FODSELSNUMMER}
                     onClick={sorteringOnClick}
                     rekkefolge={sorteringsrekkefolge}
                     erValgt={sorteringsfelt === Sorteringsfelt.FODSELSNUMMER}
                     tekst="Fødselsnr."
-                    className="col col-xs-2-5"
                     title="Fødselsnummer"
                     headerId="fnr"
                 />

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -41,6 +41,7 @@ import {OppfolgingStartet} from '../components/tabell/headerceller/OppfolgingSta
 import {SvarfristCv} from '../components/tabell/headerceller/SvarfristCv';
 import {Status14AVedtak} from '../components/tabell/headerceller/Status14AVedtak';
 import {BarnUnder18Aar} from '../components/tabell/headerceller/BarnUnder18Ar';
+import {UtdanningOgSituasjonSistEndret} from '../components/tabell/headerceller/UtdanningOgSituasjonSistEndret';
 
 function harValgteAktiviteter(aktiviteter) {
     if (aktiviteter && Object.keys(aktiviteter).length > 0) {
@@ -438,16 +439,8 @@ function EnhetListehode({
 
                 <BarnUnder18Aar {...sorteringTilHeadercelle} />
 
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET)}
-                    sortering={Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Dato sist endret"
-                    headerId="dato-sist-endret-utdanning-og-situasjon"
-                    className="col col-xs-2"
-                />
+                <UtdanningOgSituasjonSistEndret {...sorteringTilHeadercelle} />
+
                 <SorteringHeader
                     skalVises={
                         !!ferdigfilterListe?.includes(TILTAKSHENDELSER) &&

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -38,6 +38,9 @@ import {BostedKommune} from '../components/tabell/headerceller/BostedKommune';
 import {BostedBydel} from '../components/tabell/headerceller/BostedBydel';
 import {BostedSistOppdatert} from '../components/tabell/headerceller/BostedSistOppdatert';
 import {OppfolgingStartet} from '../components/tabell/headerceller/OppfolgingStartet';
+import {SvarfristCv} from '../components/tabell/headerceller/SvarfristCv';
+import {Status14AVedtak} from '../components/tabell/headerceller/Status14AVedtak';
+import {BarnUnder18Aar} from '../components/tabell/headerceller/BarnUnder18Ar';
 
 function harValgteAktiviteter(aktiviteter) {
     if (aktiviteter && Object.keys(aktiviteter).length > 0) {
@@ -373,25 +376,9 @@ function EnhetListehode({
                     headerId="dato-siste-endring"
                     className="col col-xs-2"
                 />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.CV_SVARFRIST)}
-                    sortering={Sorteringsfelt.CV_SVARFRIST}
-                    erValgt={sorteringsfelt === Sorteringsfelt.CV_SVARFRIST}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="CV svarfrist"
-                    title="Svarfrist for å svare ja til deling av CV"
-                    headerId="cv-svarfrist"
-                    className="col col-xs-2"
-                />
-                <Header
-                    skalVises={valgteKolonner.includes(Kolonne.AVVIK_14A_VEDTAK)}
-                    title="Status § 14 a-vedtak"
-                    headerId="enhetsoversikt-status-14a-vedtak-kolonne-header"
-                    className="col col-xs-2"
-                >
-                    Status § 14 a-vedtak
-                </Header>
+                <SvarfristCv {...sorteringTilHeadercelle} />
+                <Status14AVedtak {...sorteringTilHeadercelle} />
+
                 <SorteringHeader
                     skalVises={
                         valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_UTLOP_OVERGANGSSTONAD) &&
@@ -448,16 +435,9 @@ function EnhetListehode({
                     headerId="oppfolging"
                     className="col col-xs-3"
                 />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.HAR_BARN_UNDER_18)}
-                    sortering={Sorteringsfelt.BARN_UNDER_18_AAR}
-                    erValgt={sorteringsfelt === Sorteringsfelt.BARN_UNDER_18_AAR}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Barn under 18 år"
-                    headerId="barn_under_18"
-                    className="col col-xs-2"
-                />
+
+                <BarnUnder18Aar {...sorteringTilHeadercelle} />
+
                 <SorteringHeader
                     skalVises={valgteKolonner.includes(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET)}
                     sortering={Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -94,388 +94,388 @@ function EnhetListehode({
             <div className="brukerliste__innhold" data-testid="brukerliste_innhold">
                 <Navn {...sorteringTilHeadercelle} />
                 <SorteringHeader
-                    className="col col-xs-2-5"
                     sortering={Sorteringsfelt.FODSELSNUMMER}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
                     erValgt={sorteringsfelt === Sorteringsfelt.FODSELSNUMMER}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     tekst="Fødselsnr."
                     title="Fødselsnummer"
                     headerId="fnr"
+                    className="col col-xs-2-5"
                 />
                 <SorteringHeader
+                    skalVises={valgteKolonner.includes(Kolonne.FODELAND)}
                     sortering={Sorteringsfelt.FODELAND}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
                     erValgt={sorteringsfelt === Sorteringsfelt.FODELAND}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     tekst="Fødeland"
-                    className="col col-xs-2"
                     title="Fødeland"
                     headerId="fodeland"
-                    skalVises={valgteKolonner.includes(Kolonne.FODELAND)}
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
+                    skalVises={valgteKolonner.includes(Kolonne.STATSBORGERSKAP)}
                     sortering={Sorteringsfelt.STATSBORGERSKAP}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
                     erValgt={sorteringsfelt === Sorteringsfelt.STATSBORGERSKAP}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     tekst="Statsborgerskap"
-                    className="col col-xs-2"
                     title="Statsborgerskap"
                     headerId="statsborgerskap"
-                    skalVises={valgteKolonner.includes(Kolonne.STATSBORGERSKAP)}
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
+                    skalVises={valgteKolonner.includes(Kolonne.STATSBORGERSKAP_GYLDIG_FRA)}
                     sortering={Sorteringsfelt.STATSBORGERSKAP_GYLDIG_FRA}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
                     erValgt={sorteringsfelt === Sorteringsfelt.STATSBORGERSKAP_GYLDIG_FRA}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     tekst="Gyldig fra"
-                    className="col col-xs-2"
                     title="Statsborgerskap gyldig fra"
                     headerId="statsborgerskap_gyldig_fra"
-                    skalVises={valgteKolonner.includes(Kolonne.STATSBORGERSKAP_GYLDIG_FRA)}
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
+                    skalVises={valgteKolonner.includes(Kolonne.BOSTED_KOMMUNE)}
                     sortering={Sorteringsfelt.BOSTED_KOMMUNE}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
                     erValgt={sorteringsfelt === Sorteringsfelt.BOSTED_KOMMUNE}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     tekst="Bosted"
                     headerId="bosted_kommune"
                     className="col col-xs-2"
-                    skalVises={valgteKolonner.includes(Kolonne.BOSTED_KOMMUNE)}
                 />
                 <SorteringHeader
+                    skalVises={valgteKolonner.includes(Kolonne.BOSTED_BYDEL)}
                     sortering={Sorteringsfelt.BOSTED_BYDEL}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
                     erValgt={sorteringsfelt === Sorteringsfelt.BOSTED_BYDEL}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     tekst="Bosted detaljer"
                     headerId="bosted_bydel"
                     className="col col-xs-2"
-                    skalVises={valgteKolonner.includes(Kolonne.BOSTED_BYDEL)}
                 />
                 <SorteringHeader
+                    skalVises={valgteKolonner.includes(Kolonne.BOSTED_SIST_OPPDATERT)}
                     sortering={Sorteringsfelt.BOSTED_SIST_OPPDATERT}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
                     erValgt={sorteringsfelt === Sorteringsfelt.BOSTED_SIST_OPPDATERT}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     tekst="Bosted sist oppdatert"
                     headerId="bosted_sist_oppdatert"
                     className="col col-xs-2"
-                    skalVises={valgteKolonner.includes(Kolonne.BOSTED_SIST_OPPDATERT)}
                 />
                 <Header
-                    className="col col-xs-2"
+                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV)}
                     title="Tolkebehov"
                     headerId="tolkebehov"
-                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV)}
+                    className="col col-xs-2"
                 >
                     Tolkebehov
                 </Header>
                 <SorteringHeader
+                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SPRAAK)}
                     sortering={Sorteringsfelt.TOLKE_SPRAAK}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
                     erValgt={sorteringsfelt === Sorteringsfelt.TOLKE_SPRAAK}
-                    className="col col-xs-2"
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     title="Tolk behov språk"
                     tekst="Språk"
                     headerId="tolkespraak"
-                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SPRAAK)}
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
+                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SIST_OPPDATERT)}
                     sortering={Sorteringsfelt.TOLKEBEHOV_SIST_OPPDATERT}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
                     erValgt={sorteringsfelt === Sorteringsfelt.TOLKEBEHOV_SIST_OPPDATERT}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     tekst="Sist oppdatert"
-                    className="col col-xs-2"
                     title="Tolkebehov sist oppdatert"
                     headerId="tolkbehovsistoppdatert"
-                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SIST_OPPDATERT)}
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.OPPFOLGINGSTARTET}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.OPPFOLGINGSTARTET}
-                    tekst="Oppfølging startet"
-                    className="col col-xs-2"
                     skalVises={valgteKolonner.includes(Kolonne.OPPFOLGINGSTARTET)}
+                    sortering={Sorteringsfelt.OPPFOLGINGSTARTET}
+                    erValgt={sorteringsfelt === Sorteringsfelt.OPPFOLGINGSTARTET}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Oppfølging startet"
                     title="Startdato for pågående oppfølgingsperiode"
                     headerId="oppfolging-startet"
+                    className="col col-xs-2"
                 />
                 <Header
-                    className="col col-xs-2"
                     skalVises={valgteKolonner.includes(Kolonne.VEILEDER)}
                     headerId="veileder"
+                    className="col col-xs-2"
                 >
                     Veileder
                 </Header>
                 <SorteringHeader
-                    sortering={Sorteringsfelt.NAVIDENT}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.NAVIDENT}
-                    tekst="NAV-ident"
                     skalVises={valgteKolonner.includes(Kolonne.NAVIDENT)}
-                    className="header__veilederident col col-xs-2"
+                    sortering={Sorteringsfelt.NAVIDENT}
+                    erValgt={sorteringsfelt === Sorteringsfelt.NAVIDENT}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="NAV-ident"
                     title="NAV-ident på tildelt veileder"
                     headerId="navident"
+                    className="header__veilederident col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={ytelseUtlopsdatoNavn}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={ytelseUtlopsdatoNavn === sorteringsfelt}
-                    tekst="Gjenstående uker rettighet dagpenger"
                     skalVises={
                         erDagpengerYtelse && valgteKolonner.includes(Kolonne.GJENSTAENDE_UKER_RETTIGHET_DAGPENGER)
                     }
-                    className="col col-xs-2"
+                    sortering={ytelseUtlopsdatoNavn}
+                    erValgt={ytelseUtlopsdatoNavn === sorteringsfelt}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Gjenstående uker rettighet dagpenger"
                     title="Gjenstående uker av rettighetsperioden for dagpenger"
                     headerId="ytelse-utlopsdato"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={ytelseUtlopsdatoNavn}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={ytelseUtlopsdatoNavn === sorteringsfelt}
-                    tekst="Gjenstående uker vedtak tiltakspenger"
                     skalVises={
                         !!filtervalg.ytelse &&
                         !erAapYtelse &&
                         !erDagpengerYtelse &&
                         valgteKolonner.includes(Kolonne.GJENSTAENDE_UKER_VEDTAK_TILTAKSPENGER)
                     }
-                    className="col col-xs-2"
+                    sortering={ytelseUtlopsdatoNavn}
+                    erValgt={ytelseUtlopsdatoNavn === sorteringsfelt}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Gjenstående uker vedtak tiltakspenger"
                     title="Gjenstående uker på gjeldende vedtak tiltakspenger"
                     headerId="ytelse-utlopsdato"
+                    className="col col-xs-2"
                 />
                 {vis_kolonner_for_vurderingsfrist_aap && (
                     <SorteringHeader
-                        sortering={aapPeriodetype}
-                        onClick={sorteringOnClick}
-                        rekkefolge={sorteringsrekkefolge}
-                        erValgt={sorteringsfelt === aapPeriodetype}
-                        tekst="Type AAP-periode"
                         skalVises={erAapYtelse && valgteKolonner.includes(Kolonne.TYPE_YTELSE)}
-                        className="col col-xs-2"
+                        sortering={aapPeriodetype}
+                        erValgt={sorteringsfelt === aapPeriodetype}
+                        rekkefolge={sorteringsrekkefolge}
+                        onClick={sorteringOnClick}
+                        tekst="Type AAP-periode"
                         title="Type AAP-periode"
                         headerId="type-aap"
+                        className="col col-xs-2"
                     />
                 )}
                 {vis_kolonner_for_vurderingsfrist_aap && (
                     <SorteringHeader
-                        sortering={aapVurderingsfrist}
-                        onClick={sorteringOnClick}
-                        rekkefolge={sorteringsrekkefolge}
-                        erValgt={sorteringsfelt === aapVurderingsfrist}
-                        tekst="Frist vurdering rett AAP"
                         skalVises={erAapYtelse && valgteKolonner.includes(Kolonne.VURDERINGSFRIST_YTELSE)}
-                        className="col col-xs-2"
+                        sortering={aapVurderingsfrist}
+                        erValgt={sorteringsfelt === aapVurderingsfrist}
+                        rekkefolge={sorteringsrekkefolge}
+                        onClick={sorteringOnClick}
+                        tekst="Frist vurdering rett AAP"
                         title="Omtrentlig frist for ny vurdering av AAP"
                         headerId="frist-vurdering-aap"
+                        className="col col-xs-2"
                     />
                 )}
                 <SorteringHeader
-                    sortering={aapVedtakssperiode}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === aapVedtakssperiode}
-                    tekst="Gjenstående uker vedtak AAP"
                     skalVises={erAapYtelse && valgteKolonner.includes(Kolonne.VEDTAKSPERIODE)}
-                    className="col col-xs-2"
+                    sortering={aapVedtakssperiode}
+                    erValgt={sorteringsfelt === aapVedtakssperiode}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Gjenstående uker vedtak AAP"
                     title="Gjenstående uker på gjeldende vedtak AAP"
                     headerId="gjenstaende-uker-vedtak-aap"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={aapRettighetsperiode}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === aapRettighetsperiode}
-                    tekst="Gjenstående uker rettighet AAP"
                     skalVises={erAapYtelse && valgteKolonner.includes(Kolonne.RETTIGHETSPERIODE)}
-                    className="col col-xs-2"
+                    sortering={aapRettighetsperiode}
+                    erValgt={sorteringsfelt === aapRettighetsperiode}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Gjenstående uker rettighet AAP"
                     title="Gjenstående uker av rettighetsperioden for AAP"
                     headerId="rettighetsperiode-gjenstaende"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.VENTER_PA_SVAR_FRA_NAV}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.VENTER_PA_SVAR_FRA_NAV}
-                    tekst="Dato på melding"
                     skalVises={
                         !!ferdigfilterListe?.includes(VENTER_PA_SVAR_FRA_NAV) &&
                         valgteKolonner.includes(Kolonne.VENTER_SVAR)
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.VENTER_PA_SVAR_FRA_NAV}
+                    erValgt={sorteringsfelt === Sorteringsfelt.VENTER_PA_SVAR_FRA_NAV}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Dato på melding"
                     title='Dato på meldingen som er merket "Venter på svar fra NAV"'
                     headerId="venter-pa-svar-fra-nav"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.VENTER_PA_SVAR_FRA_BRUKER}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.VENTER_PA_SVAR_FRA_BRUKER}
-                    tekst="Dato på melding"
                     skalVises={
                         !!ferdigfilterListe?.includes(VENTER_PA_SVAR_FRA_BRUKER) &&
                         valgteKolonner.includes(Kolonne.VENTER_SVAR)
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.VENTER_PA_SVAR_FRA_BRUKER}
+                    erValgt={sorteringsfelt === Sorteringsfelt.VENTER_PA_SVAR_FRA_BRUKER}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Dato på melding"
                     title='Dato på meldingen som er merket "Venter på svar fra bruker"'
                     headerId="venter-pa-svar-fra-bruker"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.UTLOPTE_AKTIVITETER}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTLOPTE_AKTIVITETER}
-                    tekst="Utløpsdato aktivitet"
                     skalVises={
                         !!ferdigfilterListe?.includes(UTLOPTE_AKTIVITETER) &&
                         valgteKolonner.includes(Kolonne.UTLOPTE_AKTIVITETER)
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.UTLOPTE_AKTIVITETER}
+                    erValgt={sorteringsfelt === Sorteringsfelt.UTLOPTE_AKTIVITETER}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Utløpsdato aktivitet"
                     title='Utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
                     headerId="utlopte-aktiviteter"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.I_AVTALT_AKTIVITET}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.I_AVTALT_AKTIVITET}
-                    tekst="Neste utløpsdato aktivitet"
                     skalVises={iAvtaltAktivitet}
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.I_AVTALT_AKTIVITET}
+                    erValgt={sorteringsfelt === Sorteringsfelt.I_AVTALT_AKTIVITET}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Neste utløpsdato aktivitet"
                     title='Neste utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
                     headerId="i-avtalt-aktivitet"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.VALGTE_AKTIVITETER}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.VALGTE_AKTIVITETER}
-                    tekst="Neste utløpsdato valgt aktivitet"
                     skalVises={avansertAktivitet || forenkletAktivitet || tiltaksType}
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.VALGTE_AKTIVITETER}
+                    erValgt={sorteringsfelt === Sorteringsfelt.VALGTE_AKTIVITETER}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Neste utløpsdato valgt aktivitet"
                     title='Neste utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
                     headerId="valgte-aktiviteter"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.MOTER_IDAG}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.MOTER_IDAG}
-                    tekst="Klokkeslett møte"
                     skalVises={!!ferdigfilterListe?.includes(MOTER_IDAG) && valgteKolonner.includes(Kolonne.MOTER_IDAG)}
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.MOTER_IDAG}
+                    erValgt={sorteringsfelt === Sorteringsfelt.MOTER_IDAG}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Klokkeslett møte"
                     title="Tidspunktet møtet starter"
                     headerId="moter-idag"
+                    className="col col-xs-2"
                 />
                 <Header
                     skalVises={
                         !!ferdigfilterListe?.includes(MOTER_IDAG) && valgteKolonner.includes(Kolonne.MOTER_VARIGHET)
                     }
-                    className="col col-xs-2"
                     title="Varighet på møtet"
                     headerId="varighet-mote"
+                    className="col col-xs-2"
                 >
                     Varighet møte
                 </Header>
                 <SorteringHeader
-                    sortering={Sorteringsfelt.MOTESTATUS}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.MOTESTATUS}
                     skalVises={
                         !!ferdigfilterListe?.includes(MOTER_IDAG) && valgteKolonner.includes(Kolonne.MOTE_ER_AVTALT)
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.MOTESTATUS}
+                    erValgt={sorteringsfelt === Sorteringsfelt.MOTESTATUS}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     title="Møtestatus"
                     tekst="Avtalt med NAV"
                     headerId="avtalt-mote"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.UTKAST_14A_STATUS}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS}
                     skalVises={
                         !!ferdigfilterListe?.includes(UNDER_VURDERING) && valgteKolonner.includes(Kolonne.VEDTAKSTATUS)
                     }
+                    sortering={Sorteringsfelt.UTKAST_14A_STATUS}
+                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     tekst="Status § 14a-vedtak"
-                    className="col col-xs-2"
                     title="Status oppfølgingvedtak"
                     headerId="vedtakstatus"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
-                    tekst="Statusendring"
                     skalVises={
                         !!ferdigfilterListe?.includes(UNDER_VURDERING) &&
                         valgteKolonner.includes(Kolonne.VEDTAKSTATUS_ENDRET)
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
+                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Statusendring"
                     title="Dager siden fikk status"
                     headerId="vedtakstatus-endret"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
-                    tekst="Ansvarlig for vedtak"
                     skalVises={
                         !!ferdigfilterListe?.includes(UNDER_VURDERING) &&
                         valgteKolonner.includes(Kolonne.ANSVARLIG_VEILEDER_FOR_VEDTAK)
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
+                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Ansvarlig for vedtak"
                     title="Ansvarlig veileder for vedtak"
                     headerId="vedtakstatus-endret"
+                    className="col col-xs-2"
                 />
                 <Header
                     skalVises={!!filtervalg.sisteEndringKategori && valgteKolonner.includes(Kolonne.SISTE_ENDRING)}
-                    className="col col-xs-2"
                     title="Siste endring"
                     headerId="siste-endring"
+                    className="col col-xs-2"
                 >
                     Siste endring
                 </Header>
                 <SorteringHeader
-                    sortering={Sorteringsfelt.SISTE_ENDRING_DATO}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.SISTE_ENDRING_DATO}
-                    tekst="Dato siste endring"
                     skalVises={!!filtervalg.sisteEndringKategori && valgteKolonner.includes(Kolonne.SISTE_ENDRING_DATO)}
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.SISTE_ENDRING_DATO}
+                    erValgt={sorteringsfelt === Sorteringsfelt.SISTE_ENDRING_DATO}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Dato siste endring"
                     title="Dato siste endring"
                     headerId="dato-siste-endring"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.CV_SVARFRIST}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.CV_SVARFRIST}
-                    tekst="CV svarfrist"
-                    className="col col-xs-2"
                     skalVises={valgteKolonner.includes(Kolonne.CV_SVARFRIST)}
+                    sortering={Sorteringsfelt.CV_SVARFRIST}
+                    erValgt={sorteringsfelt === Sorteringsfelt.CV_SVARFRIST}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="CV svarfrist"
                     title="Svarfrist for å svare ja til deling av CV"
                     headerId="cv-svarfrist"
+                    className="col col-xs-2"
                 />
                 <Header
                     skalVises={valgteKolonner.includes(Kolonne.AVVIK_14A_VEDTAK)}
-                    className="col col-xs-2"
                     title="Status § 14 a-vedtak"
                     headerId="enhetsoversikt-status-14a-vedtak-kolonne-header"
+                    className="col col-xs-2"
                 >
                     Status § 14 a-vedtak
                 </Header>
@@ -484,104 +484,104 @@ function EnhetListehode({
                         valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_UTLOP_OVERGANGSSTONAD) &&
                         !!filtervalg.ensligeForsorgere.length
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_UTLOPS_YTELSE}
+                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_UTLOPS_YTELSE}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Utløp overgangsstønad"
                     title="Utløpsdato for overgangsstønad"
                     headerId="utlop_overgangsstonad"
-                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_UTLOPS_YTELSE}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_UTLOPS_YTELSE}
-                    tekst="Utløp overgangsstønad"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
                     skalVises={
                         valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_VEDTAKSPERIODE) &&
                         !!filtervalg.ensligeForsorgere.length
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE}
+                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Type vedtaksperiode overgangsstønad"
                     title="Type vedtaksperiode for overgangsstønad"
                     headerId="type_vedtaksperiode"
-                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE}
-                    tekst="Type vedtaksperiode overgangsstønad"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
                     skalVises={
                         valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_AKIVITETSPLIKT) &&
                         !!filtervalg.ensligeForsorgere.length
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_AKTIVITETSPLIKT}
+                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_AKTIVITETSPLIKT}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Om aktivitetsplikt overgangsstønad"
                     title="Om bruker har aktivitetsplikt på overgangsstønad"
                     headerId="om_aktivitetsplikt"
-                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_AKTIVITETSPLIKT}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_AKTIVITETSPLIKT}
-                    tekst="Om aktivitetsplikt overgangsstønad"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
                     skalVises={
                         valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_OM_BARNET) &&
                         !!filtervalg.ensligeForsorgere.length
                     }
-                    className="col col-xs-3"
+                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_OM_BARNET}
+                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_OM_BARNET}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Om barnet"
                     title="Dato når barnet er hhv. 6 mnd/1 år gammelt"
                     headerId="oppfolging"
-                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_OM_BARNET}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_OM_BARNET}
-                    tekst="Om barnet"
+                    className="col col-xs-3"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.BARN_UNDER_18_AAR}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.BARN_UNDER_18_AAR}
-                    tekst="Barn under 18 år"
-                    className="col col-xs-2"
-                    headerId="barn_under_18"
                     skalVises={valgteKolonner.includes(Kolonne.HAR_BARN_UNDER_18)}
+                    sortering={Sorteringsfelt.BARN_UNDER_18_AAR}
+                    erValgt={sorteringsfelt === Sorteringsfelt.BARN_UNDER_18_AAR}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Barn under 18 år"
+                    headerId="barn_under_18"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
-                    tekst="Dato sist endret"
-                    className="col col-xs-2"
-                    headerId="dato-sist-endret-utdanning-og-situasjon"
                     skalVises={valgteKolonner.includes(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET)}
+                    sortering={Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
+                    erValgt={sorteringsfelt === Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Dato sist endret"
+                    headerId="dato-sist-endret-utdanning-og-situasjon"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.TILTAKSHENDELSE_TEKST}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.TILTAKSHENDELSE_TEKST}
-                    tekst="Hendelse på tiltak"
-                    title="Lenke til hendelsen"
-                    className="col col-xs-2"
-                    headerId="tiltakshendelse-lenke"
                     skalVises={
                         !!ferdigfilterListe?.includes(TILTAKSHENDELSER) &&
                         valgteKolonner.includes(Kolonne.TILTAKSHENDELSE_LENKE)
                     }
+                    sortering={Sorteringsfelt.TILTAKSHENDELSE_TEKST}
+                    erValgt={sorteringsfelt === Sorteringsfelt.TILTAKSHENDELSE_TEKST}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Hendelse på tiltak"
+                    title="Lenke til hendelsen"
+                    headerId="tiltakshendelse-lenke"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.TILTAKSHENDELSE_DATO_OPPRETTET}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.TILTAKSHENDELSE_DATO_OPPRETTET}
-                    tekst="Dato for hendelse"
-                    title="Dato da hendelsen ble opprettet"
-                    className="col col-xs-2"
-                    headerId="tiltakshendelse-dato-opprettet"
                     skalVises={
                         !!ferdigfilterListe?.includes(TILTAKSHENDELSER) &&
                         valgteKolonner.includes(Kolonne.TILTAKSHENDELSE_DATO_OPPRETTET)
                     }
+                    sortering={Sorteringsfelt.TILTAKSHENDELSE_DATO_OPPRETTET}
+                    erValgt={sorteringsfelt === Sorteringsfelt.TILTAKSHENDELSE_DATO_OPPRETTET}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Dato for hendelse"
+                    title="Dato da hendelsen ble opprettet"
+                    headerId="tiltakshendelse-dato-opprettet"
+                    className="col col-xs-2"
                 />
             </div>
             <div className="brukerliste__gutter-right" />

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -37,6 +37,7 @@ import {TolkebehovSistOppdatert} from '../components/tabell/headerceller/Tolkebe
 import {BostedKommune} from '../components/tabell/headerceller/BostedKommune';
 import {BostedBydel} from '../components/tabell/headerceller/BostedBydel';
 import {BostedSistOppdatert} from '../components/tabell/headerceller/BostedSistOppdatert';
+import {OppfolgingStartet} from '../components/tabell/headerceller/OppfolgingStartet';
 
 function harValgteAktiviteter(aktiviteter) {
     if (aktiviteter && Object.keys(aktiviteter).length > 0) {
@@ -117,17 +118,8 @@ function EnhetListehode({
                 <Tolkesprak {...sorteringTilHeadercelle} />
                 <TolkebehovSistOppdatert {...sorteringTilHeadercelle} />
 
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.OPPFOLGINGSTARTET)}
-                    sortering={Sorteringsfelt.OPPFOLGINGSTARTET}
-                    erValgt={sorteringsfelt === Sorteringsfelt.OPPFOLGINGSTARTET}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Oppfølging startet"
-                    title="Startdato for pågående oppfølgingsperiode"
-                    headerId="oppfolging-startet"
-                    className="col col-xs-2"
-                />
+                <OppfolgingStartet {...sorteringTilHeadercelle} />
+
                 <Header
                     skalVises={valgteKolonner.includes(Kolonne.VEILEDER)}
                     headerId="veileder"

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -34,8 +34,8 @@ import {StatsborgerskapGyldigFra} from '../components/tabell/headerceller/Statsb
 import {Tolkebehov} from '../components/tabell/headerceller/Tolkebehov';
 import {Tolkesprak} from '../components/tabell/headerceller/Tolkesprak';
 import {TolkebehovSistOppdatert} from '../components/tabell/headerceller/TolkebehovSistOppdatert';
-import {BostedKommune} from '../components/tabell/headerceller/BostedKommune';
-import {BostedBydel} from '../components/tabell/headerceller/BostedBydel';
+import {Bosted} from '../components/tabell/headerceller/Bosted';
+import {BostedDetaljer} from '../components/tabell/headerceller/BostedDetaljer';
 import {BostedSistOppdatert} from '../components/tabell/headerceller/BostedSistOppdatert';
 import {OppfolgingStartet} from '../components/tabell/headerceller/OppfolgingStartet';
 import {SvarfristCv} from '../components/tabell/headerceller/SvarfristCv';
@@ -114,8 +114,8 @@ function EnhetListehode({
                 <Statsborgerskap {...sorteringTilHeadercelle} />
                 <StatsborgerskapGyldigFra {...sorteringTilHeadercelle} />
 
-                <BostedKommune {...sorteringTilHeadercelle} />
-                <BostedBydel {...sorteringTilHeadercelle} />
+                <Bosted {...sorteringTilHeadercelle} />
+                <BostedDetaljer {...sorteringTilHeadercelle} />
                 <BostedSistOppdatert {...sorteringTilHeadercelle} />
 
                 <Tolkebehov {...sorteringTilHeadercelle} />
@@ -312,8 +312,8 @@ function EnhetListehode({
                     erValgt={sorteringsfelt === Sorteringsfelt.MOTESTATUS}
                     rekkefolge={sorteringsrekkefolge}
                     onClick={sorteringOnClick}
-                    title="Møtestatus"
                     tekst="Avtalt med NAV"
+                    title="Møtestatus"
                     headerId="avtalt-mote"
                     className="col col-xs-2"
                 />
@@ -359,21 +359,23 @@ function EnhetListehode({
                     className="col col-xs-2"
                 />
                 <Header
+                    // Dette er siste endring frå under "Hendelser", i aktiviteter personen sjølv har oppretta.
                     skalVises={!!filtervalg.sisteEndringKategori && valgteKolonner.includes(Kolonne.SISTE_ENDRING)}
-                    title="Siste endring"
+                    title="Personens siste endring av aktiviteter/mål"
                     headerId="siste-endring"
                     className="col col-xs-2"
                 >
                     Siste endring
                 </Header>
                 <SorteringHeader
+                    // Dette er siste endring frå under "Hendelser", i aktiviteter personen sjølv har oppretta.
                     skalVises={!!filtervalg.sisteEndringKategori && valgteKolonner.includes(Kolonne.SISTE_ENDRING_DATO)}
                     sortering={Sorteringsfelt.SISTE_ENDRING_DATO}
                     erValgt={sorteringsfelt === Sorteringsfelt.SISTE_ENDRING_DATO}
                     rekkefolge={sorteringsrekkefolge}
                     onClick={sorteringOnClick}
                     tekst="Dato siste endring"
-                    title="Dato siste endring"
+                    title="Dato personen sist gjorde endring i aktiviteter/mål"
                     headerId="dato-siste-endring"
                     className="col col-xs-2"
                 />

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -27,6 +27,16 @@ import {OrNothing} from '../utils/types/types';
 import {useFeatureSelector} from '../hooks/redux/use-feature-selector';
 import {VIS_AAP_VURDERINGSFRISTKOLONNER} from '../konstanter';
 import {Navn} from '../components/tabell/headerceller/Navn';
+import {Fnr} from '../components/tabell/headerceller/Fnr';
+import {Fodeland} from '../components/tabell/headerceller/Fodeland';
+import {Statsborgerskap} from '../components/tabell/headerceller/Statsborgerskap';
+import {StatsborgerskapGyldigFra} from '../components/tabell/headerceller/StatsborgerskapGyldigFra';
+import {Tolkebehov} from '../components/tabell/headerceller/Tolkebehov';
+import {Tolkesprak} from '../components/tabell/headerceller/Tolkesprak';
+import {TolkebehovSistOppdatert} from '../components/tabell/headerceller/TolkebehovSistOppdatert';
+import {BostedKommune} from '../components/tabell/headerceller/BostedKommune';
+import {BostedBydel} from '../components/tabell/headerceller/BostedBydel';
+import {BostedSistOppdatert} from '../components/tabell/headerceller/BostedSistOppdatert';
 
 function harValgteAktiviteter(aktiviteter) {
     if (aktiviteter && Object.keys(aktiviteter).length > 0) {
@@ -93,109 +103,20 @@ function EnhetListehode({
             <VelgalleCheckboks />
             <div className="brukerliste__innhold" data-testid="brukerliste_innhold">
                 <Navn {...sorteringTilHeadercelle} />
-                <SorteringHeader
-                    sortering={Sorteringsfelt.FODSELSNUMMER}
-                    erValgt={sorteringsfelt === Sorteringsfelt.FODSELSNUMMER}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Fødselsnr."
-                    title="Fødselsnummer"
-                    headerId="fnr"
-                    className="col col-xs-2-5"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.FODELAND)}
-                    sortering={Sorteringsfelt.FODELAND}
-                    erValgt={sorteringsfelt === Sorteringsfelt.FODELAND}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Fødeland"
-                    title="Fødeland"
-                    headerId="fodeland"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.STATSBORGERSKAP)}
-                    sortering={Sorteringsfelt.STATSBORGERSKAP}
-                    erValgt={sorteringsfelt === Sorteringsfelt.STATSBORGERSKAP}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Statsborgerskap"
-                    title="Statsborgerskap"
-                    headerId="statsborgerskap"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.STATSBORGERSKAP_GYLDIG_FRA)}
-                    sortering={Sorteringsfelt.STATSBORGERSKAP_GYLDIG_FRA}
-                    erValgt={sorteringsfelt === Sorteringsfelt.STATSBORGERSKAP_GYLDIG_FRA}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Gyldig fra"
-                    title="Statsborgerskap gyldig fra"
-                    headerId="statsborgerskap_gyldig_fra"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.BOSTED_KOMMUNE)}
-                    sortering={Sorteringsfelt.BOSTED_KOMMUNE}
-                    erValgt={sorteringsfelt === Sorteringsfelt.BOSTED_KOMMUNE}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Bosted"
-                    headerId="bosted_kommune"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.BOSTED_BYDEL)}
-                    sortering={Sorteringsfelt.BOSTED_BYDEL}
-                    erValgt={sorteringsfelt === Sorteringsfelt.BOSTED_BYDEL}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Bosted detaljer"
-                    headerId="bosted_bydel"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.BOSTED_SIST_OPPDATERT)}
-                    sortering={Sorteringsfelt.BOSTED_SIST_OPPDATERT}
-                    erValgt={sorteringsfelt === Sorteringsfelt.BOSTED_SIST_OPPDATERT}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Bosted sist oppdatert"
-                    headerId="bosted_sist_oppdatert"
-                    className="col col-xs-2"
-                />
-                <Header
-                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV)}
-                    title="Tolkebehov"
-                    headerId="tolkebehov"
-                    className="col col-xs-2"
-                >
-                    Tolkebehov
-                </Header>
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SPRAAK)}
-                    sortering={Sorteringsfelt.TOLKE_SPRAAK}
-                    erValgt={sorteringsfelt === Sorteringsfelt.TOLKE_SPRAAK}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    title="Tolk behov språk"
-                    tekst="Språk"
-                    headerId="tolkespraak"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SIST_OPPDATERT)}
-                    sortering={Sorteringsfelt.TOLKEBEHOV_SIST_OPPDATERT}
-                    erValgt={sorteringsfelt === Sorteringsfelt.TOLKEBEHOV_SIST_OPPDATERT}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Sist oppdatert"
-                    title="Tolkebehov sist oppdatert"
-                    headerId="tolkbehovsistoppdatert"
-                    className="col col-xs-2"
-                />
+                <Fnr {...sorteringTilHeadercelle} />
+
+                <Fodeland {...sorteringTilHeadercelle} />
+                <Statsborgerskap {...sorteringTilHeadercelle} />
+                <StatsborgerskapGyldigFra {...sorteringTilHeadercelle} />
+
+                <BostedKommune {...sorteringTilHeadercelle} />
+                <BostedBydel {...sorteringTilHeadercelle} />
+                <BostedSistOppdatert {...sorteringTilHeadercelle} />
+
+                <Tolkebehov {...sorteringTilHeadercelle} />
+                <Tolkesprak {...sorteringTilHeadercelle} />
+                <TolkebehovSistOppdatert {...sorteringTilHeadercelle} />
+
                 <SorteringHeader
                     skalVises={valgteKolonner.includes(Kolonne.OPPFOLGINGSTARTET)}
                     sortering={Sorteringsfelt.OPPFOLGINGSTARTET}

--- a/src/minoversikt/minoversikt-kolonner.tsx
+++ b/src/minoversikt/minoversikt-kolonner.tsx
@@ -167,7 +167,7 @@ function MinoversiktDatokolonner({bruker, enhetId, filtervalg, valgteKolonner}: 
             <TekstKolonne
                 className="col col-xs-2"
                 tekst={tolkBehovSpraak(filtervalg, bruker, tolkbehovSpraakData)}
-                skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SPRAAK)}
+                skalVises={valgteKolonner.includes(Kolonne.TOLKESPRAK)}
             />
             <TekstKolonne
                 className="col col-xs-2"

--- a/src/minoversikt/minoversikt-kolonner.tsx
+++ b/src/minoversikt/minoversikt-kolonner.tsx
@@ -191,7 +191,7 @@ function MinoversiktDatokolonner({bruker, enhetId, filtervalg, valgteKolonner}: 
             />
             <DatoKolonne
                 className="col col-xs-2"
-                skalVises={valgteKolonner.includes(Kolonne.OPPFOLGINGSTARTET)}
+                skalVises={valgteKolonner.includes(Kolonne.OPPFOLGING_STARTET)}
                 dato={oppfolgingStartetDato(bruker.oppfolgingStartdato)}
             />
             <DatoKolonne

--- a/src/minoversikt/minoversikt-kolonner.tsx
+++ b/src/minoversikt/minoversikt-kolonner.tsx
@@ -421,7 +421,7 @@ function MinoversiktDatokolonner({bruker, enhetId, filtervalg, valgteKolonner}: 
             />
             <TekstKolonne
                 className="col col-xs-2"
-                skalVises={valgteKolonner.includes(Kolonne.HAR_BARN_UNDER_18)}
+                skalVises={valgteKolonner.includes(Kolonne.BARN_UNDER_18_AAR)}
                 tekst={bruker.barnUnder18AarData ? brukerBarnUnder18AarInfo(bruker.barnUnder18AarData) : '-'}
             />
             <DatoKolonne

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -30,6 +30,7 @@ import {ReactComponent as ArbeidslisteikonBla} from '../components/ikoner/arbeid
 import {ReactComponent as FargekategoriIkonTomtBokmerke} from '../components/ikoner/fargekategorier/Fargekategoriikon_bokmerke.svg';
 import {ReactComponent as HuskelappIkon} from '../components/ikoner/huskelapp/Huskelappikon.svg';
 import './minoversikt.css';
+import {Navn} from '../components/tabell/headerceller/Navn';
 
 function harValgteAktiviteter(aktiviteter) {
     if (aktiviteter && Object.keys(aktiviteter).length > 0) {
@@ -85,6 +86,13 @@ function MinOversiktListeHode({
     const tiltaksType =
         harValgteAktiviteter(filtervalg.tiltakstyper) && valgteKolonner.includes(Kolonne.UTLOP_AKTIVITET);
 
+    const sorteringTilHeadercelle = {
+        gjeldendeSorteringsfelt: sorteringsfelt,
+        valgteKolonner: valgteKolonner,
+        rekkefolge: sorteringsrekkefolge,
+        onClick: sorteringOnClick
+    };
+
     return (
         <div className="brukerliste__header brukerliste__sorteringheader">
             <VelgalleCheckboks />
@@ -124,16 +132,7 @@ function MinOversiktListeHode({
                 </div>
             )}
             <div className="brukerliste__innhold" data-testid="brukerliste_innhold">
-                <SorteringHeader
-                    className="col col-xs-2"
-                    sortering={Sorteringsfelt.ETTERNAVN}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ETTERNAVN}
-                    tekst="Etternavn"
-                    title="Etternavn"
-                    headerId="etternavn"
-                />
+                <Navn {...sorteringTilHeadercelle} />
                 <SorteringHeader
                     className="col col-xs-2-5"
                     sortering={Sorteringsfelt.FODSELSNUMMER}

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -38,8 +38,8 @@ import {StatsborgerskapGyldigFra} from '../components/tabell/headerceller/Statsb
 import {Tolkebehov} from '../components/tabell/headerceller/Tolkebehov';
 import {Tolkesprak} from '../components/tabell/headerceller/Tolkesprak';
 import {TolkebehovSistOppdatert} from '../components/tabell/headerceller/TolkebehovSistOppdatert';
-import {BostedKommune} from '../components/tabell/headerceller/BostedKommune';
-import {BostedBydel} from '../components/tabell/headerceller/BostedBydel';
+import {Bosted} from '../components/tabell/headerceller/Bosted';
+import {BostedDetaljer} from '../components/tabell/headerceller/BostedDetaljer';
 import {BostedSistOppdatert} from '../components/tabell/headerceller/BostedSistOppdatert';
 import {OppfolgingStartet} from '../components/tabell/headerceller/OppfolgingStartet';
 import {SvarfristCv} from '../components/tabell/headerceller/SvarfristCv';
@@ -113,36 +113,36 @@ function MinOversiktListeHode({
     return (
         <div className="brukerliste__header brukerliste__sorteringheader">
             <VelgalleCheckboks />
-                {!vis_kolonner_for_huskelapp && (
-                    <SorteringHeader
-                        sortering={Sorteringsfelt.ARBEIDSLISTEKATEGORI}
-                        erValgt={sorteringsfelt === Sorteringsfelt.ARBEIDSLISTEKATEGORI}
+            {!vis_kolonner_for_huskelapp && (
+                <SorteringHeader
+                    sortering={Sorteringsfelt.ARBEIDSLISTEKATEGORI}
+                    erValgt={sorteringsfelt === Sorteringsfelt.ARBEIDSLISTEKATEGORI}
                     rekkefolge={sorteringsrekkefolge}
                     onClick={sorteringOnClick}
-                        tekst={<ArbeidslisteikonBla id="arbeidslisteikon__listehode" />}
-                        title="Sorter på farge"
-                        headerId="arbeidslistekategori"
-                        className="arbeidslistekategori__sorteringsheader"
-                    />
-                )}
-                {vis_kolonner_for_huskelapp && (
-                    <div className="brukerliste__minoversikt-ikonknapper">
-                        <SorteringHeaderIkon
-                            ikon={<FargekategoriIkonTomtBokmerke aria-hidden />}
-                            sortering={Sorteringsfelt.FARGEKATEGORI}
-                            erValgt={sorteringsfelt === Sorteringsfelt.FARGEKATEGORI}
-                            rekkefolge={sorteringsrekkefolge}
-                            onClick={sorteringOnClick}
-                            title="Fargekategori-sortering"
-                            headerId="fargekategori"
+                    tekst={<ArbeidslisteikonBla id="arbeidslisteikon__listehode" />}
+                    title="Sorter på farge"
+                    headerId="arbeidslistekategori"
+                    className="arbeidslistekategori__sorteringsheader"
+                />
+            )}
+            {vis_kolonner_for_huskelapp && (
+                <div className="brukerliste__minoversikt-ikonknapper">
+                    <SorteringHeaderIkon
+                        ikon={<FargekategoriIkonTomtBokmerke aria-hidden />}
+                        sortering={Sorteringsfelt.FARGEKATEGORI}
+                        erValgt={sorteringsfelt === Sorteringsfelt.FARGEKATEGORI}
+                        rekkefolge={sorteringsrekkefolge}
+                        onClick={sorteringOnClick}
+                        title="Fargekategori-sortering"
+                        headerId="fargekategori"
                     />
                     <SorteringHeaderIkon
                         ikon={<HuskelappIkon aria-hidden />}
                         sortering={Sorteringsfelt.HUSKELAPP}
-                            erValgt={sorteringsfelt === Sorteringsfelt.HUSKELAPP}
-                            rekkefolge={sorteringsrekkefolge}
-                            onClick={sorteringOnClick}
-                            title="Huskelapp-sortering"
+                        erValgt={sorteringsfelt === Sorteringsfelt.HUSKELAPP}
+                        rekkefolge={sorteringsrekkefolge}
+                        onClick={sorteringOnClick}
+                        title="Huskelapp-sortering"
                         headerId="huskelapp"
                         className="huskelapp__sorteringsheader"
                     />
@@ -160,8 +160,8 @@ function MinOversiktListeHode({
                 <Tolkesprak {...sorteringTilHeadercelle} />
                 <TolkebehovSistOppdatert {...sorteringTilHeadercelle} />
 
-                <BostedKommune {...sorteringTilHeadercelle} />
-                <BostedBydel {...sorteringTilHeadercelle} />
+                <Bosted {...sorteringTilHeadercelle} />
+                <BostedDetaljer {...sorteringTilHeadercelle} />
                 <BostedSistOppdatert {...sorteringTilHeadercelle} />
 
                 <OppfolgingStartet {...sorteringTilHeadercelle} />
@@ -344,8 +344,8 @@ function MinOversiktListeHode({
                     erValgt={sorteringsfelt === Sorteringsfelt.MOTESTATUS}
                     rekkefolge={sorteringsrekkefolge}
                     onClick={sorteringOnClick}
-                    title="Møtestatus"
                     tekst="Avtalt med NAV"
+                    title="Møtestatus"
                     headerId="avtalt-mote"
                     className="col col-xs-2"
                 />
@@ -458,20 +458,22 @@ function MinOversiktListeHode({
                     className="col col-xs-2"
                 />
                 <Header
+                    // Dette er siste endring frå under "Hendelser", i aktiviteter personen sjølv har oppretta.
                     skalVises={!!filtervalg.sisteEndringKategori && valgteKolonner.includes(Kolonne.SISTE_ENDRING)}
-                    title="Siste endring"
+                    title="Personens siste endring av aktiviteter/mål"
                     headerId="siste-endring"
                     className="col col-xs-2"
                 >
                     Siste endring
                 </Header>
                 <SorteringHeader
+                    // Dette er siste endring frå under "Hendelser", i aktiviteter personen sjølv har oppretta.
                     skalVises={!!filtervalg.sisteEndringKategori && valgteKolonner.includes(Kolonne.SISTE_ENDRING_DATO)}
                     sortering={Sorteringsfelt.SISTE_ENDRING_DATO}
                     erValgt={sorteringsfelt === Sorteringsfelt.SISTE_ENDRING_DATO}
                     rekkefolge={sorteringsrekkefolge}
                     onClick={sorteringOnClick}
-                    tekst="Dato siste endring"
+                    tekst="Dato personen sist gjorde endring i aktiviteter/mål"
                     title="Dato siste endring"
                     headerId="dato-siste-endring"
                     className="col col-xs-2"

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -31,6 +31,16 @@ import {ReactComponent as FargekategoriIkonTomtBokmerke} from '../components/iko
 import {ReactComponent as HuskelappIkon} from '../components/ikoner/huskelapp/Huskelappikon.svg';
 import './minoversikt.css';
 import {Navn} from '../components/tabell/headerceller/Navn';
+import {Fnr} from '../components/tabell/headerceller/Fnr';
+import {Fodeland} from '../components/tabell/headerceller/Fodeland';
+import {Statsborgerskap} from '../components/tabell/headerceller/Statsborgerskap';
+import {StatsborgerskapGyldigFra} from '../components/tabell/headerceller/StatsborgerskapGyldigFra';
+import {Tolkebehov} from '../components/tabell/headerceller/Tolkebehov';
+import {Tolkesprak} from '../components/tabell/headerceller/Tolkesprak';
+import {TolkebehovSistOppdatert} from '../components/tabell/headerceller/TolkebehovSistOppdatert';
+import {BostedKommune} from '../components/tabell/headerceller/BostedKommune';
+import {BostedBydel} from '../components/tabell/headerceller/BostedBydel';
+import {BostedSistOppdatert} from '../components/tabell/headerceller/BostedSistOppdatert';
 
 function harValgteAktiviteter(aktiviteter) {
     if (aktiviteter && Object.keys(aktiviteter).length > 0) {
@@ -133,112 +143,19 @@ function MinOversiktListeHode({
             )}
             <div className="brukerliste__innhold" data-testid="brukerliste_innhold">
                 <Navn {...sorteringTilHeadercelle} />
-                <SorteringHeader
-                    sortering={Sorteringsfelt.FODSELSNUMMER}
-                    erValgt={sorteringsfelt === Sorteringsfelt.FODSELSNUMMER}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Fødselsnr."
-                    title="Fødselsnummer"
-                    headerId="fnr"
-                    className="col col-xs-2-5"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.FODELAND)}
-                    sortering={Sorteringsfelt.FODELAND}
-                    erValgt={sorteringsfelt === Sorteringsfelt.FODELAND}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Fødeland"
-                    title="Fødeland"
-                    headerId="fodeland"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.STATSBORGERSKAP)}
-                    sortering={Sorteringsfelt.STATSBORGERSKAP}
-                    erValgt={sorteringsfelt === Sorteringsfelt.STATSBORGERSKAP}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Statsborgerskap"
-                    title="Statsborgerskap"
-                    headerId="statsborgerskap"
-                    className="col col-xs-2"
-                />
+                <Fnr {...sorteringTilHeadercelle} />
 
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.STATSBORGERSKAP_GYLDIG_FRA)}
-                    sortering={Sorteringsfelt.STATSBORGERSKAP_GYLDIG_FRA}
-                    erValgt={sorteringsfelt === Sorteringsfelt.STATSBORGERSKAP_GYLDIG_FRA}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Gyldig fra"
-                    title="Statsborgerskap gyldig fra"
-                    headerId="statsborgerskap_gyldig_fra"
-                    className="col col-xs-2"
-                />
+                <Fodeland {...sorteringTilHeadercelle} />
+                <Statsborgerskap {...sorteringTilHeadercelle} />
+                <StatsborgerskapGyldigFra {...sorteringTilHeadercelle} />
 
-                <Header
-                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV)}
-                    title="Tolkebehov"
-                    headerId="tolkebehov"
-                    className="col col-xs-2"
-                >
-                    Tolkebehov
-                </Header>
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SPRAAK)}
-                    sortering={Sorteringsfelt.TOLKE_SPRAAK}
-                    erValgt={sorteringsfelt === Sorteringsfelt.TOLKE_SPRAAK}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    title="Tolk behov språk"
-                    tekst="Språk"
-                    headerId="tolkespraak"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SIST_OPPDATERT)}
-                    sortering={Sorteringsfelt.TOLKEBEHOV_SIST_OPPDATERT}
-                    erValgt={sorteringsfelt === Sorteringsfelt.TOLKEBEHOV_SIST_OPPDATERT}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Sist oppdatert"
-                    title="Tolkebehov sist oppdatert"
-                    headerId="tolkbehovsistoppdatert"
-                    className="col col-xs-2"
-                />
+                <Tolkebehov {...sorteringTilHeadercelle} />
+                <Tolkesprak {...sorteringTilHeadercelle} />
+                <TolkebehovSistOppdatert {...sorteringTilHeadercelle} />
 
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.BOSTED_KOMMUNE)}
-                    sortering={Sorteringsfelt.BOSTED_KOMMUNE}
-                    erValgt={sorteringsfelt === Sorteringsfelt.BOSTED_KOMMUNE}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Bosted"
-                    headerId="bosted_kommune"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.BOSTED_BYDEL)}
-                    sortering={Sorteringsfelt.BOSTED_BYDEL}
-                    erValgt={sorteringsfelt === Sorteringsfelt.BOSTED_BYDEL}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Bosted detaljer"
-                    headerId="bosted_bydel"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.BOSTED_SIST_OPPDATERT)}
-                    sortering={Sorteringsfelt.BOSTED_SIST_OPPDATERT}
-                    erValgt={sorteringsfelt === Sorteringsfelt.BOSTED_SIST_OPPDATERT}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Bosted sist oppdatert"
-                    headerId="bosted_sist_oppdatert"
-                    className="col col-xs-2"
-                />
+                <BostedKommune {...sorteringTilHeadercelle} />
+                <BostedBydel {...sorteringTilHeadercelle} />
+                <BostedSistOppdatert {...sorteringTilHeadercelle} />
 
                 <SorteringHeader
                     skalVises={valgteKolonner.includes(Kolonne.OPPFOLGINGSTARTET)}

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -45,6 +45,9 @@ import {OppfolgingStartet} from '../components/tabell/headerceller/OppfolgingSta
 import {SvarfristCv} from '../components/tabell/headerceller/SvarfristCv';
 import {Status14AVedtak} from '../components/tabell/headerceller/Status14AVedtak';
 import {BarnUnder18Aar} from '../components/tabell/headerceller/BarnUnder18Ar';
+import {UtdanningOgSituasjonSistEndret} from '../components/tabell/headerceller/UtdanningOgSituasjonSistEndret';
+import {HuskelappKommentar} from '../components/tabell/headerceller/HuskelappKommentar';
+import {HuskelappFrist} from '../components/tabell/headerceller/HuskelappFrist';
 
 function harValgteAktiviteter(aktiviteter) {
     if (aktiviteter && Object.keys(aktiviteter).length > 0) {
@@ -535,36 +538,11 @@ function MinOversiktListeHode({
                 />
                 <BarnUnder18Aar {...sorteringTilHeadercelle} />
 
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET)}
-                    sortering={Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Dato sist endret"
-                    headerId="dato-sist-endret-utdanning-situasjon"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.HUSKELAPP_KOMMENTAR)}
-                    sortering={Sorteringsfelt.HUSKELAPP_KOMMENTAR}
-                    erValgt={sorteringsfelt === Sorteringsfelt.HUSKELAPP_KOMMENTAR}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Huskelapp"
-                    headerId="huskelapp"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.HUSKELAPP_FRIST)}
-                    sortering={Sorteringsfelt.HUSKELAPP_FRIST}
-                    erValgt={sorteringsfelt === Sorteringsfelt.HUSKELAPP_FRIST}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Frist huskelapp"
-                    headerId="huskelapp-frist"
-                    className="col col-xs-2"
-                />
+                <UtdanningOgSituasjonSistEndret {...sorteringTilHeadercelle} />
+
+                <HuskelappKommentar {...sorteringTilHeadercelle} />
+                <HuskelappFrist {...sorteringTilHeadercelle} />
+
                 <SorteringHeader
                     skalVises={
                         !!ferdigfilterListe?.includes(TILTAKSHENDELSER) &&

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -41,6 +41,7 @@ import {TolkebehovSistOppdatert} from '../components/tabell/headerceller/Tolkebe
 import {BostedKommune} from '../components/tabell/headerceller/BostedKommune';
 import {BostedBydel} from '../components/tabell/headerceller/BostedBydel';
 import {BostedSistOppdatert} from '../components/tabell/headerceller/BostedSistOppdatert';
+import {OppfolgingStartet} from '../components/tabell/headerceller/OppfolgingStartet';
 
 function harValgteAktiviteter(aktiviteter) {
     if (aktiviteter && Object.keys(aktiviteter).length > 0) {
@@ -157,17 +158,8 @@ function MinOversiktListeHode({
                 <BostedBydel {...sorteringTilHeadercelle} />
                 <BostedSistOppdatert {...sorteringTilHeadercelle} />
 
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.OPPFOLGINGSTARTET)}
-                    sortering={Sorteringsfelt.OPPFOLGINGSTARTET}
-                    erValgt={sorteringsfelt === Sorteringsfelt.OPPFOLGINGSTARTET}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Oppfølging startet"
-                    title="Startdato for pågående oppfølgingsperiode"
-                    headerId="oppfolgingstartet"
-                    className="col col-xs-2"
-                />
+                <OppfolgingStartet {...sorteringTilHeadercelle} />
+
                 <SorteringHeader
                     skalVises={
                         !!ferdigfilterListe?.includes(MIN_ARBEIDSLISTE) &&

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -96,487 +96,487 @@ function MinOversiktListeHode({
     return (
         <div className="brukerliste__header brukerliste__sorteringheader">
             <VelgalleCheckboks />
-            {!vis_kolonner_for_huskelapp && (
-                <SorteringHeader
-                    className="arbeidslistekategori__sorteringsheader"
-                    sortering={Sorteringsfelt.ARBEIDSLISTEKATEGORI}
-                    onClick={sorteringOnClick}
+                {!vis_kolonner_for_huskelapp && (
+                    <SorteringHeader
+                        sortering={Sorteringsfelt.ARBEIDSLISTEKATEGORI}
+                        erValgt={sorteringsfelt === Sorteringsfelt.ARBEIDSLISTEKATEGORI}
                     rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ARBEIDSLISTEKATEGORI}
-                    tekst={<ArbeidslisteikonBla id="arbeidslisteikon__listehode" />}
-                    title="Sorter på farge"
-                    headerId="arbeidslistekategori"
-                />
-            )}
-            {vis_kolonner_for_huskelapp && (
-                <div className="brukerliste__minoversikt-ikonknapper">
-                    <SorteringHeaderIkon
-                        ikon={<FargekategoriIkonTomtBokmerke aria-hidden />}
-                        erValgt={sorteringsfelt === Sorteringsfelt.FARGEKATEGORI}
-                        sortering={Sorteringsfelt.FARGEKATEGORI}
-                        rekkefolge={sorteringsrekkefolge}
-                        onClick={sorteringOnClick}
-                        headerId="fargekategori"
-                        title="Fargekategori-sortering"
+                    onClick={sorteringOnClick}
+                        tekst={<ArbeidslisteikonBla id="arbeidslisteikon__listehode" />}
+                        title="Sorter på farge"
+                        headerId="arbeidslistekategori"
+                        className="arbeidslistekategori__sorteringsheader"
+                    />
+                )}
+                {vis_kolonner_for_huskelapp && (
+                    <div className="brukerliste__minoversikt-ikonknapper">
+                        <SorteringHeaderIkon
+                            ikon={<FargekategoriIkonTomtBokmerke aria-hidden />}
+                            sortering={Sorteringsfelt.FARGEKATEGORI}
+                            erValgt={sorteringsfelt === Sorteringsfelt.FARGEKATEGORI}
+                            rekkefolge={sorteringsrekkefolge}
+                            onClick={sorteringOnClick}
+                            title="Fargekategori-sortering"
+                            headerId="fargekategori"
                     />
                     <SorteringHeaderIkon
                         ikon={<HuskelappIkon aria-hidden />}
-                        erValgt={sorteringsfelt === Sorteringsfelt.HUSKELAPP}
                         sortering={Sorteringsfelt.HUSKELAPP}
-                        rekkefolge={sorteringsrekkefolge}
-                        onClick={sorteringOnClick}
-                        className="huskelapp__sorteringsheader"
+                            erValgt={sorteringsfelt === Sorteringsfelt.HUSKELAPP}
+                            rekkefolge={sorteringsrekkefolge}
+                            onClick={sorteringOnClick}
+                            title="Huskelapp-sortering"
                         headerId="huskelapp"
-                        title="Huskelapp-sortering"
+                        className="huskelapp__sorteringsheader"
                     />
                 </div>
             )}
             <div className="brukerliste__innhold" data-testid="brukerliste_innhold">
                 <Navn {...sorteringTilHeadercelle} />
                 <SorteringHeader
-                    className="col col-xs-2-5"
                     sortering={Sorteringsfelt.FODSELSNUMMER}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
                     erValgt={sorteringsfelt === Sorteringsfelt.FODSELSNUMMER}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     tekst="Fødselsnr."
                     title="Fødselsnummer"
                     headerId="fnr"
+                    className="col col-xs-2-5"
                 />
                 <SorteringHeader
+                    skalVises={valgteKolonner.includes(Kolonne.FODELAND)}
                     sortering={Sorteringsfelt.FODELAND}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
                     erValgt={sorteringsfelt === Sorteringsfelt.FODELAND}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     tekst="Fødeland"
-                    className="col col-xs-2"
                     title="Fødeland"
                     headerId="fodeland"
-                    skalVises={valgteKolonner.includes(Kolonne.FODELAND)}
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
+                    skalVises={valgteKolonner.includes(Kolonne.STATSBORGERSKAP)}
                     sortering={Sorteringsfelt.STATSBORGERSKAP}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
                     erValgt={sorteringsfelt === Sorteringsfelt.STATSBORGERSKAP}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     tekst="Statsborgerskap"
-                    className="col col-xs-2"
                     title="Statsborgerskap"
                     headerId="statsborgerskap"
-                    skalVises={valgteKolonner.includes(Kolonne.STATSBORGERSKAP)}
+                    className="col col-xs-2"
                 />
 
                 <SorteringHeader
+                    skalVises={valgteKolonner.includes(Kolonne.STATSBORGERSKAP_GYLDIG_FRA)}
                     sortering={Sorteringsfelt.STATSBORGERSKAP_GYLDIG_FRA}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
                     erValgt={sorteringsfelt === Sorteringsfelt.STATSBORGERSKAP_GYLDIG_FRA}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     tekst="Gyldig fra"
-                    className="col col-xs-2"
                     title="Statsborgerskap gyldig fra"
                     headerId="statsborgerskap_gyldig_fra"
-                    skalVises={valgteKolonner.includes(Kolonne.STATSBORGERSKAP_GYLDIG_FRA)}
+                    className="col col-xs-2"
                 />
 
                 <Header
-                    className="col col-xs-2"
+                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV)}
                     title="Tolkebehov"
                     headerId="tolkebehov"
-                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV)}
+                    className="col col-xs-2"
                 >
                     Tolkebehov
                 </Header>
                 <SorteringHeader
+                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SPRAAK)}
                     sortering={Sorteringsfelt.TOLKE_SPRAAK}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
                     erValgt={sorteringsfelt === Sorteringsfelt.TOLKE_SPRAAK}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     title="Tolk behov språk"
-                    className="col col-xs-2"
                     tekst="Språk"
                     headerId="tolkespraak"
-                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SPRAAK)}
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
+                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SIST_OPPDATERT)}
                     sortering={Sorteringsfelt.TOLKEBEHOV_SIST_OPPDATERT}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
                     erValgt={sorteringsfelt === Sorteringsfelt.TOLKEBEHOV_SIST_OPPDATERT}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     tekst="Sist oppdatert"
-                    className="col col-xs-2"
                     title="Tolkebehov sist oppdatert"
                     headerId="tolkbehovsistoppdatert"
-                    skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SIST_OPPDATERT)}
+                    className="col col-xs-2"
                 />
 
                 <SorteringHeader
-                    sortering={Sorteringsfelt.BOSTED_KOMMUNE}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.BOSTED_KOMMUNE}
-                    tekst="Bosted"
-                    className="col col-xs-2"
-                    headerId="bosted_kommune"
                     skalVises={valgteKolonner.includes(Kolonne.BOSTED_KOMMUNE)}
-                />
-                <SorteringHeader
-                    sortering={Sorteringsfelt.BOSTED_BYDEL}
-                    onClick={sorteringOnClick}
+                    sortering={Sorteringsfelt.BOSTED_KOMMUNE}
+                    erValgt={sorteringsfelt === Sorteringsfelt.BOSTED_KOMMUNE}
                     rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.BOSTED_BYDEL}
-                    tekst="Bosted detaljer"
+                    onClick={sorteringOnClick}
+                    tekst="Bosted"
+                    headerId="bosted_kommune"
                     className="col col-xs-2"
-                    headerId="bosted_bydel"
-                    skalVises={valgteKolonner.includes(Kolonne.BOSTED_BYDEL)}
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.BOSTED_SIST_OPPDATERT}
-                    onClick={sorteringOnClick}
+                    skalVises={valgteKolonner.includes(Kolonne.BOSTED_BYDEL)}
+                    sortering={Sorteringsfelt.BOSTED_BYDEL}
+                    erValgt={sorteringsfelt === Sorteringsfelt.BOSTED_BYDEL}
                     rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Bosted detaljer"
+                    headerId="bosted_bydel"
+                    className="col col-xs-2"
+                />
+                <SorteringHeader
+                    skalVises={valgteKolonner.includes(Kolonne.BOSTED_SIST_OPPDATERT)}
+                    sortering={Sorteringsfelt.BOSTED_SIST_OPPDATERT}
                     erValgt={sorteringsfelt === Sorteringsfelt.BOSTED_SIST_OPPDATERT}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     tekst="Bosted sist oppdatert"
                     headerId="bosted_sist_oppdatert"
                     className="col col-xs-2"
-                    skalVises={valgteKolonner.includes(Kolonne.BOSTED_SIST_OPPDATERT)}
                 />
 
                 <SorteringHeader
-                    sortering={Sorteringsfelt.OPPFOLGINGSTARTET}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.OPPFOLGINGSTARTET}
-                    tekst="Oppfølging startet"
-                    className="col col-xs-2"
                     skalVises={valgteKolonner.includes(Kolonne.OPPFOLGINGSTARTET)}
+                    sortering={Sorteringsfelt.OPPFOLGINGSTARTET}
+                    erValgt={sorteringsfelt === Sorteringsfelt.OPPFOLGINGSTARTET}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Oppfølging startet"
                     title="Startdato for pågående oppfølgingsperiode"
                     headerId="oppfolgingstartet"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.ARBEIDSLISTE_FRIST}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ARBEIDSLISTE_FRIST}
-                    tekst="Arbeidsliste frist"
                     skalVises={
                         !!ferdigfilterListe?.includes(MIN_ARBEIDSLISTE) &&
                         valgteKolonner.includes(Kolonne.ARBEIDSLISTE_FRIST)
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.ARBEIDSLISTE_FRIST}
+                    erValgt={sorteringsfelt === Sorteringsfelt.ARBEIDSLISTE_FRIST}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Arbeidsliste frist"
                     title="Fristdato som er satt i arbeidslisten"
                     headerId="arbeidsliste-frist"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.ARBEIDSLISTE_OVERSKRIFT}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ARBEIDSLISTE_OVERSKRIFT}
-                    tekst="Arbeidsliste tittel"
                     skalVises={
                         !!ferdigfilterListe?.includes(MIN_ARBEIDSLISTE) &&
                         valgteKolonner.includes(Kolonne.ARBEIDSLISTE_OVERSKRIFT)
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.ARBEIDSLISTE_OVERSKRIFT}
+                    erValgt={sorteringsfelt === Sorteringsfelt.ARBEIDSLISTE_OVERSKRIFT}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Arbeidsliste tittel"
                     title="Tittel som er skrevet i arbeidslisten"
                     headerId="arbeidsliste-overskrift"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={ytelseUtlopsdatoNavn}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={ytelseUtlopsdatoNavn === sorteringsfelt}
-                    tekst="Gjenstående uker rettighet dagpenger"
                     skalVises={
                         erDagpengerYtelse && valgteKolonner.includes(Kolonne.GJENSTAENDE_UKER_RETTIGHET_DAGPENGER)
                     }
-                    className="col col-xs-2"
+                    sortering={ytelseUtlopsdatoNavn}
+                    erValgt={ytelseUtlopsdatoNavn === sorteringsfelt}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Gjenstående uker rettighet dagpenger"
                     title="Gjenstående uker av rettighetsperioden for dagpenger"
                     headerId="ytelse-utlopsdato"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={ytelseUtlopsdatoNavn}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={ytelseUtlopsdatoNavn === sorteringsfelt}
-                    tekst="Gjenstående uker vedtak tiltakspenger"
                     skalVises={
                         !!filtervalg.ytelse &&
                         !erAapYtelse &&
                         !erDagpengerYtelse &&
                         valgteKolonner.includes(Kolonne.GJENSTAENDE_UKER_VEDTAK_TILTAKSPENGER)
                     }
-                    className="col col-xs-2"
+                    sortering={ytelseUtlopsdatoNavn}
+                    erValgt={ytelseUtlopsdatoNavn === sorteringsfelt}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Gjenstående uker vedtak tiltakspenger"
                     title="Gjenstående uker på gjeldende vedtak tiltakspenger"
                     headerId="ytelse-utlopsdato"
+                    className="col col-xs-2"
                 />
                 {vis_kolonner_for_vurderingsfrist_aap && (
                     <SorteringHeader
-                        sortering={aapPeriodetype}
-                        onClick={sorteringOnClick}
-                        rekkefolge={sorteringsrekkefolge}
-                        erValgt={sorteringsfelt === aapPeriodetype}
-                        tekst="Type AAP-periode"
                         skalVises={erAapYtelse && valgteKolonner.includes(Kolonne.TYPE_YTELSE)}
-                        className="col col-xs-2"
+                        sortering={aapPeriodetype}
+                        erValgt={sorteringsfelt === aapPeriodetype}
+                        rekkefolge={sorteringsrekkefolge}
+                        onClick={sorteringOnClick}
+                        tekst="Type AAP-periode"
                         title="Type AAP-periode"
                         headerId="type-aap"
+                        className="col col-xs-2"
                     />
                 )}
                 {vis_kolonner_for_vurderingsfrist_aap && (
                     <SorteringHeader
-                        sortering={aapVurderingsfrist}
-                        onClick={sorteringOnClick}
-                        rekkefolge={sorteringsrekkefolge}
-                        erValgt={sorteringsfelt === aapVurderingsfrist}
-                        tekst="Frist vurdering rett AAP"
                         skalVises={erAapYtelse && valgteKolonner.includes(Kolonne.VURDERINGSFRIST_YTELSE)}
-                        className="col col-xs-2"
+                        sortering={aapVurderingsfrist}
+                        erValgt={sorteringsfelt === aapVurderingsfrist}
+                        rekkefolge={sorteringsrekkefolge}
+                        onClick={sorteringOnClick}
+                        tekst="Frist vurdering rett AAP"
                         title="Omtrentlig frist for ny vurdering av AAP"
                         headerId="frist-vurdering-aap"
+                        className="col col-xs-2"
                     />
                 )}
                 <SorteringHeader
-                    sortering={aapVedtakssperiode}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === aapVedtakssperiode}
-                    tekst="Gjenstående uker vedtak AAP"
                     skalVises={erAapYtelse && valgteKolonner.includes(Kolonne.VEDTAKSPERIODE)}
-                    className="col col-xs-2"
+                    sortering={aapVedtakssperiode}
+                    erValgt={sorteringsfelt === aapVedtakssperiode}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Gjenstående uker vedtak AAP"
                     title="Gjenstående uker på gjeldende vedtak AAP"
                     headerId="gjenstaende-uker-vedtak-aap"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={aapRettighetsperiode}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === aapRettighetsperiode}
-                    tekst="Gjenstående uker rettighet AAP"
                     skalVises={!!ytelse && erAapYtelse && valgteKolonner.includes(Kolonne.RETTIGHETSPERIODE)}
-                    className="col col-xs-2"
+                    sortering={aapRettighetsperiode}
+                    erValgt={sorteringsfelt === aapRettighetsperiode}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Gjenstående uker rettighet AAP"
                     title="Gjenstående uker av rettighetsperioden for AAP"
                     headerId="rettighetsperiode-gjenstaende"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.VENTER_PA_SVAR_FRA_NAV}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.VENTER_PA_SVAR_FRA_NAV}
-                    tekst="Dato på melding"
                     skalVises={!!ferdigfilterListe?.includes(VENTER_PA_SVAR_FRA_NAV)}
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.VENTER_PA_SVAR_FRA_NAV}
+                    erValgt={sorteringsfelt === Sorteringsfelt.VENTER_PA_SVAR_FRA_NAV}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Dato på melding"
                     title='Dato på meldingen som er merket "Venter på svar fra NAV"'
                     headerId="venter-pa-svar-fra-nav"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.VENTER_PA_SVAR_FRA_BRUKER}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.VENTER_PA_SVAR_FRA_BRUKER}
-                    tekst="Dato på melding"
                     skalVises={!!ferdigfilterListe?.includes(VENTER_PA_SVAR_FRA_BRUKER)}
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.VENTER_PA_SVAR_FRA_BRUKER}
+                    erValgt={sorteringsfelt === Sorteringsfelt.VENTER_PA_SVAR_FRA_BRUKER}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Dato på melding"
                     title='Dato på meldingen som er merket "Venter på svar fra bruker"'
                     headerId="venter-pa-svar-fra-bruker"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.UTLOPTE_AKTIVITETER}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTLOPTE_AKTIVITETER}
-                    tekst="Utløpsdato aktivitet"
                     skalVises={!!ferdigfilterListe?.includes(UTLOPTE_AKTIVITETER)}
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.UTLOPTE_AKTIVITETER}
+                    erValgt={sorteringsfelt === Sorteringsfelt.UTLOPTE_AKTIVITETER}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Utløpsdato aktivitet"
                     title='Utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
                     headerId="utlopte-aktiviteter"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.I_AVTALT_AKTIVITET}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.I_AVTALT_AKTIVITET}
-                    tekst="Neste utløpsdato aktivitet"
                     skalVises={iAvtaltAktivitet}
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.I_AVTALT_AKTIVITET}
+                    erValgt={sorteringsfelt === Sorteringsfelt.I_AVTALT_AKTIVITET}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Neste utløpsdato aktivitet"
                     title='Neste utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
                     headerId="i-avtalt-aktivitet"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.MOTER_IDAG}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.MOTER_IDAG}
-                    tekst="Klokkeslett møte"
                     skalVises={!!ferdigfilterListe?.includes(MOTER_IDAG) && valgteKolonner.includes(Kolonne.MOTER_IDAG)}
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.MOTER_IDAG}
+                    erValgt={sorteringsfelt === Sorteringsfelt.MOTER_IDAG}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Klokkeslett møte"
                     title="Tidspunktet møtet starter"
                     headerId="moter-idag"
+                    className="col col-xs-2"
                 />
                 <Header
                     skalVises={
                         !!ferdigfilterListe?.includes(MOTER_IDAG) && valgteKolonner.includes(Kolonne.MOTER_VARIGHET)
                     }
-                    className="col col-xs-2"
                     title="Varighet på møtet"
                     headerId="varighet-mote"
+                    className="col col-xs-2"
                 >
                     Varighet møte
                 </Header>
                 <SorteringHeader
-                    sortering={Sorteringsfelt.MOTESTATUS}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.MOTESTATUS}
                     skalVises={
                         !!ferdigfilterListe?.includes(MOTER_IDAG) && valgteKolonner.includes(Kolonne.MOTE_ER_AVTALT)
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.MOTESTATUS}
+                    erValgt={sorteringsfelt === Sorteringsfelt.MOTESTATUS}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     title="Møtestatus"
                     tekst="Avtalt med NAV"
                     headerId="avtalt-mote"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.UTKAST_14A_STATUS}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS}
                     skalVises={
                         !!ferdigfilterListe?.includes(UNDER_VURDERING) && valgteKolonner.includes(Kolonne.VEDTAKSTATUS)
                     }
+                    sortering={Sorteringsfelt.UTKAST_14A_STATUS}
+                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
                     tekst="Status § 14a-vedtak"
-                    className="col col-xs-2"
                     title="Status oppfølgingvedtak"
                     headerId="vedtakstatus"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
-                    tekst="Dager siden status"
                     skalVises={
                         !!ferdigfilterListe?.includes(UNDER_VURDERING) &&
                         valgteKolonner.includes(Kolonne.VEDTAKSTATUS_ENDRET)
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
+                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Dager siden status"
                     title="Dager siden status"
                     headerId="vedtakstatus-endret"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
-                    tekst="Ansvarlig for vedtak"
                     skalVises={
                         !!ferdigfilterListe?.includes(UNDER_VURDERING) &&
                         valgteKolonner.includes(Kolonne.ANSVARLIG_VEILEDER_FOR_VEDTAK)
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
+                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Ansvarlig for vedtak"
                     title="Ansvarlig veileder for vedtak"
                     headerId="vedtakstatus-endret"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.VALGTE_AKTIVITETER}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.VALGTE_AKTIVITETER}
-                    tekst="Neste utløpsdato valgt aktivitet"
                     skalVises={avansertAktivitet || forenkletAktivitet || tiltaksType}
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.VALGTE_AKTIVITETER}
+                    erValgt={sorteringsfelt === Sorteringsfelt.VALGTE_AKTIVITETER}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Neste utløpsdato valgt aktivitet"
                     title='Neste utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
                     headerId="valgte-aktiviteter"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.START_DATO_FOR_AVTALT_AKTIVITET}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.START_DATO_FOR_AVTALT_AKTIVITET}
-                    tekst="Startdato aktivitet"
                     skalVises={
                         !!ferdigfilterListe?.includes(I_AVTALT_AKTIVITET) &&
                         valgteKolonner.includes(Kolonne.START_DATO_AKTIVITET)
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.START_DATO_FOR_AVTALT_AKTIVITET}
+                    erValgt={sorteringsfelt === Sorteringsfelt.START_DATO_FOR_AVTALT_AKTIVITET}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Startdato aktivitet"
                     title='Startdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
                     headerId="start-dato-for-avtalt-aktivitet"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.NESTE_START_DATO_FOR_AVTALT_AKTIVITET}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.NESTE_START_DATO_FOR_AVTALT_AKTIVITET}
-                    tekst="Neste startdato aktivitet"
                     skalVises={
                         !!ferdigfilterListe?.includes(I_AVTALT_AKTIVITET) &&
                         valgteKolonner.includes(Kolonne.NESTE_START_DATO_AKTIVITET)
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.NESTE_START_DATO_FOR_AVTALT_AKTIVITET}
+                    erValgt={sorteringsfelt === Sorteringsfelt.NESTE_START_DATO_FOR_AVTALT_AKTIVITET}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Neste startdato aktivitet"
                     title='Neste startdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
                     headerId="neste-start-dato-for-avtalt-aktivitet"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.FORRIGE_DATO_FOR_AVTALT_AKTIVITET}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.FORRIGE_DATO_FOR_AVTALT_AKTIVITET}
-                    tekst="Passert startdato aktivitet"
                     skalVises={
                         !!ferdigfilterListe?.includes(I_AVTALT_AKTIVITET) &&
                         valgteKolonner.includes(Kolonne.FORRIGE_START_DATO_AKTIVITET)
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.FORRIGE_DATO_FOR_AVTALT_AKTIVITET}
+                    erValgt={sorteringsfelt === Sorteringsfelt.FORRIGE_DATO_FOR_AVTALT_AKTIVITET}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Passert startdato aktivitet"
                     title='Passert startdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
                     headerId="forrige-dato-for-avtalt-aktivitet"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.FORRIGE_DATO_FOR_AVTALT_AKTIVITET}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.FORRIGE_DATO_FOR_AVTALT_AKTIVITET}
-                    tekst="Passert startdato aktivitet"
                     skalVises={
                         !!ferdigfilterListe?.includes(I_AVTALT_AKTIVITET) &&
                         valgteKolonner.includes(Kolonne.FORRIGE_START_DATO_AKTIVITET)
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.FORRIGE_DATO_FOR_AVTALT_AKTIVITET}
+                    erValgt={sorteringsfelt === Sorteringsfelt.FORRIGE_DATO_FOR_AVTALT_AKTIVITET}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Passert startdato aktivitet"
                     title='Passert startdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
                     headerId="forrige-dato-for-avtalt-aktivitet"
+                    className="col col-xs-2"
                 />
                 <Header
                     skalVises={!!filtervalg.sisteEndringKategori && valgteKolonner.includes(Kolonne.SISTE_ENDRING)}
-                    className="col col-xs-2"
                     title="Siste endring"
                     headerId="siste-endring"
+                    className="col col-xs-2"
                 >
                     Siste endring
                 </Header>
                 <SorteringHeader
-                    sortering={Sorteringsfelt.SISTE_ENDRING_DATO}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.SISTE_ENDRING_DATO}
-                    tekst="Dato siste endring"
                     skalVises={!!filtervalg.sisteEndringKategori && valgteKolonner.includes(Kolonne.SISTE_ENDRING_DATO)}
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.SISTE_ENDRING_DATO}
+                    erValgt={sorteringsfelt === Sorteringsfelt.SISTE_ENDRING_DATO}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Dato siste endring"
                     title="Dato siste endring"
                     headerId="dato-siste-endring"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.CV_SVARFRIST}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.CV_SVARFRIST}
-                    tekst="CV svarfrist"
-                    className="col col-xs-2"
                     skalVises={valgteKolonner.includes(Kolonne.CV_SVARFRIST)}
+                    sortering={Sorteringsfelt.CV_SVARFRIST}
+                    erValgt={sorteringsfelt === Sorteringsfelt.CV_SVARFRIST}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="CV svarfrist"
                     title="Svarfrist for å svare ja til deling av CV"
                     headerId="cv-svarfrist"
+                    className="col col-xs-2"
                 />
                 <Header
                     skalVises={valgteKolonner.includes(Kolonne.AVVIK_14A_VEDTAK)}
-                    className="col col-xs-2"
                     title="Status § 14 a-vedtak"
                     headerId="minoversikt-status-14a-vedtak-kolonne-header"
+                    className="col col-xs-2"
                 >
                     Status § 14 a-vedtak
                 </Header>
@@ -585,124 +585,124 @@ function MinOversiktListeHode({
                         valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_UTLOP_OVERGANGSSTONAD) &&
                         !!filtervalg.ensligeForsorgere.length
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_UTLOPS_YTELSE}
+                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_UTLOPS_YTELSE}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Utløp overgangsstønad"
                     title="Utløpsdato for overgangsstønad"
                     headerId="utlop_overgangsstonad"
-                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_UTLOPS_YTELSE}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_UTLOPS_YTELSE}
-                    tekst="Utløp overgangsstønad"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
                     skalVises={
                         valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_VEDTAKSPERIODE) &&
                         !!filtervalg.ensligeForsorgere.length
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE}
+                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Type vedtaksperiode overgangsstønad"
                     title="Type vedtaksperiode for overgangsstønad"
                     headerId="type_vedtaksperiode"
-                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE}
-                    tekst="Type vedtaksperiode overgangsstønad"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
                     skalVises={
                         valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_AKIVITETSPLIKT) &&
                         !!filtervalg.ensligeForsorgere.length
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_AKTIVITETSPLIKT}
+                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_AKTIVITETSPLIKT}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Om aktivitetsplikt overgangsstønad"
                     title="Om bruker har aktivitetsplikt på overgangsstønad"
                     headerId="om_aktivitetsplikt"
-                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_AKTIVITETSPLIKT}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_AKTIVITETSPLIKT}
-                    tekst="Om aktivitetsplikt overgangsstønad"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
                     skalVises={
                         valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_OM_BARNET) &&
                         !!filtervalg.ensligeForsorgere.length
                     }
-                    className="col col-xs-2"
+                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_OM_BARNET}
+                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_OM_BARNET}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Om barnet"
                     title="Dato når barnet er hhv. 6 mnd/1 år gammelt"
                     headerId="oppfolging"
-                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_OM_BARNET}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_OM_BARNET}
-                    tekst="Om barnet"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.BARN_UNDER_18_AAR}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.BARN_UNDER_18_AAR}
-                    tekst="Barn under 18 år"
-                    className="col col-xs-2"
-                    headerId="barn_under_18"
                     skalVises={valgteKolonner.includes(Kolonne.HAR_BARN_UNDER_18)}
+                    sortering={Sorteringsfelt.BARN_UNDER_18_AAR}
+                    erValgt={sorteringsfelt === Sorteringsfelt.BARN_UNDER_18_AAR}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Barn under 18 år"
+                    headerId="barn_under_18"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
-                    tekst="Dato sist endret"
-                    className="col col-xs-2"
-                    headerId="dato-sist-endret-utdanning-situasjon"
                     skalVises={valgteKolonner.includes(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET)}
+                    sortering={Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
+                    erValgt={sorteringsfelt === Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Dato sist endret"
+                    headerId="dato-sist-endret-utdanning-situasjon"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.HUSKELAPP_KOMMENTAR}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.HUSKELAPP_KOMMENTAR}
-                    tekst="Huskelapp"
-                    className="col col-xs-2"
-                    headerId="huskelapp"
                     skalVises={valgteKolonner.includes(Kolonne.HUSKELAPP_KOMMENTAR)}
+                    sortering={Sorteringsfelt.HUSKELAPP_KOMMENTAR}
+                    erValgt={sorteringsfelt === Sorteringsfelt.HUSKELAPP_KOMMENTAR}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Huskelapp"
+                    headerId="huskelapp"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.HUSKELAPP_FRIST}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.HUSKELAPP_FRIST}
-                    tekst="Frist huskelapp"
-                    className="col col-xs-2"
-                    headerId="huskelapp-frist"
                     skalVises={valgteKolonner.includes(Kolonne.HUSKELAPP_FRIST)}
+                    sortering={Sorteringsfelt.HUSKELAPP_FRIST}
+                    erValgt={sorteringsfelt === Sorteringsfelt.HUSKELAPP_FRIST}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Frist huskelapp"
+                    headerId="huskelapp-frist"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.TILTAKSHENDELSE_TEKST}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.TILTAKSHENDELSE_TEKST}
-                    tekst="Hendelse på tiltak"
-                    title="Lenke til hendelsen"
-                    className="col col-xs-2"
-                    headerId="tiltakshendelse-lenke"
                     skalVises={
                         !!ferdigfilterListe?.includes(TILTAKSHENDELSER) &&
                         valgteKolonner.includes(Kolonne.TILTAKSHENDELSE_LENKE)
                     }
+                    sortering={Sorteringsfelt.TILTAKSHENDELSE_TEKST}
+                    erValgt={sorteringsfelt === Sorteringsfelt.TILTAKSHENDELSE_TEKST}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Hendelse på tiltak"
+                    title="Lenke til hendelsen"
+                    headerId="tiltakshendelse-lenke"
+                    className="col col-xs-2"
                 />
                 <SorteringHeader
-                    sortering={Sorteringsfelt.TILTAKSHENDELSE_DATO_OPPRETTET}
-                    onClick={sorteringOnClick}
-                    rekkefolge={sorteringsrekkefolge}
-                    erValgt={sorteringsfelt === Sorteringsfelt.TILTAKSHENDELSE_DATO_OPPRETTET}
-                    tekst="Dato for hendelse"
-                    title="Dato da hendelsen ble opprettet"
-                    className="col col-xs-2"
-                    headerId="tiltakshendelse-dato-opprettet"
                     skalVises={
                         !!ferdigfilterListe?.includes(TILTAKSHENDELSER) &&
                         valgteKolonner.includes(Kolonne.TILTAKSHENDELSE_DATO_OPPRETTET)
                     }
+                    sortering={Sorteringsfelt.TILTAKSHENDELSE_DATO_OPPRETTET}
+                    erValgt={sorteringsfelt === Sorteringsfelt.TILTAKSHENDELSE_DATO_OPPRETTET}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Dato for hendelse"
+                    title="Dato da hendelsen ble opprettet"
+                    headerId="tiltakshendelse-dato-opprettet"
+                    className="col col-xs-2"
                 />
             </div>
             <div className="brukerliste__gutter-right" />

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -42,6 +42,9 @@ import {BostedKommune} from '../components/tabell/headerceller/BostedKommune';
 import {BostedBydel} from '../components/tabell/headerceller/BostedBydel';
 import {BostedSistOppdatert} from '../components/tabell/headerceller/BostedSistOppdatert';
 import {OppfolgingStartet} from '../components/tabell/headerceller/OppfolgingStartet';
+import {SvarfristCv} from '../components/tabell/headerceller/SvarfristCv';
+import {Status14AVedtak} from '../components/tabell/headerceller/Status14AVedtak';
+import {BarnUnder18Aar} from '../components/tabell/headerceller/BarnUnder18Ar';
 
 function harValgteAktiviteter(aktiviteter) {
     if (aktiviteter && Object.keys(aktiviteter).length > 0) {
@@ -470,25 +473,10 @@ function MinOversiktListeHode({
                     headerId="dato-siste-endring"
                     className="col col-xs-2"
                 />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.CV_SVARFRIST)}
-                    sortering={Sorteringsfelt.CV_SVARFRIST}
-                    erValgt={sorteringsfelt === Sorteringsfelt.CV_SVARFRIST}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="CV svarfrist"
-                    title="Svarfrist for å svare ja til deling av CV"
-                    headerId="cv-svarfrist"
-                    className="col col-xs-2"
-                />
-                <Header
-                    skalVises={valgteKolonner.includes(Kolonne.AVVIK_14A_VEDTAK)}
-                    title="Status § 14 a-vedtak"
-                    headerId="minoversikt-status-14a-vedtak-kolonne-header"
-                    className="col col-xs-2"
-                >
-                    Status § 14 a-vedtak
-                </Header>
+
+                <SvarfristCv {...sorteringTilHeadercelle} />
+                <Status14AVedtak {...sorteringTilHeadercelle} />
+
                 <SorteringHeader
                     skalVises={
                         valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_UTLOP_OVERGANGSSTONAD) &&
@@ -545,16 +533,8 @@ function MinOversiktListeHode({
                     headerId="oppfolging"
                     className="col col-xs-2"
                 />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.HAR_BARN_UNDER_18)}
-                    sortering={Sorteringsfelt.BARN_UNDER_18_AAR}
-                    erValgt={sorteringsfelt === Sorteringsfelt.BARN_UNDER_18_AAR}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Barn under 18 år"
-                    headerId="barn_under_18"
-                    className="col col-xs-2"
-                />
+                <BarnUnder18Aar {...sorteringTilHeadercelle} />
+
                 <SorteringHeader
                     skalVises={valgteKolonner.includes(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET)}
                     sortering={Sorteringsfelt.UTDANNING_OG_SITUASJON_SIST_ENDRET}

--- a/src/model-interfaces.ts
+++ b/src/model-interfaces.ts
@@ -47,7 +47,7 @@ export enum Sorteringsfelt {
     BOSTED_BYDEL = 'bydelsnummer',
     BOSTED_SIST_OPPDATERT = 'bostedSistOppdatert',
     TOLKEBEHOV = 'tolkebehov',
-    TOLKE_SPRAAK = 'tolkespraak',
+    TOLKESPRAK = 'tolkespraak',
     TOLKEBEHOV_SIST_OPPDATERT = 'tolkebehov_sistoppdatert',
     CV_SVARFRIST = 'neste_svarfrist_stilling_fra_nav',
     ENSLIGE_FORSORGERE_UTLOPS_YTELSE = 'enslige_forsorgere_utlop_ytelse',

--- a/src/model-interfaces.ts
+++ b/src/model-interfaces.ts
@@ -11,7 +11,7 @@ export enum Sorteringsfelt {
     VALGTE_AKTIVITETER = 'valgteaktiviteter',
     ETTERNAVN = 'etternavn',
     FODSELSNUMMER = 'fodselsnummer',
-    OPPFOLGINGSTARTET = 'oppfolging_startdato',
+    OPPFOLGING_STARTET = 'oppfolging_startdato',
     UTLOPSDATO = 'utlopsdato',
     DAGPENGER_UTLOP_UKE = 'dagputlopuke',
     DAGPENGER_PERM_UTLOP_UKE = 'permutlopuke',


### PR DESCRIPTION
Mål:
- Mindre duplikat i koden og kortare listehode-filer som er lettare å lese. Legg til rette for meir gjenbruk og rydding på sikt.
- Betre hjelpetekstar på kolonne-titlar

Kva er gjort:
- Listehode-filene for Enhetsoversikt og Min oversikt har fått alle kolonner-props sortert i same rekkefølge, slik at det er lettare å sjå kvar dei har overlapp (ctrl+f = <3)
- Kolonner som er like i både enhet og minoversikt er trukke ut i eigne komponentar.
- Endra namn på kolonne- og sorteringsenumar slik at same verdi har same namn i begge. 
- Gjennomgang av tekst og hjelpetekst på dei "nye" komponentane (i lag med Kari)

Kva er ikkje gjort:
- Kolonner som treng valgtefilter for å bestemme om dei skal visast
