### PR TITLE
Fiks bug i tildel veileder

### DIFF
--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -157,7 +157,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
         }
     };
 
-    function tildelVeiledereForBrukereDerIngentingBlirSlettet() {
+    const tildelVeiledereForBrukereDerIngentingBlirSlettet = () => {
         if (tilordningerBrukereUtenTingSomVilBliSlettet.length > 0) {
             trackAmplitude(
                 {
@@ -172,7 +172,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
             doTildelTilVeileder(tilordningerBrukereUtenTingSomVilBliSlettet, ident);
         }
         lukkFjernModal();
-    }
+    };
 
     const tildelVeilederForAlleValgteBrukere = () => {
         trackAmplitude(

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -174,7 +174,7 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
         lukkFjernModal();
     }
 
-    const tildelVeilederForAlleValgteBrukere = () => () => {
+    const tildelVeilederForAlleValgteBrukere = () => {
         trackAmplitude(
             {
                 name: 'knapp klikket',


### PR DESCRIPTION
Ved å ta bort dobbel lambda-funksjon (`() => () => {}`) slik at tildeling faktisk vert kalla