### PR TITLE
Unngår at dekoratøren les endringar i fnr frå kontekstholdaren

### DIFF
--- a/src/decorator.tsx
+++ b/src/decorator.tsx
@@ -31,6 +31,7 @@ function getConfig(enhet: string | null, settValgtEnhet: (enhet) => void): Decor
                 window.location.href = getVeilarbpersonflateBasePath();
             }
         },
+        fnrSyncMode: 'writeOnly',
         showSearchArea: true,
         enhet: enhet ?? undefined,
         showEnheter: true,

--- a/src/decorator.tsx
+++ b/src/decorator.tsx
@@ -25,7 +25,6 @@ function getDecoratorEnv(): Environment {
 function getConfig(enhet: string | null, settValgtEnhet: (enhet) => void): DecoratorPropsV3 {
     return {
         appName: 'Arbeidsrettet oppfølging',
-        fnr: undefined,
         onFnrChanged: value => {
             if (value) {
                 window.location.href = getVeilarbpersonflateBasePath();
@@ -107,7 +106,13 @@ export function Decorator() {
     const config = getConfig(enhetId, velgEnhet);
 
     if (erMidlertidigFiksFnrIKontekstFeatureTogglePa) {
-        return <InternflateDecorator {...config} onFnrChanged={fnr => onFnrChangedMedFeatureToggle(fnr)} />;
+        return (
+            <InternflateDecorator
+                {...config}
+                onFnrChanged={fnr => onFnrChangedMedFeatureToggle(fnr)}
+                fnrSyncMode={undefined} // Slik at vi kan skru av/på permanentfiks med feature-toggle
+            />
+        );
     }
     return <InternflateDecorator {...config} />;
 }

--- a/src/utils/types/decorator-props-v3.ts
+++ b/src/utils/types/decorator-props-v3.ts
@@ -7,6 +7,8 @@ export interface DecoratorPropsV3 {
     enableHotkeys?: boolean; // Aktivere hurtigtaster
     fetchActiveEnhetOnMount?: boolean; // Om enhet er undefined fra container appen, og denne er satt til true, henter den sist aktiv enhet og bruker denne.
     fetchActiveUserOnMount?: boolean; // Om fnr er undefined fra container appen, og denne er satt til true for at den skal hente siste aktiv fnr.
+    fnrSyncMode?: 'sync' | 'writeOnly'; // Modus til fnr state management. "sync" er default. "writeOnly" gjør at endringer aldri hentes men vil settes dersom det oppdateres lokalt i appen
+    enhetSyncMode?: 'sync' | 'writeOnly'; // Samme som fnrSyncMode, men for enhet state.
     onEnhetChanged: (enhetId?: string | null, enhet?: Enhet) => void; // Kalles når enheten endres
     onFnrChanged: (fnr?: string | null) => void; // Kalles når fnr enheten endres
     onLinkClick?: (link: {text: string; url: string}) => void; // Kan brukes for å legge til callbacks ved klikk på lenker i menyen. Merk at callbacken ikke kan awaites og man må selv håndtere at siden lukkes. Nyttig for å f.eks tracke navigasjon events i amplitude


### PR DESCRIPTION
Ved å sende inn prop'en `fnrSyncMode="readOnly"`. Dette tilsvarer "ignoreWSEvents" (websocket-events) i dekoratøren v3 og gjer at oversiktfaner ignorerer alle oppdateringar av brukar-i-kontekst som dei ikkje er skuld i sjølv.

Burde løyse ctrl+klikk-buggen og problem der oversikten-sider navigerer til personsider fordi ein har søkt i anna fane.