### PR TITLE
Refaktorer og fiks logikk i tildeling av ny veileder

### DIFF
--- a/src/components/modal/tildel-veileder/tildel-veileder-utils.ts
+++ b/src/components/modal/tildel-veileder/tildel-veileder-utils.ts
@@ -1,0 +1,88 @@
+import {FargekategoriModell, HuskelappModell} from '../../../model-interfaces';
+
+interface SjekkOmNoeSkalSlettesProps {
+    tilVeileder: string;
+    fraVeileder: string | undefined;
+    tilEnhet: string | null;
+}
+
+interface SjekkOmArebeidslisteSkalSlettesProps extends SjekkOmNoeSkalSlettesProps {
+    arbeidslisteAktiv: boolean;
+    navkontorForArbeidsliste: string | undefined;
+}
+
+export const harArbeidslisteSomVilBliSlettetFilter = ({
+    tilVeileder,
+    fraVeileder,
+    tilEnhet,
+    arbeidslisteAktiv,
+    navkontorForArbeidsliste
+}: SjekkOmArebeidslisteSkalSlettesProps): boolean => {
+    return (
+        arbeidslisteAktiv &&
+        (fraVeileder !== tilVeileder || fraVeileder === null) &&
+        navkontorForArbeidsliste !== null &&
+        navkontorForArbeidsliste !== tilEnhet
+    );
+};
+
+interface SjekkOmHuskelappSkalSlettesProps extends SjekkOmNoeSkalSlettesProps {
+    huskelapp: HuskelappModell | undefined;
+}
+
+export const harHuskelappSomVilBliSlettetFilter = ({
+    tilVeileder,
+    fraVeileder,
+    tilEnhet,
+    huskelapp
+}: SjekkOmHuskelappSkalSlettesProps) => {
+    return (
+        !!huskelapp &&
+        (fraVeileder !== tilVeileder || fraVeileder === null) &&
+        huskelapp.enhetId !== null &&
+        huskelapp.enhetId !== tilEnhet
+    );
+};
+
+interface SjekkOmFargekategoriSkalSlettesProps extends SjekkOmNoeSkalSlettesProps {
+    fargekategori: FargekategoriModell | null;
+    fargekategoriEnhetId: string | null;
+}
+
+export const harFargekategoriSomVilBliSlettetFilter = ({
+    tilVeileder,
+    fraVeileder,
+    tilEnhet,
+    fargekategori,
+    fargekategoriEnhetId
+}: SjekkOmFargekategoriSkalSlettesProps) => {
+    return (
+        fargekategori &&
+        (fraVeileder !== tilVeileder || fraVeileder === null) &&
+        fargekategoriEnhetId !== null &&
+        fargekategoriEnhetId !== tilEnhet
+    );
+};
+
+interface SjekkOmIngentingSkalSlettesProps
+    extends SjekkOmArebeidslisteSkalSlettesProps,
+        SjekkOmHuskelappSkalSlettesProps,
+        SjekkOmFargekategoriSkalSlettesProps {}
+
+export const ingentingHosBrukerVilBliSlettet = ({
+    tilVeileder,
+    fraVeileder,
+    tilEnhet,
+    arbeidslisteAktiv,
+    navkontorForArbeidsliste,
+    huskelapp,
+    fargekategori,
+    fargekategoriEnhetId
+}: SjekkOmIngentingSkalSlettesProps) => {
+    return (
+        fraVeileder === tilVeileder ||
+        ((!arbeidslisteAktiv || navkontorForArbeidsliste === tilEnhet) &&
+            (!huskelapp || huskelapp?.enhetId === tilEnhet) &&
+            (!fargekategori || fargekategoriEnhetId === tilEnhet))
+    );
+};

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -26,6 +26,12 @@ const fjernduplikatOgMapTilFnrArray = (brukereSomTildeles: BrukerModell[]) =>
         return arrayUtenDuplikater;
     }, []);
 
+interface Tilordning {
+    fraVeilederId: string | undefined;
+    tilVeilederId: string;
+    brukerFnr: string;
+}
+
 interface TildelVeilederProps {
     oversiktType?: OversiktType;
     closeInput: () => void;
@@ -34,19 +40,16 @@ interface TildelVeilederProps {
 function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
     const [ident, setIdent] = useState<string | null>(null);
     const [visAdvarselOmSletting, setVisAdvarselOmSletting] = useState<boolean>(false);
-    const brukere = useSelector((state: AppState) => state.portefolje.data.brukere);
-    const veiledere = useSelector((state: AppState) => state.veiledere.data.veilederListe);
-    const [tilordningerAlle, setTilordningerAlle] = useState<
-        {fraVeilederId: string | undefined; tilVeilederId: string; brukerFnr: string}[]
-    >([]);
-    const [tilordningerBrukereBlirIkkeSlettet, setTilordningerBrukereBlirIkkeSlettet] = useState<
-        {fraVeilederId: string | undefined; tilVeilederId: string; brukerFnr: string}[]
-    >([]);
+    const [tilordningerAlle, setTilordningerAlle] = useState<Tilordning[]>([]);
+    const [tilordningerBrukereBlirIkkeSlettet, setTilordningerBrukereBlirIkkeSlettet] = useState<Tilordning[]>([]);
     const [fnrIAdvarselslista, setFnrIAdvarselslista] = useState<Fnr[]>([]);
+
     const dispatch = useDispatch();
     const gjeldendeVeileder = useSelectGjeldendeVeileder();
     const innloggetVeileder = useIdentSelector()?.ident;
     const enhet = useEnhetSelector();
+    const brukere = useSelector((state: AppState) => state.portefolje.data.brukere);
+    const veiledere = useSelector((state: AppState) => state.veiledere.data.veilederListe);
 
     const sorterVeiledere = veiledere.sort((a, b) => {
         if (a.ident === b.ident) return 0;

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -14,6 +14,12 @@ import {trackAmplitude} from '../../../amplitude/amplitude';
 import {OversiktType} from '../../../ducks/ui/listevisning';
 import {TildelVeilederRenderer} from './tildel-veileder-renderer';
 import '../../toolbar/toolbar.css';
+import {
+    harArbeidslisteSomVilBliSlettetFilter,
+    harFargekategoriSomVilBliSlettetFilter,
+    harHuskelappSomVilBliSlettetFilter,
+    ingentingHosBrukerVilBliSlettet
+} from './tildel-veileder-utils';
 
 const fjernduplikatOgMapTilFnrArray = (brukereSomTildeles: BrukerModell[]) =>
     brukereSomTildeles.reduce((arrayUtenDuplikater: Fnr[], bruker: BrukerModell) => {
@@ -77,13 +83,17 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 brukerFnr: bruker.fnr
             }));
 
-            const brukereVilIkkeBliSlettet = valgteBrukere.filter(
-                bruker =>
-                    bruker.veilederId === ident ||
-                    ((!bruker.arbeidsliste.arbeidslisteAktiv ||
-                        bruker.arbeidsliste.navkontorForArbeidsliste === enhet) &&
-                        (!bruker.huskelapp || bruker.huskelapp?.enhetId === enhet) &&
-                        (!bruker.fargekategori || bruker.fargekategoriEnhetId === enhet))
+            const brukereVilIkkeBliSlettet = valgteBrukere.filter(bruker =>
+                ingentingHosBrukerVilBliSlettet({
+                    tilVeileder: ident,
+                    fraVeileder: bruker.veilederId,
+                    tilEnhet: enhet,
+                    arbeidslisteAktiv: bruker.arbeidsliste.arbeidslisteAktiv,
+                    navkontorForArbeidsliste: bruker.arbeidsliste.navkontorForArbeidsliste,
+                    huskelapp: bruker.huskelapp,
+                    fargekategori: bruker.fargekategori,
+                    fargekategoriEnhetId: bruker.fargekategoriEnhetId
+                })
             );
 
             const tilordningerBrukereBlirIkkeSlettet = brukereVilIkkeBliSlettet.map(bruker => ({
@@ -96,32 +106,33 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
 
             setTilordningerBrukereBlirIkkeSlettet(tilordningerBrukereBlirIkkeSlettet);
 
-            const fnrBrukereArbeidslisteVilBliSlettet = valgteBrukere.filter(
-                bruker =>
-                    // har arbeidsliste å slette
-                    bruker.arbeidsliste.arbeidslisteAktiv &&
-                    // endring av veileder eller ingen veileder frå før
-                    (bruker.veilederId !== ident || bruker.veilederId === null) &&
-                    // har kontor for arbeidslista
-                    bruker.arbeidsliste.navkontorForArbeidsliste !== null &&
-                    // endring i kontor frå det i arbeidslista
-                    bruker.arbeidsliste.navkontorForArbeidsliste !== enhet
+            const fnrBrukereArbeidslisteVilBliSlettet = valgteBrukere.filter(bruker =>
+                harArbeidslisteSomVilBliSlettetFilter({
+                    tilVeileder: ident,
+                    fraVeileder: bruker.veilederId,
+                    tilEnhet: enhet,
+                    arbeidslisteAktiv: bruker.arbeidsliste.arbeidslisteAktiv,
+                    navkontorForArbeidsliste: bruker.arbeidsliste.navkontorForArbeidsliste
+                })
             );
 
-            const fnrBrukereHuskelappVilBliSlettet = valgteBrukere.filter(
-                bruker =>
-                    !!bruker.huskelapp &&
-                    (bruker.veilederId !== ident || bruker.veilederId === null) &&
-                    bruker.huskelapp.enhetId !== null &&
-                    bruker.huskelapp.enhetId !== enhet
+            const fnrBrukereHuskelappVilBliSlettet = valgteBrukere.filter(bruker =>
+                harHuskelappSomVilBliSlettetFilter({
+                    tilVeileder: ident,
+                    fraVeileder: bruker.veilederId,
+                    tilEnhet: enhet,
+                    huskelapp: bruker.huskelapp
+                })
             );
 
-            const fnrBrukereKategoriVilBliSlettet = valgteBrukere.filter(
-                bruker =>
-                    bruker.fargekategori &&
-                    (bruker.veilederId !== ident || bruker.veilederId === null) &&
-                    bruker.fargekategoriEnhetId !== null &&
-                    bruker.fargekategoriEnhetId !== enhet
+            const fnrBrukereKategoriVilBliSlettet = valgteBrukere.filter(bruker =>
+                harFargekategoriSomVilBliSlettetFilter({
+                    tilVeileder: ident,
+                    fraVeileder: bruker.veilederId,
+                    tilEnhet: enhet,
+                    fargekategori: bruker.fargekategori,
+                    fargekategoriEnhetId: bruker.fargekategoriEnhetId
+                })
             );
 
             const fnrBrukereArbeidslisteHuskelappEllerFargekategoriVilBliSlettet = [

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -108,7 +108,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
 
             setTilordningerBrukereUtenTingSomVilBliSlettet(tilordningerBrukereUtenTingSomVilBliSlettet);
 
-            const fnrBrukereArbeidslisteVilBliSlettet = valgteBrukere.filter(bruker =>
+            const brukereDerArbeidslisteVilBliSlettet = valgteBrukere.filter(bruker =>
                 harArbeidslisteSomVilBliSlettetFilter({
                     tilVeileder: ident,
                     fraVeileder: bruker.veilederId,
@@ -118,7 +118,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 })
             );
 
-            const fnrBrukereHuskelappVilBliSlettet = valgteBrukere.filter(bruker =>
+            const brukereDerHuskelappVilBliSlettet = valgteBrukere.filter(bruker =>
                 harHuskelappSomVilBliSlettetFilter({
                     tilVeileder: ident,
                     fraVeileder: bruker.veilederId,
@@ -127,7 +127,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 })
             );
 
-            const fnrBrukereKategoriVilBliSlettet = valgteBrukere.filter(bruker =>
+            const brukereDerFargekategoriVilBliSlettet = valgteBrukere.filter(bruker =>
                 harFargekategoriSomVilBliSlettetFilter({
                     tilVeileder: ident,
                     fraVeileder: bruker.veilederId,
@@ -137,17 +137,15 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 })
             );
 
-            const fnrBrukereArbeidslisteHuskelappEllerFargekategoriVilBliSlettet = [
-                ...fnrBrukereHuskelappVilBliSlettet,
-                ...fnrBrukereArbeidslisteVilBliSlettet,
-                ...fnrBrukereKategoriVilBliSlettet
+            const fnrBrukereMedTingSomVilBliSlettetVedTildeling = [
+                ...brukereDerHuskelappVilBliSlettet,
+                ...brukereDerArbeidslisteVilBliSlettet,
+                ...brukereDerFargekategoriVilBliSlettet
             ];
 
-            setFnrIAdvarselslista(
-                fjernduplikatOgMapTilFnrArray(fnrBrukereArbeidslisteHuskelappEllerFargekategoriVilBliSlettet)
-            );
+            setFnrIAdvarselslista(fjernduplikatOgMapTilFnrArray(fnrBrukereMedTingSomVilBliSlettetVedTildeling));
 
-            if (fnrBrukereArbeidslisteHuskelappEllerFargekategoriVilBliSlettet.length > 0) {
+            if (fnrBrukereMedTingSomVilBliSlettetVedTildeling.length > 0) {
                 trackAmplitude(
                     {name: 'modal åpnet', data: {tekst: 'Fikk advarsel om sletting av arbeidsliste'}},
                     {modalId: 'veilarbportefoljeflatefs-advarselOmSlettingAvArbeidsliste'}

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -48,7 +48,9 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
     const [visAdvarselOmSletting, setVisAdvarselOmSletting] = useState<boolean>(false);
     const [fnrIAdvarselslista, setFnrIAdvarselslista] = useState<Fnr[]>([]);
     const [tilordningerAlle, setTilordningerAlle] = useState<Tilordning[]>([]);
-    const [tilordningerBrukereBlirIkkeSlettet, setTilordningerBrukereBlirIkkeSlettet] = useState<Tilordning[]>([]);
+    const [tilordningerBrukereUtenTingSomVilBliSlettet, setTilordningerBrukereUtenTingSomVilBliSlettet] = useState<
+        Tilordning[]
+    >([]);
 
     const dispatch = useDispatch();
     const gjeldendeVeileder = useSelectGjeldendeVeileder();
@@ -83,7 +85,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 brukerFnr: bruker.fnr
             }));
 
-            const brukereVilIkkeBliSlettet = valgteBrukere.filter(bruker =>
+            const brukereUtenTingSomVilBliSlettet = valgteBrukere.filter(bruker =>
                 ingentingHosBrukerVilBliSlettet({
                     tilVeileder: ident,
                     fraVeileder: bruker.veilederId,
@@ -96,7 +98,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 })
             );
 
-            const tilordningerBrukereBlirIkkeSlettet = brukereVilIkkeBliSlettet.map(bruker => ({
+            const tilordningerBrukereUtenTingSomVilBliSlettet = brukereUtenTingSomVilBliSlettet.map(bruker => ({
                 fraVeilederId: bruker.veilederId,
                 tilVeilederId: ident,
                 brukerFnr: bruker.fnr
@@ -104,7 +106,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
 
             setTilordningerAlle(alleTilordninger);
 
-            setTilordningerBrukereBlirIkkeSlettet(tilordningerBrukereBlirIkkeSlettet);
+            setTilordningerBrukereUtenTingSomVilBliSlettet(tilordningerBrukereUtenTingSomVilBliSlettet);
 
             const fnrBrukereArbeidslisteVilBliSlettet = valgteBrukere.filter(bruker =>
                 harArbeidslisteSomVilBliSlettetFilter({
@@ -190,7 +192,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                             className="knapp-avbryt-tildeling"
                             size="medium"
                             onClick={() => {
-                                if (tilordningerBrukereBlirIkkeSlettet.length > 0) {
+                                if (tilordningerBrukereUtenTingSomVilBliSlettet.length > 0) {
                                     trackAmplitude(
                                         {
                                             name: 'knapp klikket',
@@ -201,7 +203,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                                         },
                                         {modalId: 'veilarbportefoljeflatefs-advarselOmSlettingAvArbeidsliste'}
                                     );
-                                    doTildelTilVeileder(tilordningerBrukereBlirIkkeSlettet, ident);
+                                    doTildelTilVeileder(tilordningerBrukereUtenTingSomVilBliSlettet, ident);
                                 }
                                 lukkFjernModal();
                             }}

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -79,9 +79,10 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
 
             const brukereVilIkkeBliSlettet = valgteBrukere.filter(
                 bruker =>
-                    (!bruker.arbeidsliste.arbeidslisteAktiv || bruker.veilederId === ident) &&
-                    (!bruker.huskelapp || bruker.huskelapp?.enhetId === enhet || bruker.veilederId === ident) &&
-                    (!bruker.fargekategori || bruker.fargekategoriEnhetId === enhet || bruker.veilederId === ident)
+                    bruker.veilederId === ident ||
+                    (!bruker.arbeidsliste.arbeidslisteAktiv &&
+                        (!bruker.huskelapp || bruker.huskelapp?.enhetId === enhet) &&
+                        (!bruker.fargekategori || bruker.fargekategoriEnhetId === enhet))
             );
 
             const tilordningerBrukereBlirIkkeSlettet = brukereVilIkkeBliSlettet.map(bruker => ({

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -47,7 +47,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
     const [ident, setIdent] = useState<string | null>(null);
     const [visAdvarselOmSletting, setVisAdvarselOmSletting] = useState<boolean>(false);
     const [fnrIAdvarselslista, setFnrIAdvarselslista] = useState<Fnr[]>([]);
-    const [tilordningerAlle, setTilordningerAlle] = useState<Tilordning[]>([]);
+    const [tilordningerAlleBrukere, setTilordningerAlleBrukere] = useState<Tilordning[]>([]);
     const [tilordningerBrukereUtenTingSomVilBliSlettet, setTilordningerBrukereUtenTingSomVilBliSlettet] = useState<
         Tilordning[]
     >([]);
@@ -104,7 +104,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 brukerFnr: bruker.fnr
             }));
 
-            setTilordningerAlle(alleTilordninger);
+            setTilordningerAlleBrukere(alleTilordninger);
 
             setTilordningerBrukereUtenTingSomVilBliSlettet(tilordningerBrukereUtenTingSomVilBliSlettet);
 
@@ -160,6 +160,38 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
         }
     };
 
+    function tildelVeiledereForBrukereDerIngentingBlirSlettet() {
+        if (tilordningerBrukereUtenTingSomVilBliSlettet.length > 0) {
+            trackAmplitude(
+                {
+                    name: 'knapp klikket',
+                    data: {
+                        knapptekst: 'Avbryt tildeling for de aktuelle brukerne',
+                        effekt: 'Avbryter tildeling'
+                    }
+                },
+                {modalId: 'veilarbportefoljeflatefs-advarselOmSlettingAvArbeidsliste'}
+            );
+            doTildelTilVeileder(tilordningerBrukereUtenTingSomVilBliSlettet, ident);
+        }
+        lukkFjernModal();
+    }
+
+    const tildelVeilederForAlleValgteBrukere = () => () => {
+        trackAmplitude(
+            {
+                name: 'knapp klikket',
+                data: {
+                    knapptekst: 'Ja, tildel veilederen',
+                    effekt: 'Fortsetter tildeling'
+                }
+            },
+            {modalId: 'veilarbportefoljeflatefs-advarselOmSlettingAvArbeidsliste'}
+        );
+        doTildelTilVeileder(tilordningerAlleBrukere, ident);
+        lukkFjernModal();
+    };
+
     return (
         <>
             <Modal
@@ -189,22 +221,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                             variant="tertiary"
                             className="knapp-avbryt-tildeling"
                             size="medium"
-                            onClick={() => {
-                                if (tilordningerBrukereUtenTingSomVilBliSlettet.length > 0) {
-                                    trackAmplitude(
-                                        {
-                                            name: 'knapp klikket',
-                                            data: {
-                                                knapptekst: 'Avbryt tildeling for de aktuelle brukerne',
-                                                effekt: 'Avbryter tildeling'
-                                            }
-                                        },
-                                        {modalId: 'veilarbportefoljeflatefs-advarselOmSlettingAvArbeidsliste'}
-                                    );
-                                    doTildelTilVeileder(tilordningerBrukereUtenTingSomVilBliSlettet, ident);
-                                }
-                                lukkFjernModal();
-                            }}
+                            onClick={tildelVeiledereForBrukereDerIngentingBlirSlettet}
                         >
                             Avbryt tildeling for nevnte bruker(e)
                         </Button>
@@ -212,20 +229,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                             type={'submit'}
                             className="knapp"
                             size="medium"
-                            onClick={() => {
-                                trackAmplitude(
-                                    {
-                                        name: 'knapp klikket',
-                                        data: {
-                                            knapptekst: 'Ja, tildel veilederen',
-                                            effekt: 'Fortsetter tildeling'
-                                        }
-                                    },
-                                    {modalId: 'veilarbportefoljeflatefs-advarselOmSlettingAvArbeidsliste'}
-                                );
-                                doTildelTilVeileder(tilordningerAlle, ident);
-                                lukkFjernModal();
-                            }}
+                            onClick={tildelVeilederForAlleValgteBrukere}
                         >
                             Ja, tildel veilederen
                         </Button>

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -84,6 +84,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 tilVeilederId: ident,
                 brukerFnr: bruker.fnr
             }));
+            setTilordningerAlleBrukere(alleTilordninger);
 
             const brukereUtenTingSomVilBliSlettet = valgteBrukere.filter(bruker =>
                 ingentingHosBrukerVilBliSlettet({
@@ -103,9 +104,6 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 tilVeilederId: ident,
                 brukerFnr: bruker.fnr
             }));
-
-            setTilordningerAlleBrukere(alleTilordninger);
-
             setTilordningerBrukereUtenTingSomVilBliSlettet(tilordningerBrukereUtenTingSomVilBliSlettet);
 
             const brukereDerArbeidslisteVilBliSlettet = valgteBrukere.filter(bruker =>
@@ -137,15 +135,14 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
                 })
             );
 
-            const fnrBrukereMedTingSomVilBliSlettetVedTildeling = [
+            const brukereMedTingSomVilBliSlettetVedTildeling = [
                 ...brukereDerHuskelappVilBliSlettet,
                 ...brukereDerArbeidslisteVilBliSlettet,
                 ...brukereDerFargekategoriVilBliSlettet
             ];
+            setFnrIAdvarselslista(fjernduplikatOgMapTilFnrArray(brukereMedTingSomVilBliSlettetVedTildeling));
 
-            setFnrIAdvarselslista(fjernduplikatOgMapTilFnrArray(fnrBrukereMedTingSomVilBliSlettetVedTildeling));
-
-            if (fnrBrukereMedTingSomVilBliSlettetVedTildeling.length > 0) {
+            if (brukereMedTingSomVilBliSlettetVedTildeling.length > 0) {
                 trackAmplitude(
                     {name: 'modal åpnet', data: {tekst: 'Fikk advarsel om sletting av arbeidsliste'}},
                     {modalId: 'veilarbportefoljeflatefs-advarselOmSlettingAvArbeidsliste'}

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -40,9 +40,9 @@ interface TildelVeilederProps {
 function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
     const [ident, setIdent] = useState<string | null>(null);
     const [visAdvarselOmSletting, setVisAdvarselOmSletting] = useState<boolean>(false);
+    const [fnrIAdvarselslista, setFnrIAdvarselslista] = useState<Fnr[]>([]);
     const [tilordningerAlle, setTilordningerAlle] = useState<Tilordning[]>([]);
     const [tilordningerBrukereBlirIkkeSlettet, setTilordningerBrukereBlirIkkeSlettet] = useState<Tilordning[]>([]);
-    const [fnrIAdvarselslista, setFnrIAdvarselslista] = useState<Fnr[]>([]);
 
     const dispatch = useDispatch();
     const gjeldendeVeileder = useSelectGjeldendeVeileder();
@@ -80,7 +80,8 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
             const brukereVilIkkeBliSlettet = valgteBrukere.filter(
                 bruker =>
                     bruker.veilederId === ident ||
-                    (!bruker.arbeidsliste.arbeidslisteAktiv &&
+                    ((!bruker.arbeidsliste.arbeidslisteAktiv ||
+                        bruker.arbeidsliste.navkontorForArbeidsliste === enhet) &&
                         (!bruker.huskelapp || bruker.huskelapp?.enhetId === enhet) &&
                         (!bruker.fargekategori || bruker.fargekategoriEnhetId === enhet))
             );
@@ -97,9 +98,13 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
 
             const fnrBrukereArbeidslisteVilBliSlettet = valgteBrukere.filter(
                 bruker =>
+                    // har arbeidsliste å slette
                     bruker.arbeidsliste.arbeidslisteAktiv &&
+                    // endring av veileder eller ingen veileder frå før
                     (bruker.veilederId !== ident || bruker.veilederId === null) &&
+                    // har kontor for arbeidslista
                     bruker.arbeidsliste.navkontorForArbeidsliste !== null &&
+                    // endring i kontor frå det i arbeidslista
                     bruker.arbeidsliste.navkontorForArbeidsliste !== enhet
             );
 

--- a/src/components/modal/tildel-veileder/tildelveileder.test.ts
+++ b/src/components/modal/tildel-veileder/tildelveileder.test.ts
@@ -1,4 +1,4 @@
-import {BrukerModell, FargekategoriModell, HuskelappModell} from '../../../model-interfaces';
+import {FargekategoriModell, HuskelappModell} from '../../../model-interfaces';
 import {
     harArbeidslisteSomVilBliSlettetFilter,
     harFargekategoriSomVilBliSlettetFilter,
@@ -6,8 +6,9 @@ import {
     ingentingHosBrukerVilBliSlettet
 } from './tildel-veileder-utils';
 
+/** Minifisert utgåve av BrukerModell der vi berre har med felta som er relevant i testane */
 interface MiniBrukerModell {
-    veilederId?: string | undefined;
+    veilederId?: string;
     arbeidsliste: {
         arbeidslisteAktiv: boolean;
         navkontorForArbeidsliste: string | undefined;
@@ -17,19 +18,6 @@ interface MiniBrukerModell {
     fargekategoriEnhetId: string | null;
     fnr: string;
 }
-
-const brukereSomIkkeSkalSlettesFilter = (
-    bruker: MiniBrukerModell | BrukerModell,
-    ident: string,
-    enhet: string | null
-) => {
-    return (
-        bruker.veilederId === ident ||
-        ((!bruker.arbeidsliste.arbeidslisteAktiv || bruker.arbeidsliste.navkontorForArbeidsliste === enhet) &&
-            (!bruker.huskelapp || bruker.huskelapp?.enhetId === enhet) &&
-            (!bruker.fargekategori || bruker.fargekategoriEnhetId === enhet))
-    );
-};
 
 describe('Testar logikk for tildeling av veileder', () => {
     it('Sjekk om vi kan få mismatch mellom brukarar der arbeidslister vert sletta og der det ikkje blir sletta', () => {
@@ -172,7 +160,16 @@ describe('Testar logikk for tildeling av veileder', () => {
         ];
 
         const brukereDerIngentingSkalSlettast: MiniBrukerModell[] = brukere.filter(bruker =>
-            brukereSomIkkeSkalSlettesFilter(bruker, ident, enhet)
+            ingentingHosBrukerVilBliSlettet({
+                tilVeileder: ident,
+                fraVeileder: bruker.veilederId,
+                tilEnhet: enhet,
+                arbeidslisteAktiv: bruker.arbeidsliste.arbeidslisteAktiv,
+                navkontorForArbeidsliste: bruker.arbeidsliste.navkontorForArbeidsliste,
+                huskelapp: bruker.huskelapp,
+                fargekategori: bruker.fargekategori,
+                fargekategoriEnhetId: bruker.fargekategoriEnhetId
+            })
         );
         const brukereSomSkalSletteHuskelapp: MiniBrukerModell[] = brukere.filter(bruker =>
             harHuskelappSomVilBliSlettetFilter({
@@ -240,7 +237,16 @@ describe('Testar logikk for tildeling av veileder', () => {
         ];
 
         const brukereDerIngentingSkalSlettast: MiniBrukerModell[] = brukere.filter(bruker =>
-            brukereSomIkkeSkalSlettesFilter(bruker, ident, enhet)
+            ingentingHosBrukerVilBliSlettet({
+                tilVeileder: ident,
+                fraVeileder: bruker.veilederId,
+                tilEnhet: enhet,
+                arbeidslisteAktiv: bruker.arbeidsliste.arbeidslisteAktiv,
+                navkontorForArbeidsliste: bruker.arbeidsliste.navkontorForArbeidsliste,
+                huskelapp: bruker.huskelapp,
+                fargekategori: bruker.fargekategori,
+                fargekategoriEnhetId: bruker.fargekategoriEnhetId
+            })
         );
         const brukereSomSkalSletteHuskelapp: MiniBrukerModell[] = brukere.filter(bruker =>
             harFargekategoriSomVilBliSlettetFilter({

--- a/src/components/modal/tildel-veileder/tildelveileder.test.ts
+++ b/src/components/modal/tildel-veileder/tildelveileder.test.ts
@@ -26,7 +26,7 @@ describe('Testar logikk for tildeling av veileder', () => {
         const enhet = '1234';
         const ulikEnhet = '4321';
 
-        const brukerMedArbeidslisteSomSkalSlettast: MiniBrukerModell = {
+        const brukerMedArbeidslisteSomSkalSlettes: MiniBrukerModell = {
             fnr: '1',
             veilederId: ulikIdent, // eller null
             arbeidsliste: {
@@ -38,7 +38,7 @@ describe('Testar logikk for tildeling av veileder', () => {
             fargekategoriEnhetId: null
         };
 
-        const brukerMedArbeidslisteSomIkkjeSkalSlettast: MiniBrukerModell = {
+        const brukerMedArbeidslisteSomIkkeSkalSlettes: MiniBrukerModell = {
             fnr: '2',
             veilederId: ulikIdent, // eller null
             arbeidsliste: {
@@ -50,7 +50,7 @@ describe('Testar logikk for tildeling av veileder', () => {
             fargekategoriEnhetId: null
         };
 
-        const brukerUtanArbeidsliste: MiniBrukerModell = {
+        const brukerUtenArbeidsliste: MiniBrukerModell = {
             fnr: '3',
             veilederId: ulikIdent, // eller null
             arbeidsliste: {
@@ -63,23 +63,17 @@ describe('Testar logikk for tildeling av veileder', () => {
         };
 
         const brukere = [
-            brukerMedArbeidslisteSomSkalSlettast,
-            brukerMedArbeidslisteSomIkkjeSkalSlettast,
-            brukerUtanArbeidsliste
+            brukerMedArbeidslisteSomSkalSlettes,
+            brukerMedArbeidslisteSomIkkeSkalSlettes,
+            brukerUtenArbeidsliste
         ];
 
-        const brukereDerIngentingSkalSlettast: MiniBrukerModell[] = brukere.filter(bruker =>
-            ingentingHosBrukerVilBliSlettet({
-                tilVeileder: ident,
-                fraVeileder: bruker.veilederId,
-                tilEnhet: enhet,
-                arbeidslisteAktiv: bruker.arbeidsliste.arbeidslisteAktiv,
-                navkontorForArbeidsliste: bruker.arbeidsliste.navkontorForArbeidsliste,
-                huskelapp: bruker.huskelapp,
-                fargekategori: bruker.fargekategori,
-                fargekategoriEnhetId: bruker.fargekategoriEnhetId
-            })
+        const brukereDerIngentingSkalSlettes: MiniBrukerModell[] = finnBrukereDerIngentingSkalSlettes(
+            brukere,
+            ident,
+            enhet
         );
+
         const brukereSomSkalSletteArbeidsliste: MiniBrukerModell[] = brukere.filter(bruker =>
             harArbeidslisteSomVilBliSlettetFilter({
                 tilVeileder: ident,
@@ -92,14 +86,14 @@ describe('Testar logikk for tildeling av veileder', () => {
 
         // Ikkje overlapp i dei som skal slettast og ikkje
         expect(
-            brukereDerIngentingSkalSlettast.some(bruker => brukereSomSkalSletteArbeidsliste.includes(bruker))
+            brukereDerIngentingSkalSlettes.some(bruker => brukereSomSkalSletteArbeidsliste.includes(bruker))
         ).toBeFalsy();
         expect(
-            brukereSomSkalSletteArbeidsliste.some(bruker => brukereDerIngentingSkalSlettast.includes(bruker))
+            brukereSomSkalSletteArbeidsliste.some(bruker => brukereDerIngentingSkalSlettes.includes(bruker))
         ).toBeFalsy();
 
         // Alle brukarane skal anten slette noko eller ikkje slette noko
-        expect(brukereDerIngentingSkalSlettast.concat(brukereSomSkalSletteArbeidsliste).length).toEqual(brukere.length);
+        expect(brukereDerIngentingSkalSlettes.concat(brukereSomSkalSletteArbeidsliste).length).toEqual(brukere.length);
     });
 
     it('Sjekk om vi kan få mismatch mellom brukarar der huskelapp vert sletta og ikkje blir sletta', () => {
@@ -120,7 +114,7 @@ describe('Testar logikk for tildeling av veileder', () => {
             endretAv: 'Z111111'
         };
 
-        const brukerMedHuskelappSomSkalSlettast: MiniBrukerModell = {
+        const brukerMedHuskelappSomSkalSlettes: MiniBrukerModell = {
             fnr: '1',
             veilederId: ulikIdent, // eller null
             arbeidsliste: ingenArbeidsliste,
@@ -132,7 +126,7 @@ describe('Testar logikk for tildeling av veileder', () => {
             fargekategoriEnhetId: null
         };
 
-        const brukerMedHuskelappSomIkkjeSkalSlettast: MiniBrukerModell = {
+        const brukerMedHuskelappSomIkkeSkalSlettes: MiniBrukerModell = {
             fnr: '2',
             veilederId: ulikIdent, // eller null
             arbeidsliste: ingenArbeidsliste,
@@ -144,7 +138,7 @@ describe('Testar logikk for tildeling av veileder', () => {
             fargekategoriEnhetId: null
         };
 
-        const brukerUtanHuskelapp: MiniBrukerModell = {
+        const brukerUtenHuskelapp: MiniBrukerModell = {
             fnr: '3',
             veilederId: ulikIdent, // eller null
             arbeidsliste: ingenArbeidsliste,
@@ -153,24 +147,14 @@ describe('Testar logikk for tildeling av veileder', () => {
             fargekategoriEnhetId: null
         };
 
-        const brukere = [
-            brukerMedHuskelappSomSkalSlettast,
-            brukerMedHuskelappSomIkkjeSkalSlettast,
-            brukerUtanHuskelapp
-        ];
+        const brukere = [brukerMedHuskelappSomSkalSlettes, brukerMedHuskelappSomIkkeSkalSlettes, brukerUtenHuskelapp];
 
-        const brukereDerIngentingSkalSlettast: MiniBrukerModell[] = brukere.filter(bruker =>
-            ingentingHosBrukerVilBliSlettet({
-                tilVeileder: ident,
-                fraVeileder: bruker.veilederId,
-                tilEnhet: enhet,
-                arbeidslisteAktiv: bruker.arbeidsliste.arbeidslisteAktiv,
-                navkontorForArbeidsliste: bruker.arbeidsliste.navkontorForArbeidsliste,
-                huskelapp: bruker.huskelapp,
-                fargekategori: bruker.fargekategori,
-                fargekategoriEnhetId: bruker.fargekategoriEnhetId
-            })
+        const brukereDerIngentingSkalSlettes: MiniBrukerModell[] = finnBrukereDerIngentingSkalSlettes(
+            brukere,
+            ident,
+            enhet
         );
+
         const brukereSomSkalSletteHuskelapp: MiniBrukerModell[] = brukere.filter(bruker =>
             harHuskelappSomVilBliSlettetFilter({
                 tilVeileder: ident,
@@ -182,14 +166,14 @@ describe('Testar logikk for tildeling av veileder', () => {
 
         // Ikkje overlapp i dei som skal slettast og ikkje
         expect(
-            brukereDerIngentingSkalSlettast.some(bruker => brukereSomSkalSletteHuskelapp.includes(bruker))
+            brukereDerIngentingSkalSlettes.some(bruker => brukereSomSkalSletteHuskelapp.includes(bruker))
         ).toBeFalsy();
         expect(
-            brukereSomSkalSletteHuskelapp.some(bruker => brukereDerIngentingSkalSlettast.includes(bruker))
+            brukereSomSkalSletteHuskelapp.some(bruker => brukereDerIngentingSkalSlettes.includes(bruker))
         ).toBeFalsy();
 
         // Alle brukarane skal anten slette noko eller ikkje slette noko
-        expect(brukereDerIngentingSkalSlettast.concat(brukereSomSkalSletteHuskelapp).length).toEqual(brukere.length);
+        expect(brukereDerIngentingSkalSlettes.concat(brukereSomSkalSletteHuskelapp).length).toEqual(brukere.length);
     });
 
     it('Sjekk om vi kan få mismatch mellom brukarar der fargekategori vert sletta og ikkje blir sletta', () => {
@@ -203,7 +187,7 @@ describe('Testar logikk for tildeling av veileder', () => {
             navkontorForArbeidsliste: undefined
         };
 
-        const brukerMedHuskelappSomSkalSlettast: MiniBrukerModell = {
+        const brukerMedHuskelappSomSkalSlettes: MiniBrukerModell = {
             fnr: '1',
             veilederId: ulikIdent, // eller null
             arbeidsliste: ingenArbeidsliste,
@@ -212,7 +196,7 @@ describe('Testar logikk for tildeling av veileder', () => {
             fargekategoriEnhetId: ulikEnhet
         };
 
-        const brukerMedHuskelappSomIkkjeSkalSlettast: MiniBrukerModell = {
+        const brukerMedHuskelappSomIkkeSkalSlettes: MiniBrukerModell = {
             fnr: '2',
             veilederId: ulikIdent, // eller null
             arbeidsliste: ingenArbeidsliste,
@@ -221,7 +205,7 @@ describe('Testar logikk for tildeling av veileder', () => {
             fargekategoriEnhetId: enhet
         };
 
-        const brukerUtanHuskelapp: MiniBrukerModell = {
+        const brukerUtenHuskelapp: MiniBrukerModell = {
             fnr: '3',
             veilederId: ulikIdent, // eller null
             arbeidsliste: ingenArbeidsliste,
@@ -230,24 +214,14 @@ describe('Testar logikk for tildeling av veileder', () => {
             fargekategoriEnhetId: null
         };
 
-        const brukere = [
-            brukerMedHuskelappSomSkalSlettast,
-            brukerMedHuskelappSomIkkjeSkalSlettast,
-            brukerUtanHuskelapp
-        ];
+        const brukere = [brukerMedHuskelappSomSkalSlettes, brukerMedHuskelappSomIkkeSkalSlettes, brukerUtenHuskelapp];
 
-        const brukereDerIngentingSkalSlettast: MiniBrukerModell[] = brukere.filter(bruker =>
-            ingentingHosBrukerVilBliSlettet({
-                tilVeileder: ident,
-                fraVeileder: bruker.veilederId,
-                tilEnhet: enhet,
-                arbeidslisteAktiv: bruker.arbeidsliste.arbeidslisteAktiv,
-                navkontorForArbeidsliste: bruker.arbeidsliste.navkontorForArbeidsliste,
-                huskelapp: bruker.huskelapp,
-                fargekategori: bruker.fargekategori,
-                fargekategoriEnhetId: bruker.fargekategoriEnhetId
-            })
+        const brukereDerIngentingSkalSlettes: MiniBrukerModell[] = finnBrukereDerIngentingSkalSlettes(
+            brukere,
+            ident,
+            enhet
         );
+
         const brukereSomSkalSletteHuskelapp: MiniBrukerModell[] = brukere.filter(bruker =>
             harFargekategoriSomVilBliSlettetFilter({
                 tilVeileder: ident,
@@ -260,13 +234,28 @@ describe('Testar logikk for tildeling av veileder', () => {
 
         // Ikkje overlapp i dei som skal slettast og ikkje
         expect(
-            brukereDerIngentingSkalSlettast.some(bruker => brukereSomSkalSletteHuskelapp.includes(bruker))
+            brukereDerIngentingSkalSlettes.some(bruker => brukereSomSkalSletteHuskelapp.includes(bruker))
         ).toBeFalsy();
         expect(
-            brukereSomSkalSletteHuskelapp.some(bruker => brukereDerIngentingSkalSlettast.includes(bruker))
+            brukereSomSkalSletteHuskelapp.some(bruker => brukereDerIngentingSkalSlettes.includes(bruker))
         ).toBeFalsy();
 
         // Alle brukarane skal anten slette noko eller ikkje slette noko
-        expect(brukereDerIngentingSkalSlettast.concat(brukereSomSkalSletteHuskelapp).length).toEqual(brukere.length);
+        expect(brukereDerIngentingSkalSlettes.concat(brukereSomSkalSletteHuskelapp).length).toEqual(brukere.length);
     });
 });
+
+const finnBrukereDerIngentingSkalSlettes = (brukere: MiniBrukerModell[], ident, enhet) => {
+    return brukere.filter(bruker =>
+        ingentingHosBrukerVilBliSlettet({
+            tilVeileder: ident,
+            fraVeileder: bruker.veilederId,
+            tilEnhet: enhet,
+            arbeidslisteAktiv: bruker.arbeidsliste.arbeidslisteAktiv,
+            navkontorForArbeidsliste: bruker.arbeidsliste.navkontorForArbeidsliste,
+            huskelapp: bruker.huskelapp,
+            fargekategori: bruker.fargekategori,
+            fargekategoriEnhetId: bruker.fargekategoriEnhetId
+        })
+    );
+};

--- a/src/components/modal/tildel-veileder/tildelveileder.test.ts
+++ b/src/components/modal/tildel-veileder/tildelveileder.test.ts
@@ -1,0 +1,187 @@
+import {BrukerModell} from '../../../model-interfaces';
+
+interface MiniBrukerModell {
+    veilederId?: string | undefined;
+    arbeidsliste: {
+        arbeidslisteAktiv: boolean;
+        navkontorForArbeidsliste: string | undefined;
+    };
+    huskelapp?: {
+        enhetId: string | null;
+    };
+    fargekategori: string | null;
+    fargekategoriEnhetId: string | null;
+    fnr: string;
+}
+
+// Vi treng eigentleg ikkje Brukermodell her, men for at testen skal vere ein gyldig test må vi bruke noko frå andre filer
+const brukereSomIkkeSkalSlettesFilter = (
+    bruker: MiniBrukerModell | BrukerModell,
+    ident: string,
+    enhet: string | null
+) => {
+    return (
+        bruker.veilederId === ident ||
+        ((!bruker.arbeidsliste.arbeidslisteAktiv || bruker.arbeidsliste.navkontorForArbeidsliste === enhet) &&
+            (!bruker.huskelapp || bruker.huskelapp?.enhetId === enhet) &&
+            (!bruker.fargekategori || bruker.fargekategoriEnhetId === enhet))
+    );
+};
+
+const brukereArbeidslisteVilBliSlettet = (bruker: MiniBrukerModell, ident: string, enhet: string | null) => {
+    return (
+        // har arbeidsliste å slette
+        bruker.arbeidsliste.arbeidslisteAktiv &&
+        // endring av veileder eller ingen veileder frå før
+        (bruker.veilederId !== ident || bruker.veilederId === null) &&
+        // har kontor for arbeidslista
+        bruker.arbeidsliste.navkontorForArbeidsliste !== null &&
+        // endring i kontor frå det i arbeidslista
+        bruker.arbeidsliste.navkontorForArbeidsliste !== enhet
+    );
+};
+
+const brukereHuskelappVilBliSlettet = (bruker: MiniBrukerModell, ident: string, enhet: string | null) => {
+    return (
+        !!bruker.huskelapp &&
+        (bruker.veilederId !== ident || bruker.veilederId === null) &&
+        bruker.huskelapp.enhetId !== null &&
+        bruker.huskelapp.enhetId !== enhet
+    );
+};
+
+describe('Testar logikk for tildeling av veileder', () => {
+    it('Sjekk om vi kan få mismatch mellom arbeidslister der noko vert sletta og der ingenting blir sletta', () => {
+        const ident = 'Z123456';
+        const ulikIdent = 'Z654321';
+        const enhet = '1234';
+        const ulikEnhet = '4321';
+
+        const brukerMedArbeidslisteSomSkalSlettast: MiniBrukerModell = {
+            fnr: '1',
+            veilederId: ulikIdent, // eller null
+            arbeidsliste: {
+                arbeidslisteAktiv: true,
+                navkontorForArbeidsliste: ulikEnhet
+            },
+            huskelapp: undefined,
+            fargekategori: null,
+            fargekategoriEnhetId: null
+        };
+
+        const brukerMedArbeidslisteSomIkkjeSkalSlettast: MiniBrukerModell = {
+            fnr: '2',
+            veilederId: ulikIdent, // eller null
+            arbeidsliste: {
+                arbeidslisteAktiv: true,
+                navkontorForArbeidsliste: enhet
+            },
+            huskelapp: undefined,
+            fargekategori: null,
+            fargekategoriEnhetId: null
+        };
+
+        const brukerUtanArbeidsliste: MiniBrukerModell = {
+            fnr: '3',
+            veilederId: ulikIdent, // eller null
+            arbeidsliste: {
+                arbeidslisteAktiv: false,
+                navkontorForArbeidsliste: undefined
+            },
+            huskelapp: undefined,
+            fargekategori: null,
+            fargekategoriEnhetId: null
+        };
+
+        const brukere = [
+            brukerMedArbeidslisteSomSkalSlettast,
+            brukerMedArbeidslisteSomIkkjeSkalSlettast,
+            brukerUtanArbeidsliste
+        ];
+
+        const brukereDerIngentingSkalSlettast: MiniBrukerModell[] = brukere.filter(bruker =>
+            brukereSomIkkeSkalSlettesFilter(bruker, ident, enhet)
+        );
+        const brukereSomSkalSletteArbeidsliste: MiniBrukerModell[] = brukere.filter(bruker =>
+            brukereArbeidslisteVilBliSlettet(bruker, ident, enhet)
+        );
+
+        // Ikkje overlapp i dei som skal slettast og ikkje
+        expect(
+            brukereDerIngentingSkalSlettast.some(bruker => brukereSomSkalSletteArbeidsliste.includes(bruker))
+        ).toBeFalsy();
+        expect(
+            brukereSomSkalSletteArbeidsliste.some(bruker => brukereDerIngentingSkalSlettast.includes(bruker))
+        ).toBeFalsy();
+
+        // Alle brukarane skal anten slette noko eller ikkje slette noko
+        expect(brukereDerIngentingSkalSlettast.concat(brukereSomSkalSletteArbeidsliste).length).toEqual(brukere.length);
+    });
+
+    it('Sjekk om vi kan få mismatch mellom huskelappar der noko vert sletta og der ingenting blir sletta', () => {
+        const ident = 'Z123456';
+        const ulikIdent = 'Z654321';
+        const enhet = '1234';
+        const ulikEnhet = '4321';
+
+        const ingenArbeidsliste = {
+            arbeidslisteAktiv: false,
+            navkontorForArbeidsliste: undefined
+        };
+
+        const brukerMedHuskelappSomSkalSlettast: MiniBrukerModell = {
+            fnr: '1',
+            veilederId: ulikIdent, // eller null
+            arbeidsliste: ingenArbeidsliste,
+            huskelapp: {
+                enhetId: ulikEnhet
+            },
+            fargekategori: null,
+            fargekategoriEnhetId: null
+        };
+
+        const brukerMedHuskelappSomIkkjeSkalSlettast: MiniBrukerModell = {
+            fnr: '2',
+            veilederId: ulikIdent, // eller null
+            arbeidsliste: ingenArbeidsliste,
+            huskelapp: {
+                enhetId: enhet
+            },
+            fargekategori: null,
+            fargekategoriEnhetId: null
+        };
+
+        const brukerUtanHuskelapp: MiniBrukerModell = {
+            fnr: '3',
+            veilederId: ulikIdent, // eller null
+            arbeidsliste: ingenArbeidsliste,
+            huskelapp: undefined,
+            fargekategori: null,
+            fargekategoriEnhetId: null
+        };
+
+        const brukere = [
+            brukerMedHuskelappSomSkalSlettast,
+            brukerMedHuskelappSomIkkjeSkalSlettast,
+            brukerUtanHuskelapp
+        ];
+
+        const brukereDerIngentingSkalSlettast: MiniBrukerModell[] = brukere.filter(bruker =>
+            brukereSomIkkeSkalSlettesFilter(bruker, ident, enhet)
+        );
+        const brukereSomSkalSletteHuskelapp: MiniBrukerModell[] = brukere.filter(bruker =>
+            brukereHuskelappVilBliSlettet(bruker, ident, enhet)
+        );
+
+        // Ikkje overlapp i dei som skal slettast og ikkje
+        expect(
+            brukereDerIngentingSkalSlettast.some(bruker => brukereSomSkalSletteHuskelapp.includes(bruker))
+        ).toBeFalsy();
+        expect(
+            brukereSomSkalSletteHuskelapp.some(bruker => brukereDerIngentingSkalSlettast.includes(bruker))
+        ).toBeFalsy();
+
+        // Alle brukarane skal anten slette noko eller ikkje slette noko
+        expect(brukereDerIngentingSkalSlettast.concat(brukereSomSkalSletteHuskelapp).length).toEqual(brukere.length);
+    });
+});

--- a/src/components/modal/tildel-veileder/tildelveileder.test.ts
+++ b/src/components/modal/tildel-veileder/tildelveileder.test.ts
@@ -1,4 +1,10 @@
-import {BrukerModell} from '../../../model-interfaces';
+import {BrukerModell, FargekategoriModell, HuskelappModell} from '../../../model-interfaces';
+import {
+    harArbeidslisteSomVilBliSlettetFilter,
+    harFargekategoriSomVilBliSlettetFilter,
+    harHuskelappSomVilBliSlettetFilter,
+    ingentingHosBrukerVilBliSlettet
+} from './tildel-veileder-utils';
 
 interface MiniBrukerModell {
     veilederId?: string | undefined;
@@ -6,15 +12,12 @@ interface MiniBrukerModell {
         arbeidslisteAktiv: boolean;
         navkontorForArbeidsliste: string | undefined;
     };
-    huskelapp?: {
-        enhetId: string | null;
-    };
-    fargekategori: string | null;
+    huskelapp?: HuskelappModell;
+    fargekategori: FargekategoriModell | null;
     fargekategoriEnhetId: string | null;
     fnr: string;
 }
 
-// Vi treng eigentleg ikkje Brukermodell her, men for at testen skal vere ein gyldig test må vi bruke noko frå andre filer
 const brukereSomIkkeSkalSlettesFilter = (
     bruker: MiniBrukerModell | BrukerModell,
     ident: string,
@@ -28,30 +31,8 @@ const brukereSomIkkeSkalSlettesFilter = (
     );
 };
 
-const brukereArbeidslisteVilBliSlettet = (bruker: MiniBrukerModell, ident: string, enhet: string | null) => {
-    return (
-        // har arbeidsliste å slette
-        bruker.arbeidsliste.arbeidslisteAktiv &&
-        // endring av veileder eller ingen veileder frå før
-        (bruker.veilederId !== ident || bruker.veilederId === null) &&
-        // har kontor for arbeidslista
-        bruker.arbeidsliste.navkontorForArbeidsliste !== null &&
-        // endring i kontor frå det i arbeidslista
-        bruker.arbeidsliste.navkontorForArbeidsliste !== enhet
-    );
-};
-
-const brukereHuskelappVilBliSlettet = (bruker: MiniBrukerModell, ident: string, enhet: string | null) => {
-    return (
-        !!bruker.huskelapp &&
-        (bruker.veilederId !== ident || bruker.veilederId === null) &&
-        bruker.huskelapp.enhetId !== null &&
-        bruker.huskelapp.enhetId !== enhet
-    );
-};
-
 describe('Testar logikk for tildeling av veileder', () => {
-    it('Sjekk om vi kan få mismatch mellom arbeidslister der noko vert sletta og der ingenting blir sletta', () => {
+    it('Sjekk om vi kan få mismatch mellom brukarar der arbeidslister vert sletta og der det ikkje blir sletta', () => {
         const ident = 'Z123456';
         const ulikIdent = 'Z654321';
         const enhet = '1234';
@@ -100,10 +81,25 @@ describe('Testar logikk for tildeling av veileder', () => {
         ];
 
         const brukereDerIngentingSkalSlettast: MiniBrukerModell[] = brukere.filter(bruker =>
-            brukereSomIkkeSkalSlettesFilter(bruker, ident, enhet)
+            ingentingHosBrukerVilBliSlettet({
+                tilVeileder: ident,
+                fraVeileder: bruker.veilederId,
+                tilEnhet: enhet,
+                arbeidslisteAktiv: bruker.arbeidsliste.arbeidslisteAktiv,
+                navkontorForArbeidsliste: bruker.arbeidsliste.navkontorForArbeidsliste,
+                huskelapp: bruker.huskelapp,
+                fargekategori: bruker.fargekategori,
+                fargekategoriEnhetId: bruker.fargekategoriEnhetId
+            })
         );
         const brukereSomSkalSletteArbeidsliste: MiniBrukerModell[] = brukere.filter(bruker =>
-            brukereArbeidslisteVilBliSlettet(bruker, ident, enhet)
+            harArbeidslisteSomVilBliSlettetFilter({
+                tilVeileder: ident,
+                fraVeileder: bruker.veilederId,
+                tilEnhet: enhet,
+                arbeidslisteAktiv: bruker.arbeidsliste.arbeidslisteAktiv,
+                navkontorForArbeidsliste: bruker.arbeidsliste.navkontorForArbeidsliste
+            })
         );
 
         // Ikkje overlapp i dei som skal slettast og ikkje
@@ -118,7 +114,7 @@ describe('Testar logikk for tildeling av veileder', () => {
         expect(brukereDerIngentingSkalSlettast.concat(brukereSomSkalSletteArbeidsliste).length).toEqual(brukere.length);
     });
 
-    it('Sjekk om vi kan få mismatch mellom huskelappar der noko vert sletta og der ingenting blir sletta', () => {
+    it('Sjekk om vi kan få mismatch mellom brukarar der huskelapp vert sletta og ikkje blir sletta', () => {
         const ident = 'Z123456';
         const ulikIdent = 'Z654321';
         const enhet = '1234';
@@ -129,12 +125,20 @@ describe('Testar logikk for tildeling av veileder', () => {
             navkontorForArbeidsliste: undefined
         };
 
+        const irrelevanteHuskelappProps = {
+            huskelappId: '1',
+            frist: null,
+            endretDato: new Date(),
+            endretAv: 'Z111111'
+        };
+
         const brukerMedHuskelappSomSkalSlettast: MiniBrukerModell = {
             fnr: '1',
             veilederId: ulikIdent, // eller null
             arbeidsliste: ingenArbeidsliste,
             huskelapp: {
-                enhetId: ulikEnhet
+                enhetId: ulikEnhet,
+                ...irrelevanteHuskelappProps
             },
             fargekategori: null,
             fargekategoriEnhetId: null
@@ -145,7 +149,8 @@ describe('Testar logikk for tildeling av veileder', () => {
             veilederId: ulikIdent, // eller null
             arbeidsliste: ingenArbeidsliste,
             huskelapp: {
-                enhetId: enhet
+                enhetId: enhet,
+                ...irrelevanteHuskelappProps
             },
             fargekategori: null,
             fargekategoriEnhetId: null
@@ -170,7 +175,81 @@ describe('Testar logikk for tildeling av veileder', () => {
             brukereSomIkkeSkalSlettesFilter(bruker, ident, enhet)
         );
         const brukereSomSkalSletteHuskelapp: MiniBrukerModell[] = brukere.filter(bruker =>
-            brukereHuskelappVilBliSlettet(bruker, ident, enhet)
+            harHuskelappSomVilBliSlettetFilter({
+                tilVeileder: ident,
+                fraVeileder: bruker.veilederId,
+                tilEnhet: enhet,
+                huskelapp: bruker.huskelapp
+            })
+        );
+
+        // Ikkje overlapp i dei som skal slettast og ikkje
+        expect(
+            brukereDerIngentingSkalSlettast.some(bruker => brukereSomSkalSletteHuskelapp.includes(bruker))
+        ).toBeFalsy();
+        expect(
+            brukereSomSkalSletteHuskelapp.some(bruker => brukereDerIngentingSkalSlettast.includes(bruker))
+        ).toBeFalsy();
+
+        // Alle brukarane skal anten slette noko eller ikkje slette noko
+        expect(brukereDerIngentingSkalSlettast.concat(brukereSomSkalSletteHuskelapp).length).toEqual(brukere.length);
+    });
+
+    it('Sjekk om vi kan få mismatch mellom brukarar der fargekategori vert sletta og ikkje blir sletta', () => {
+        const ident = 'Z123456';
+        const ulikIdent = 'Z654321';
+        const enhet = '1234';
+        const ulikEnhet = '4321';
+
+        const ingenArbeidsliste = {
+            arbeidslisteAktiv: false,
+            navkontorForArbeidsliste: undefined
+        };
+
+        const brukerMedHuskelappSomSkalSlettast: MiniBrukerModell = {
+            fnr: '1',
+            veilederId: ulikIdent, // eller null
+            arbeidsliste: ingenArbeidsliste,
+            huskelapp: undefined,
+            fargekategori: FargekategoriModell.FARGEKATEGORI_A,
+            fargekategoriEnhetId: ulikEnhet
+        };
+
+        const brukerMedHuskelappSomIkkjeSkalSlettast: MiniBrukerModell = {
+            fnr: '2',
+            veilederId: ulikIdent, // eller null
+            arbeidsliste: ingenArbeidsliste,
+            huskelapp: undefined,
+            fargekategori: null,
+            fargekategoriEnhetId: enhet
+        };
+
+        const brukerUtanHuskelapp: MiniBrukerModell = {
+            fnr: '3',
+            veilederId: ulikIdent, // eller null
+            arbeidsliste: ingenArbeidsliste,
+            huskelapp: undefined,
+            fargekategori: null,
+            fargekategoriEnhetId: null
+        };
+
+        const brukere = [
+            brukerMedHuskelappSomSkalSlettast,
+            brukerMedHuskelappSomIkkjeSkalSlettast,
+            brukerUtanHuskelapp
+        ];
+
+        const brukereDerIngentingSkalSlettast: MiniBrukerModell[] = brukere.filter(bruker =>
+            brukereSomIkkeSkalSlettesFilter(bruker, ident, enhet)
+        );
+        const brukereSomSkalSletteHuskelapp: MiniBrukerModell[] = brukere.filter(bruker =>
+            harFargekategoriSomVilBliSlettetFilter({
+                tilVeileder: ident,
+                fraVeileder: bruker.veilederId,
+                tilEnhet: enhet,
+                fargekategori: bruker.fargekategori,
+                fargekategoriEnhetId: bruker.fargekategoriEnhetId
+            })
         );
 
         // Ikkje overlapp i dei som skal slettast og ikkje

--- a/src/components/toolbar/toolbar-knapp.tsx
+++ b/src/components/toolbar/toolbar-knapp.tsx
@@ -1,4 +1,4 @@
-import {default as React, useRef, useState} from 'react';
+import {useRef, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {Button, useEventListener} from '@navikt/ds-react';
 import TildelVeileder from '../modal/tildel-veileder/tildel-veileder';
@@ -69,20 +69,6 @@ export default function ToolbarKnapp({
         }
     };
 
-    const visChildren = () => {
-        if (tildelveileder) {
-            return (
-                <TildelVeileder
-                    closeInput={() => setButtonIsClicked(true)}
-                    skalVises={skalVises}
-                    oversiktType={oversiktType}
-                />
-            );
-        } else {
-            return <SokVeileder veileder={{}} onClick={() => setButtonIsClicked(true)} skalVises={skalVises} />;
-        }
-    };
-
     useEventListener('mousedown', handleClickOutside);
     useEventListener('keydown', escHandler);
 
@@ -94,10 +80,19 @@ export default function ToolbarKnapp({
         setButtonIsClicked(false);
         setInputIsOpen(false);
     }
+
     if (inputIsOpen) {
         return (
             <div className="toolbarknapp-input" ref={loggNode} onClick={klikk}>
-                {visChildren()}
+                {tildelveileder ? (
+                    <TildelVeileder
+                        closeInput={() => setButtonIsClicked(true)}
+                        skalVises={skalVises}
+                        oversiktType={oversiktType}
+                    />
+                ) : (
+                    <SokVeileder veileder={{}} onClick={() => setButtonIsClicked(true)} skalVises={skalVises} />
+                )}
             </div>
         );
     }

--- a/src/components/toolbar/toolbar.tsx
+++ b/src/components/toolbar/toolbar.tsx
@@ -11,7 +11,7 @@ import ToolbarKnapp from './toolbar-knapp';
 import {useWindowWidth} from '../../hooks/use-window-width';
 import FargekategoriToolbarKnapp from './fargekategori-toolbar-knapp';
 import {useFeatureSelector} from '../../hooks/redux/use-feature-selector';
-import {HUSKELAPP} from '../../konstanter';
+import {HUSKELAPP, SKJUL_ARBEIDSLISTEFUNKSJONALITET} from '../../konstanter';
 import VelgKolonner from './velg-kolonner';
 import './toolbar.css';
 import '../../style.css';
@@ -39,6 +39,7 @@ function Toolbar({
 }: ToolbarProps) {
     const brukere = useSelector((state: AppState) => state.portefolje.data.brukere);
     const erFargekategoriFeatureTogglePa = useFeatureSelector()(HUSKELAPP);
+    const skalViseArbeidslistefunksjonalitet = !useFeatureSelector()(SKJUL_ARBEIDSLISTEFUNKSJONALITET);
     const valgteBrukere = brukere.filter(bruker => bruker.markert === true);
     const aktiv = valgteBrukere.length > 0;
     const brukerfeilMelding = useSelector((state: AppState) => state.brukerfeilStatus);
@@ -50,7 +51,7 @@ function Toolbar({
             case OversiktType.minOversikt:
                 return (
                     <>
-                        {!erFargekategoriFeatureTogglePa && <ArbeidslisteKnapp />}
+                        {skalViseArbeidslistefunksjonalitet && !erFargekategoriFeatureTogglePa && <ArbeidslisteKnapp />}
                         {erFargekategoriFeatureTogglePa && (
                             <FargekategoriToolbarKnapp valgteBrukereFnrs={valgteBrukereFnrs} />
                         )}
@@ -102,7 +103,7 @@ function Toolbar({
                                 tittel="Tildel veileder"
                                 skalVises={oversiktType in OversiktType}
                                 aktiv={aktiv}
-                                tildelveileder
+                                tildelveileder={true}
                                 testid="tildel-veileder_knapp"
                                 ikon={<PersonPlusIcon aria-hidden={true} fontSize="1.5rem" />}
                                 oversiktType={oversiktType}


### PR DESCRIPTION
Denne PR-en er resultat av at eg refaktorerte noko logikk for å forstå den betre, oppdaga ein feil, laga test for feilen og retta den. Og rydda litt vidare i koden så den er lettare å forstå.

Med andre ord: den er for det meste eit mellomsteg i "skjul arbeidsliste"-reisa.

Eg har også skjult knappen for å opprette/fjerne arbeidsliste for mange brukarar i oversikten. (Denne er vanlegvis skjult av huskelapp-feature-brytaren, og er gjort mest for å vere konsekvente.)