### PR TITLE
Rydd i header-testid

### DIFF
--- a/cypress/e2e/diverse_spec.js
+++ b/cypress/e2e/diverse_spec.js
@@ -269,7 +269,7 @@ describe('Diverse', () => {
         // Sjekkar at rette kolonner er synlege (Om barnet, Utløp overgangsstønad, ikkje Veileder)
         cy.getByTestId('sorteringheader_veileder').should('not.exist');
         cy.getByTestId('sorteringheader_utlop_overgangsstonad').should('be.visible');
-        cy.getByTestId('sorteringheader_oppfolging').should('be.visible'); //om barnet kolonne synlig
+        cy.getByTestId('sorteringheader_enslige-forsorgere-om-barnet').should('be.visible');
 
         // Går til Min oversikt
         cy.gaTilOversikt('min-oversikt');
@@ -284,7 +284,7 @@ describe('Diverse', () => {
         // Sjekkar at vi framleis ser Om barnet og Utløp overgangsnstønad
         cy.gaTilOversikt('enhetens-oversikt');
         cy.getByTestId('sorteringheader_veileder').should('not.exist');
-        cy.getByTestId('sorteringheader_oppfolging').should('be.visible');
+        cy.getByTestId('sorteringheader_enslige-forsorgere-om-barnet').should('be.visible');
 
         // Går til Min oversikt igjen, der skal vi framleis sjå kolonne for "Neste utløpsdato aktivitet"
         cy.gaTilOversikt('min-oversikt');

--- a/src/components/tabell/header.tsx
+++ b/src/components/tabell/header.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import './tabell.css';
 import {BodyShort} from '@navikt/ds-react';
+import './tabell.css';
 
 export interface HeaderProps {
     skalVises?: boolean | null;
     className?: string;
     children?: React.ReactNode;
     title?: string;
-    headerId: string;
+    headerTestId?: string;
 }
 
-function Header({children, skalVises = true, className = '', title, headerId}: HeaderProps) {
+function Header({children, skalVises = true, className = '', title, headerTestId}: HeaderProps) {
     if (!skalVises) {
         return null;
     }
@@ -19,8 +19,8 @@ function Header({children, skalVises = true, className = '', title, headerId}: H
         <BodyShort
             size="small"
             title={title}
-            className={classNames('sorteringheader', className, `sorteringheader_${headerId}`)}
-            data-testid={`sorteringheader_${headerId}`}
+            className={classNames('sorteringheader', className)}
+            data-testid={headerTestId}
         >
             {children}
         </BodyShort>

--- a/src/components/tabell/headerceller/BarnUnder18Ar.tsx
+++ b/src/components/tabell/headerceller/BarnUnder18Ar.tsx
@@ -12,7 +12,6 @@ export const BarnUnder18Aar = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefo
         onClick={onClick}
         tekst="Barn under 18 år"
         title="Antall og alder på barn under 18 år"
-        headerId="barn_under_18"
         className="col col-xs-2"
     />
 );

--- a/src/components/tabell/headerceller/Bosted.tsx
+++ b/src/components/tabell/headerceller/Bosted.tsx
@@ -12,7 +12,6 @@ export const Bosted = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onC
         onClick={onClick}
         tekst="Bosted"
         title="Kommunen personen bor i"
-        headerId="bosted_kommune"
         className="col col-xs-2"
     />
 );

--- a/src/components/tabell/headerceller/BostedDetaljer.tsx
+++ b/src/components/tabell/headerceller/BostedDetaljer.tsx
@@ -12,7 +12,6 @@ export const BostedDetaljer = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefo
         onClick={onClick}
         tekst="Bosted detaljer"
         title="Bydelen personen bor i (om det finnes en)"
-        headerId="bosted_bydel"
         className="col col-xs-2"
     />
 );

--- a/src/components/tabell/headerceller/BostedSistOppdatert.tsx
+++ b/src/components/tabell/headerceller/BostedSistOppdatert.tsx
@@ -17,7 +17,6 @@ export const BostedSistOppdatert = ({
         onClick={onClick}
         tekst="Bosted oppdatert"
         title="Dato for siste oppdatering av bosted"
-        headerId="bosted_sist_oppdatert"
         className="col col-xs-2"
     />
 );

--- a/src/components/tabell/headerceller/Fnr.tsx
+++ b/src/components/tabell/headerceller/Fnr.tsx
@@ -10,7 +10,6 @@ export const Fnr = ({gjeldendeSorteringsfelt, rekkefolge, onClick}: HeadercelleP
         onClick={onClick}
         tekst="Fødselsnr."
         title="Fødselsnummer"
-        headerId="fnr"
         className="col col-xs-2-5"
     />
 );

--- a/src/components/tabell/headerceller/Fodeland.tsx
+++ b/src/components/tabell/headerceller/Fodeland.tsx
@@ -12,7 +12,6 @@ export const Fodeland = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, o
         onClick={onClick}
         tekst="Fødeland"
         title="Landet personen er født i"
-        headerId="fodeland"
         className="col col-xs-2"
     />
 );

--- a/src/components/tabell/headerceller/HuskelappFrist.tsx
+++ b/src/components/tabell/headerceller/HuskelappFrist.tsx
@@ -12,7 +12,6 @@ export const HuskelappFrist = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefo
         onClick={onClick}
         tekst="Frist huskelapp"
         title="Fristen som er satt på huskelappen"
-        headerId="huskelapp-frist"
         className="col col-xs-2"
     />
 );

--- a/src/components/tabell/headerceller/HuskelappKommentar.tsx
+++ b/src/components/tabell/headerceller/HuskelappKommentar.tsx
@@ -17,7 +17,6 @@ export const HuskelappKommentar = ({
         onClick={onClick}
         tekst="Huskelapp"
         title="Huskelapp"
-        headerId="huskelapp"
         className="col col-xs-2"
     />
 );

--- a/src/components/tabell/headerceller/Navn.tsx
+++ b/src/components/tabell/headerceller/Navn.tsx
@@ -10,7 +10,6 @@ export const Navn = ({gjeldendeSorteringsfelt, rekkefolge, onClick}: Headercelle
         rekkefolge={rekkefolge}
         tekst="Etternavn"
         title="Etternavn"
-        headerId="etternavn"
         className="col col-xs-2"
     />
 );

--- a/src/components/tabell/headerceller/OppfolgingStartet.tsx
+++ b/src/components/tabell/headerceller/OppfolgingStartet.tsx
@@ -12,7 +12,7 @@ export const OppfolgingStartet = ({gjeldendeSorteringsfelt, valgteKolonner, rekk
         onClick={onClick}
         tekst="Oppfølging startet"
         title="Startdato for pågående oppfølgingsperiode"
-        headerId="oppfolging-startet"
+        headerTestId="sorteringheader_oppfolging-startet"
         className="col col-xs-2"
     />
 );

--- a/src/components/tabell/headerceller/Statsborgerskap.tsx
+++ b/src/components/tabell/headerceller/Statsborgerskap.tsx
@@ -12,7 +12,6 @@ export const Statsborgerskap = ({gjeldendeSorteringsfelt, valgteKolonner, rekkef
         onClick={onClick}
         tekst="Statsborgerskap"
         title="Statsborgerskap personen har"
-        headerId="statsborgerskap"
         className="col col-xs-2"
     />
 );

--- a/src/components/tabell/headerceller/StatsborgerskapGyldigFra.tsx
+++ b/src/components/tabell/headerceller/StatsborgerskapGyldigFra.tsx
@@ -17,7 +17,6 @@ export const StatsborgerskapGyldigFra = ({
         onClick={onClick}
         tekst="Gyldig fra"
         title="Dato statsborgerskapet er gyldig fra"
-        headerId="statsborgerskap_gyldig_fra"
         className="col col-xs-2"
     />
 );

--- a/src/components/tabell/headerceller/Status14AVedtak.tsx
+++ b/src/components/tabell/headerceller/Status14AVedtak.tsx
@@ -8,7 +8,6 @@ export const Status14AVedtak = ({valgteKolonner}: HeadercelleProps) => (
     <Header
         skalVises={valgteKolonner.includes(Kolonne.AVVIK_14A_VEDTAK)}
         title="Status for §14a-vedtak (sammenligning mellom Arena og ny løsning)"
-        headerId="status-14a-vedtak-kolonne-header"
         className="col col-xs-2"
     >
         Status §14a-vedtak

--- a/src/components/tabell/headerceller/SvarfristCv.tsx
+++ b/src/components/tabell/headerceller/SvarfristCv.tsx
@@ -12,7 +12,6 @@ export const SvarfristCv = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge
         onClick={onClick}
         tekst="Frist deling av CV"
         title="Frist for at personen skal svare ja til deling av CV med arbeidsgiver"
-        headerId="cv-svarfrist"
         className="col col-xs-2"
     />
 );

--- a/src/components/tabell/headerceller/Tolkebehov.tsx
+++ b/src/components/tabell/headerceller/Tolkebehov.tsx
@@ -6,7 +6,6 @@ export const Tolkebehov = ({valgteKolonner}: HeadercelleProps) => (
     <Header
         skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV)}
         title="Hvilke tolkebehov personen har"
-        headerId="tolkebehov"
         className="col col-xs-2"
     >
         Tolkebehov

--- a/src/components/tabell/headerceller/TolkebehovSistOppdatert.tsx
+++ b/src/components/tabell/headerceller/TolkebehovSistOppdatert.tsx
@@ -17,7 +17,6 @@ export const TolkebehovSistOppdatert = ({
         onClick={onClick}
         tekst="Tolkebehov oppdatert"
         title="Dato for siste oppdatering av tolkebehov"
-        headerId="tolkbehovsistoppdatert"
         className="col col-xs-2"
     />
 );

--- a/src/components/tabell/headerceller/Tolkesprak.tsx
+++ b/src/components/tabell/headerceller/Tolkesprak.tsx
@@ -12,7 +12,6 @@ export const Tolkesprak = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge,
         onClick={onClick}
         tekst="Tolkespråk"
         title="Hvilket språk tolken må kunne"
-        headerId="tolkespraak"
         className="col col-xs-2"
     />
 );

--- a/src/components/tabell/headerceller/UtdanningOgSituasjonSistEndret.tsx
+++ b/src/components/tabell/headerceller/UtdanningOgSituasjonSistEndret.tsx
@@ -17,7 +17,6 @@ export const UtdanningOgSituasjonSistEndret = ({
         onClick={onClick}
         tekst="Dato sist endret"
         title="Dato personen sist ga informasjon om situasjon eller utdanning"
-        headerId="dato-sist-endret-utdanning-og-situasjon"
         className="col col-xs-2"
     />
 );

--- a/src/components/tabell/sortering-header.tsx
+++ b/src/components/tabell/sortering-header.tsx
@@ -14,7 +14,7 @@ interface SorteringHeaderProps extends HeaderProps {
     erValgt: boolean;
     tekst: React.ReactNode;
     title?: string;
-    headerId: string;
+    headerTestId?: string;
 }
 
 function SorteringHeader({
@@ -26,7 +26,7 @@ function SorteringHeader({
     skalVises,
     className = '',
     title,
-    headerId
+    headerTestId
 }: SorteringHeaderProps) {
     const sorteringsrekkefolge =
         erValgt && rekkefolge !== Sorteringsrekkefolge.ikke_satt ? rekkefolge : 'ingen sortering';
@@ -47,8 +47,8 @@ function SorteringHeader({
     };
 
     return (
-        <Header skalVises={skalVises} className={className} headerId={headerId}>
-            <span className="sorteringheader__lenke">
+        <Header skalVises={skalVises} className={className} headerTestId={headerTestId}>
+            <span>
                 <Button
                     size="small"
                     variant="tertiary"

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -126,7 +126,7 @@ function EnhetListehode({
 
                 <Header
                     skalVises={valgteKolonner.includes(Kolonne.VEILEDER)}
-                    headerId="veileder"
+                    headerTestId="sorteringheader_veileder"
                     className="col col-xs-2"
                 >
                     Veileder
@@ -139,7 +139,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="NAV-ident"
                     title="NAV-ident på tildelt veileder"
-                    headerId="navident"
                     className="header__veilederident col col-xs-2"
                 />
                 <SorteringHeader
@@ -152,7 +151,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Gjenstående uker rettighet dagpenger"
                     title="Gjenstående uker av rettighetsperioden for dagpenger"
-                    headerId="ytelse-utlopsdato"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -168,7 +166,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Gjenstående uker vedtak tiltakspenger"
                     title="Gjenstående uker på gjeldende vedtak tiltakspenger"
-                    headerId="ytelse-utlopsdato"
                     className="col col-xs-2"
                 />
                 {vis_kolonner_for_vurderingsfrist_aap && (
@@ -180,7 +177,6 @@ function EnhetListehode({
                         onClick={sorteringOnClick}
                         tekst="Type AAP-periode"
                         title="Type AAP-periode"
-                        headerId="type-aap"
                         className="col col-xs-2"
                     />
                 )}
@@ -193,7 +189,6 @@ function EnhetListehode({
                         onClick={sorteringOnClick}
                         tekst="Frist vurdering rett AAP"
                         title="Omtrentlig frist for ny vurdering av AAP"
-                        headerId="frist-vurdering-aap"
                         className="col col-xs-2"
                     />
                 )}
@@ -205,7 +200,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Gjenstående uker vedtak AAP"
                     title="Gjenstående uker på gjeldende vedtak AAP"
-                    headerId="gjenstaende-uker-vedtak-aap"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -216,7 +210,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Gjenstående uker rettighet AAP"
                     title="Gjenstående uker av rettighetsperioden for AAP"
-                    headerId="rettighetsperiode-gjenstaende"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -230,7 +223,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Dato på melding"
                     title='Dato på meldingen som er merket "Venter på svar fra NAV"'
-                    headerId="venter-pa-svar-fra-nav"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -244,7 +236,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Dato på melding"
                     title='Dato på meldingen som er merket "Venter på svar fra bruker"'
-                    headerId="venter-pa-svar-fra-bruker"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -258,7 +249,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Utløpsdato aktivitet"
                     title='Utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
-                    headerId="utlopte-aktiviteter"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -269,7 +259,7 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Neste utløpsdato aktivitet"
                     title='Neste utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
-                    headerId="i-avtalt-aktivitet"
+                    headerTestId="sorteringheader_i-avtalt-aktivitet"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -280,7 +270,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Neste utløpsdato valgt aktivitet"
                     title='Neste utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
-                    headerId="valgte-aktiviteter"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -291,7 +280,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Klokkeslett møte"
                     title="Tidspunktet møtet starter"
-                    headerId="moter-idag"
                     className="col col-xs-2"
                 />
                 <Header
@@ -299,7 +287,6 @@ function EnhetListehode({
                         !!ferdigfilterListe?.includes(MOTER_IDAG) && valgteKolonner.includes(Kolonne.MOTER_VARIGHET)
                     }
                     title="Varighet på møtet"
-                    headerId="varighet-mote"
                     className="col col-xs-2"
                 >
                     Varighet møte
@@ -314,7 +301,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Avtalt med NAV"
                     title="Møtestatus"
-                    headerId="avtalt-mote"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -327,7 +313,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Status § 14a-vedtak"
                     title="Status oppfølgingvedtak"
-                    headerId="vedtakstatus"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -341,7 +326,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Statusendring"
                     title="Dager siden fikk status"
-                    headerId="vedtakstatus-endret"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -355,14 +339,12 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Ansvarlig for vedtak"
                     title="Ansvarlig veileder for vedtak"
-                    headerId="vedtakstatus-endret"
                     className="col col-xs-2"
                 />
                 <Header
                     // Dette er siste endring frå under "Hendelser", i aktiviteter personen sjølv har oppretta.
                     skalVises={!!filtervalg.sisteEndringKategori && valgteKolonner.includes(Kolonne.SISTE_ENDRING)}
                     title="Personens siste endring av aktiviteter/mål"
-                    headerId="siste-endring"
                     className="col col-xs-2"
                 >
                     Siste endring
@@ -376,7 +358,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Dato siste endring"
                     title="Dato personen sist gjorde endring i aktiviteter/mål"
-                    headerId="dato-siste-endring"
                     className="col col-xs-2"
                 />
                 <SvarfristCv {...sorteringTilHeadercelle} />
@@ -393,7 +374,7 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Utløp overgangsstønad"
                     title="Utløpsdato for overgangsstønad"
-                    headerId="utlop_overgangsstonad"
+                    headerTestId="sorteringheader_utlop_overgangsstonad"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -407,7 +388,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Type vedtaksperiode overgangsstønad"
                     title="Type vedtaksperiode for overgangsstønad"
-                    headerId="type_vedtaksperiode"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -421,7 +401,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Om aktivitetsplikt overgangsstønad"
                     title="Om bruker har aktivitetsplikt på overgangsstønad"
-                    headerId="om_aktivitetsplikt"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -435,7 +414,7 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Om barnet"
                     title="Dato når barnet er hhv. 6 mnd/1 år gammelt"
-                    headerId="oppfolging"
+                    headerTestId="sorteringheader_oppfolging" // TODO betre test-id her
                     className="col col-xs-3"
                 />
 
@@ -454,7 +433,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Hendelse på tiltak"
                     title="Lenke til hendelsen"
-                    headerId="tiltakshendelse-lenke"
                     className="col col-xs-3"
                 />
                 <SorteringHeader
@@ -468,7 +446,6 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Dato for hendelse"
                     title="Dato da hendelsen ble opprettet"
-                    headerId="tiltakshendelse-dato-opprettet"
                     className="col col-xs-2"
                 />
             </div>

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -414,7 +414,7 @@ function EnhetListehode({
                     onClick={sorteringOnClick}
                     tekst="Om barnet"
                     title="Dato når barnet er hhv. 6 mnd/1 år gammelt"
-                    headerTestId="sorteringheader_oppfolging" // TODO betre test-id her
+                    headerTestId="sorteringheader_enslige-forsorgere-om-barnet"
                     className="col col-xs-3"
                 />
 

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -512,7 +512,7 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Om barnet"
                     title="Dato når barnet er hhv. 6 mnd/1 år gammelt"
-                    headerTestId="sorteringheader_oppfolging"
+                    headerTestId="sorteringheader_enslige-forsorgere-om-barnet"
                     className="col col-xs-2"
                 />
                 <BarnUnder18Aar {...sorteringTilHeadercelle} />

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -122,7 +122,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst={<ArbeidslisteikonBla id="arbeidslisteikon__listehode" />}
                     title="Sorter på farge"
-                    headerId="arbeidslistekategori"
                     className="arbeidslistekategori__sorteringsheader"
                 />
             )}
@@ -179,21 +178,19 @@ function MinOversiktListeHode({
                             onClick={sorteringOnClick}
                             tekst="Arbeidsliste frist"
                             title="Fristdato som er satt i arbeidslisten"
-                            headerId="arbeidsliste-frist"
                             className="col col-xs-2"
-                        />
-                        <SorteringHeader
-                            skalVises={
-                                !!ferdigfilterListe?.includes(MIN_ARBEIDSLISTE) &&
-                                valgteKolonner.includes(Kolonne.ARBEIDSLISTE_OVERSKRIFT)
-                            }
-                            sortering={Sorteringsfelt.ARBEIDSLISTE_OVERSKRIFT}
-                            erValgt={sorteringsfelt === Sorteringsfelt.ARBEIDSLISTE_OVERSKRIFT}
-                            rekkefolge={sorteringsrekkefolge}
-                            onClick={sorteringOnClick}
-                            tekst="Arbeidsliste tittel"
-                            title="Tittel som er skrevet i arbeidslisten"
-                            headerId="arbeidsliste-overskrift"
+                />
+                <SorteringHeader
+                    skalVises={
+                        !!ferdigfilterListe?.includes(MIN_ARBEIDSLISTE) &&
+                        valgteKolonner.includes(Kolonne.ARBEIDSLISTE_OVERSKRIFT)
+                    }
+                    sortering={Sorteringsfelt.ARBEIDSLISTE_OVERSKRIFT}
+                    erValgt={sorteringsfelt === Sorteringsfelt.ARBEIDSLISTE_OVERSKRIFT}
+                    rekkefolge={sorteringsrekkefolge}
+                    onClick={sorteringOnClick}
+                    tekst="Arbeidsliste tittel"
+                    title="Tittel som er skrevet i arbeidslisten"
                             className="col col-xs-2"
                         />
                     </>
@@ -208,7 +205,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Gjenstående uker rettighet dagpenger"
                     title="Gjenstående uker av rettighetsperioden for dagpenger"
-                    headerId="ytelse-utlopsdato"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -224,7 +220,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Gjenstående uker vedtak tiltakspenger"
                     title="Gjenstående uker på gjeldende vedtak tiltakspenger"
-                    headerId="ytelse-utlopsdato"
                     className="col col-xs-2"
                 />
                 {vis_kolonner_for_vurderingsfrist_aap && (
@@ -236,7 +231,6 @@ function MinOversiktListeHode({
                         onClick={sorteringOnClick}
                         tekst="Type AAP-periode"
                         title="Type AAP-periode"
-                        headerId="type-aap"
                         className="col col-xs-2"
                     />
                 )}
@@ -249,7 +243,6 @@ function MinOversiktListeHode({
                         onClick={sorteringOnClick}
                         tekst="Frist vurdering rett AAP"
                         title="Omtrentlig frist for ny vurdering av AAP"
-                        headerId="frist-vurdering-aap"
                         className="col col-xs-2"
                     />
                 )}
@@ -261,7 +254,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Gjenstående uker vedtak AAP"
                     title="Gjenstående uker på gjeldende vedtak AAP"
-                    headerId="gjenstaende-uker-vedtak-aap"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -272,7 +264,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Gjenstående uker rettighet AAP"
                     title="Gjenstående uker av rettighetsperioden for AAP"
-                    headerId="rettighetsperiode-gjenstaende"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -283,7 +274,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Dato på melding"
                     title='Dato på meldingen som er merket "Venter på svar fra NAV"'
-                    headerId="venter-pa-svar-fra-nav"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -294,7 +284,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Dato på melding"
                     title='Dato på meldingen som er merket "Venter på svar fra bruker"'
-                    headerId="venter-pa-svar-fra-bruker"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -305,7 +294,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Utløpsdato aktivitet"
                     title='Utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
-                    headerId="utlopte-aktiviteter"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -316,7 +304,7 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Neste utløpsdato aktivitet"
                     title='Neste utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
-                    headerId="i-avtalt-aktivitet"
+                    headerTestId="sorteringheader_i-avtalt-aktivitet"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -327,7 +315,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Klokkeslett møte"
                     title="Tidspunktet møtet starter"
-                    headerId="moter-idag"
                     className="col col-xs-2"
                 />
                 <Header
@@ -335,7 +322,6 @@ function MinOversiktListeHode({
                         !!ferdigfilterListe?.includes(MOTER_IDAG) && valgteKolonner.includes(Kolonne.MOTER_VARIGHET)
                     }
                     title="Varighet på møtet"
-                    headerId="varighet-mote"
                     className="col col-xs-2"
                 >
                     Varighet møte
@@ -350,7 +336,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Avtalt med NAV"
                     title="Møtestatus"
-                    headerId="avtalt-mote"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -363,7 +348,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Status § 14a-vedtak"
                     title="Status oppfølgingvedtak"
-                    headerId="vedtakstatus"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -377,7 +361,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Dager siden status"
                     title="Dager siden status"
-                    headerId="vedtakstatus-endret"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -391,7 +374,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Ansvarlig for vedtak"
                     title="Ansvarlig veileder for vedtak"
-                    headerId="vedtakstatus-endret"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -402,7 +384,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Neste utløpsdato valgt aktivitet"
                     title='Neste utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
-                    headerId="valgte-aktiviteter"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -416,7 +397,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Startdato aktivitet"
                     title='Startdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
-                    headerId="start-dato-for-avtalt-aktivitet"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -430,7 +410,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Neste startdato aktivitet"
                     title='Neste startdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
-                    headerId="neste-start-dato-for-avtalt-aktivitet"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -444,7 +423,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Passert startdato aktivitet"
                     title='Passert startdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
-                    headerId="forrige-dato-for-avtalt-aktivitet"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -458,14 +436,12 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Passert startdato aktivitet"
                     title='Passert startdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
-                    headerId="forrige-dato-for-avtalt-aktivitet"
                     className="col col-xs-2"
                 />
                 <Header
                     // Dette er siste endring frå under "Hendelser", i aktiviteter personen sjølv har oppretta.
                     skalVises={!!filtervalg.sisteEndringKategori && valgteKolonner.includes(Kolonne.SISTE_ENDRING)}
                     title="Personens siste endring av aktiviteter/mål"
-                    headerId="siste-endring"
                     className="col col-xs-2"
                 >
                     Siste endring
@@ -479,7 +455,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Dato personen sist gjorde endring i aktiviteter/mål"
                     title="Dato siste endring"
-                    headerId="dato-siste-endring"
                     className="col col-xs-2"
                 />
 
@@ -497,7 +472,7 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Utløp overgangsstønad"
                     title="Utløpsdato for overgangsstønad"
-                    headerId="utlop_overgangsstonad"
+                    headerTestId="sorteringheader_utlop_overgangsstonad"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -511,7 +486,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Type vedtaksperiode overgangsstønad"
                     title="Type vedtaksperiode for overgangsstønad"
-                    headerId="type_vedtaksperiode"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -525,7 +499,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Om aktivitetsplikt overgangsstønad"
                     title="Om bruker har aktivitetsplikt på overgangsstønad"
-                    headerId="om_aktivitetsplikt"
                     className="col col-xs-2"
                 />
                 <SorteringHeader
@@ -539,7 +512,7 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Om barnet"
                     title="Dato når barnet er hhv. 6 mnd/1 år gammelt"
-                    headerId="oppfolging"
+                    headerTestId="sorteringheader_oppfolging"
                     className="col col-xs-2"
                 />
                 <BarnUnder18Aar {...sorteringTilHeadercelle} />
@@ -560,7 +533,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Hendelse på tiltak"
                     title="Lenke til hendelsen"
-                    headerId="tiltakshendelse-lenke"
                     className="col col-xs-3"
                 />
                 <SorteringHeader
@@ -574,7 +546,6 @@ function MinOversiktListeHode({
                     onClick={sorteringOnClick}
                     tekst="Dato for hendelse"
                     title="Dato da hendelsen ble opprettet"
-                    headerId="tiltakshendelse-dato-opprettet"
                     className="col col-xs-2"
                 />
             </div>


### PR DESCRIPTION
- Fjern ubrukt klassenamn
- Presiser i propnamn at header-id er brukt til test-id
- Ikkje generer (ubrukte) klassenamn med header-id
- Send inn fullstendige test-id-ar i staden for å generere dei med prefiks+id
- Bruk meir skildrande test-id for Om barnet-kolonne
