### PR TITLE
Gjer at dekoratøren får lik(are) tekststorleik som på andre sider

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1210,6 +1210,16 @@ GRID
     font-size: 0.875rem !important;
 }
 
+/* Gjer at tekst i dekoratøren i oversikten får same storleik som på andre sider*/
+.veilarbportefoljeflatefs .dekorator .navds-body-short {
+    font-size: initial !important; /* Bruker !important for å overskrive !important frå selector ".veilarbportefoljeflatefs .navds-body-short" */
+}
+
+/* Gjer at tekst i dekoratøren i oversikten får same storleik som på andre sider*/
+.veilarbportefoljeflatefs .dekorator .navds-label {
+    font-size: initial !important; /* Bruker !important for å overskrive !important frå selector ".veilarbportefoljeflatefs .navds-label" */
+}
+
 @media (max-width: 1200px) {
     .veilarbportefoljeflatefs .oversikt-sideinnhold .oversikt__container {
         grid-column-start: 1;


### PR DESCRIPTION
Bakgrunn:
Vi har overskrive tekststorleiken i ein del designsystem-element til å bruke 0.875rem (14px) i oversikten. 

Løysing:
Vi skriv over overskrivinga slik at dekoratøren "ignorerer" !important-stylinga som vert brukt i resten av Oversikten.


Kommentar:
Vi vert ikkje heilt like med dette fyrste steget, men det er nærare enn vi var. Framgang heller enn perfeksjon.
Problemet som ikkje er løyst: knapp og heading får litt for lita skrift no, skulle vore 18px. Prøv om vi kan gjere noko utan å måtte bruke !important.