### PR TITLE
Oppdater tekst for tiltakshendelse-kolonner i velg kolonner

### DIFF
--- a/src/components/toolbar/listevisning/listevisning-utils.ts
+++ b/src/components/toolbar/listevisning/listevisning-utils.ts
@@ -60,5 +60,5 @@ alternativerConfig.set(Kolonne.BARN_UNDER_18_AAR, {tekstlabel: 'Barn under 18 å
 alternativerConfig.set(Kolonne.UTDANNING_OG_SITUASJON_SIST_ENDRET, {tekstlabel: 'Situasjon/utdanning sist endret'});
 alternativerConfig.set(Kolonne.HUSKELAPP_KOMMENTAR, {tekstlabel: 'Huskelapp'});
 alternativerConfig.set(Kolonne.HUSKELAPP_FRIST, {tekstlabel: 'Frist huskelapp'});
-alternativerConfig.set(Kolonne.TILTAKSHENDELSE_LENKE, {tekstlabel: 'Tiltakshendelse lenke'});
-alternativerConfig.set(Kolonne.TILTAKSHENDELSE_DATO_OPPRETTET, {tekstlabel: 'Tiltakshendelse opprettet'});
+alternativerConfig.set(Kolonne.TILTAKSHENDELSE_LENKE, {tekstlabel: 'Hendelse på tiltak (lenke)'});
+alternativerConfig.set(Kolonne.TILTAKSHENDELSE_DATO_OPPRETTET, {tekstlabel: 'Dato for hendelse på tiltak'});


### PR DESCRIPTION
- Brukar begrepet "hendelse på tiltak" i staden for "tiltakshendelse", fordi det er det veiledarane ser andre stadar.
- Presiserar at oppdateringskolonna har ein dato slik at det vert lettare for veiledar å kople kva kolonne det er snakk om.