### PR TITLE
Legg til stjerne-ikon på lagre-filter-knapp

### DIFF
--- a/src/components/modal/mine-filter/mine-filter-nytt.tsx
+++ b/src/components/modal/mine-filter/mine-filter-nytt.tsx
@@ -67,6 +67,7 @@ export function LagreNyttMineFilter({lukkModal, oversiktType}: LagreNyttMineFilt
                     error={feilmelding.filterNavn}
                     autoFocus
                     data-testid="lagre-nytt-filter_modal_navn-input"
+                    size="small"
                 />
                 <div className="lagret-filter-knapp-wrapper">
                     <Button size="small" type="submit" data-testid="lagre-nytt-filter_modal_lagre-knapp">

--- a/src/components/modal/mine-filter/mine-filter-oppdater.tsx
+++ b/src/components/modal/mine-filter/mine-filter-oppdater.tsx
@@ -83,6 +83,7 @@ export function OppdaterMineFilter({gammeltFilterNavn, filterId, lukkModal, over
                     error={feilmelding.filterNavn}
                     autoFocus
                     data-testid="redigere-filter-navn-input"
+                    size="small"
                 />
                 <div className="lagret-filter-knapp-wrapper">
                     <Button size="small" type="submit" data-testid="rediger-filter_modal_lagre-knapp">

--- a/src/minoversikt/mine-filter-lagre-filter-knapp.tsx
+++ b/src/minoversikt/mine-filter-lagre-filter-knapp.tsx
@@ -6,6 +6,7 @@ import {AppState} from '../reducer';
 import {apneMineFilterModal} from '../ducks/lagret-filter-ui-state';
 import {OversiktType} from '../ducks/ui/listevisning';
 import {Button} from '@navikt/ds-react';
+import {StarIcon} from '@navikt/aksel-icons';
 
 interface Props {
     oversiktType: OversiktType;
@@ -56,12 +57,13 @@ export function MineFilterLagreFilterKnapp({oversiktType}: Props) {
 
     return (
         <Button
-            variant="secondary"
+            variant="secondary-neutral"
             size="small"
             className="lagre-filter-knapp"
             hidden={erLagreKnappSkjult}
             data-testid="lagre-filter_knapp"
             onClick={event => lagreFilterModal(event)}
+            icon={<StarIcon aria-hidden={true} fontSize="1.2rem" />}
         >
             Lagre filter
         </Button>

--- a/src/style.css
+++ b/src/style.css
@@ -1234,13 +1234,15 @@ GRID
     }
 }
 
-.veilarbportefoljeflatefs .navds-button--secondary {
+.veilarbportefoljeflatefs .navds-button--secondary,
+.veilarbportefoljeflatefs .navds-button--secondary-neutral {
     /* Gjer at secondary-knappar vert kvite uavhengig av bakgrunnsfargen.
      * (I designsystemet er dei gjennomsiktige.) */
     background-color: var(--a-bg-default);
 }
 
-.veilarbportefoljeflatefs .dekorator .navds-button--secondary {
+.veilarbportefoljeflatefs .dekorator .navds-button--secondary,
+.veilarbportefoljeflatefs .dekorator .navds-button--secondary-neutral {
     /* Unngår at søk-knappen i dekoratøren (og andre knappar i dekoratøren) får kvit bakgrunn.
      * (I designsystemet er dei gjennomsiktige.) */
     background-color: initial;


### PR DESCRIPTION
Oppgåve frå Kari si skisse av "småfiks i oversikten".

Legg til stjerne-ikon på lagre-filter-knapp slik at det er litt tydelegare samanheng mellom "lagre filter" og "mine filter".

Tek også i bruk secondary-neutral i staden for secondary, fordi den blå-kanta knappen stakk seg litt ut blant alle dei grå.