### PR TITLE
Fiks kolonner utan innhald

### DIFF
--- a/src/components/tabell/headerceller/Bosted.tsx
+++ b/src/components/tabell/headerceller/Bosted.tsx
@@ -3,6 +3,7 @@ import {Sorteringsfelt} from '../../../model-interfaces';
 import {Kolonne} from '../../../ducks/ui/listevisning';
 import SorteringHeader from '../sortering-header';
 
+/** Denne viser kommune, "Utland eller "Ukjent". */
 export const Bosted = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
     <SorteringHeader
         skalVises={valgteKolonner.includes(Kolonne.BOSTED_KOMMUNE)}

--- a/src/components/tabell/kolonner/tekstkolonne.tsx
+++ b/src/components/tabell/kolonner/tekstkolonne.tsx
@@ -3,13 +3,14 @@ import {BodyShort} from '@navikt/ds-react';
 import classNames from 'classnames';
 
 interface TekstKolonneProps {
-    tekst?: string;
+    /** Send inn "-" om det ikkje er noko tekst å vise */
+    tekst: string;
     skalVises: boolean;
     className?: string;
 }
 
 export function TekstKolonne({tekst, skalVises, className}: TekstKolonneProps) {
-    if (!skalVises || !tekst) {
+    if (!skalVises) {
         return null;
     }
 

--- a/src/enhetsportefolje/enhet-kolonner.tsx
+++ b/src/enhetsportefolje/enhet-kolonner.tsx
@@ -151,9 +151,7 @@ function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKolonner, 
                 className="col col-xs-2"
                 skalVises={valgteKolonner.includes(Kolonne.STATSBORGERSKAP_GYLDIG_FRA)}
                 tekst={
-                    bruker.hovedStatsborgerskap?.gyldigFra
-                        ? toDateString(bruker.hovedStatsborgerskap.gyldigFra)!.toString()
-                        : '-'
+                    bruker.hovedStatsborgerskap?.gyldigFra ? toDateString(bruker.hovedStatsborgerskap.gyldigFra) : '-'
                 }
             />
             <TekstKolonne
@@ -169,7 +167,7 @@ function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKolonner, 
             <TekstKolonne
                 className="col col-xs-2"
                 skalVises={valgteKolonner.includes(Kolonne.BOSTED_SIST_OPPDATERT)}
-                tekst={bruker.bostedSistOppdatert ? toDateString(bruker.bostedSistOppdatert)!.toString() : '-'}
+                tekst={bruker.bostedSistOppdatert ? toDateString(bruker.bostedSistOppdatert) : '-'}
             />
             <TekstKolonne
                 className="col col-xs-2"
@@ -184,7 +182,7 @@ function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKolonner, 
             <TekstKolonne
                 className="col col-xs-2"
                 skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SIST_OPPDATERT)}
-                tekst={bruker.tolkBehovSistOppdatert ? toDateString(bruker.tolkBehovSistOppdatert)!.toString() : '-'}
+                tekst={bruker.tolkBehovSistOppdatert ? toDateString(bruker.tolkBehovSistOppdatert) : '-'}
             />
             <DatoKolonne
                 className="col col-xs-2"

--- a/src/enhetsportefolje/enhet-kolonner.tsx
+++ b/src/enhetsportefolje/enhet-kolonner.tsx
@@ -21,8 +21,9 @@ import {BarnUnder18Aar, BrukerModell, FiltervalgModell, VeilederModell} from '..
 import {
     aapRettighetsperiode,
     aapVurderingsfrist,
-    bostedKommune,
+    bostedKommuneUtlandEllerUkjent,
     capitalize,
+    bostedBydelEllerUkjent,
     mapOmAktivitetsPlikt,
     nesteUtlopsdatoEllerNull,
     oppfolingsdatoEnsligeForsorgere,
@@ -157,12 +158,12 @@ function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKolonner, 
             <TekstKolonne
                 className="col col-xs-2"
                 skalVises={valgteKolonner.includes(Kolonne.BOSTED_KOMMUNE)}
-                tekst={bostedKommune(bruker, geografiskbostedData)}
+                tekst={bostedKommuneUtlandEllerUkjent(bruker, geografiskbostedData)}
             />
             <TekstKolonne
                 className="col col-xs-2"
                 skalVises={valgteKolonner.includes(Kolonne.BOSTED_BYDEL)}
-                tekst={bruker.bostedBydel ? geografiskbostedData.get(bruker.bostedBydel) : '-'}
+                tekst={bruker.bostedBydel ? bostedBydelEllerUkjent(bruker.bostedBydel, geografiskbostedData) : '-'}
             />
             <TekstKolonne
                 className="col col-xs-2"
@@ -325,7 +326,7 @@ function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKolonner, 
                 skalVises={!!ferdigfilterListe?.includes(MOTER_IDAG) && valgteKolonner.includes(Kolonne.MOTE_ER_AVTALT)}
             />
             <TekstKolonne
-                tekst={bruker.utkast14aStatus}
+                tekst={bruker.utkast14aStatus ?? '-'}
                 skalVises={
                     !!ferdigfilterListe?.includes(UNDER_VURDERING) && valgteKolonner.includes(Kolonne.VEDTAKSTATUS)
                 }
@@ -380,7 +381,7 @@ function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKolonner, 
                 className="col col-xs-2"
             />
             <TekstKolonne
-                tekst={bruker.ensligeForsorgereOvergangsstonad?.vedtaksPeriodetype}
+                tekst={bruker.ensligeForsorgereOvergangsstonad?.vedtaksPeriodetype ?? '-'}
                 skalVises={valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_VEDTAKSPERIODE)}
                 className="col col-xs-2"
             />

--- a/src/minoversikt/minoversikt-kolonner.tsx
+++ b/src/minoversikt/minoversikt-kolonner.tsx
@@ -3,8 +3,9 @@ import moment from 'moment';
 import {
     aapRettighetsperiode,
     aapVurderingsfrist,
-    bostedKommune,
+    bostedKommuneUtlandEllerUkjent,
     capitalize,
+    bostedBydelEllerUkjent,
     mapOmAktivitetsPlikt,
     nesteUtlopsdatoEllerNull,
     oppfolingsdatoEnsligeForsorgere,
@@ -176,12 +177,12 @@ function MinoversiktDatokolonner({bruker, enhetId, filtervalg, valgteKolonner}: 
             <TekstKolonne
                 className="col col-xs-2"
                 skalVises={valgteKolonner.includes(Kolonne.BOSTED_KOMMUNE)}
-                tekst={bostedKommune(bruker, geografiskbostedData)}
+                tekst={bostedKommuneUtlandEllerUkjent(bruker, geografiskbostedData)}
             />
             <TekstKolonne
                 className="col col-xs-2"
                 skalVises={valgteKolonner.includes(Kolonne.BOSTED_BYDEL)}
-                tekst={bruker.bostedBydel ? geografiskbostedData.get(bruker.bostedBydel) : '-'}
+                tekst={bruker.bostedBydel ? bostedBydelEllerUkjent(bruker.bostedBydel, geografiskbostedData) : '-'}
             />
             <TekstKolonne
                 className="col col-xs-2"
@@ -353,7 +354,7 @@ function MinoversiktDatokolonner({bruker, enhetId, filtervalg, valgteKolonner}: 
                 }
             />
             <TekstKolonne
-                tekst={bruker.utkast14aStatus}
+                tekst={bruker.utkast14aStatus ?? '-'}
                 skalVises={
                     !!ferdigfilterListe?.includes(UNDER_VURDERING) && valgteKolonner.includes(Kolonne.VEDTAKSTATUS)
                 }
@@ -408,7 +409,7 @@ function MinoversiktDatokolonner({bruker, enhetId, filtervalg, valgteKolonner}: 
                 className="col col-xs-2"
             />
             <TekstKolonne
-                tekst={bruker.ensligeForsorgereOvergangsstonad?.vedtaksPeriodetype}
+                tekst={bruker.ensligeForsorgereOvergangsstonad?.vedtaksPeriodetype ?? '-'}
                 skalVises={valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_VEDTAKSPERIODE)}
                 className="col col-xs-2"
             />

--- a/src/minoversikt/minoversikt-kolonner.tsx
+++ b/src/minoversikt/minoversikt-kolonner.tsx
@@ -155,9 +155,7 @@ function MinoversiktDatokolonner({bruker, enhetId, filtervalg, valgteKolonner}: 
                 className="col col-xs-2"
                 skalVises={valgteKolonner.includes(Kolonne.STATSBORGERSKAP_GYLDIG_FRA)}
                 tekst={
-                    bruker.hovedStatsborgerskap?.gyldigFra
-                        ? toDateString(bruker.hovedStatsborgerskap.gyldigFra)!.toString()
-                        : '-'
+                    bruker.hovedStatsborgerskap?.gyldigFra ? toDateString(bruker.hovedStatsborgerskap.gyldigFra) : '-'
                 }
             />
             <TekstKolonne
@@ -173,7 +171,7 @@ function MinoversiktDatokolonner({bruker, enhetId, filtervalg, valgteKolonner}: 
             <TekstKolonne
                 className="col col-xs-2"
                 skalVises={valgteKolonner.includes(Kolonne.TOLKEBEHOV_SIST_OPPDATERT)}
-                tekst={bruker.tolkBehovSistOppdatert ? toDateString(bruker.tolkBehovSistOppdatert)!.toString() : '-'}
+                tekst={bruker.tolkBehovSistOppdatert ? toDateString(bruker.tolkBehovSistOppdatert) : '-'}
             />
             <TekstKolonne
                 className="col col-xs-2"
@@ -188,7 +186,7 @@ function MinoversiktDatokolonner({bruker, enhetId, filtervalg, valgteKolonner}: 
             <TekstKolonne
                 className="col col-xs-2"
                 skalVises={valgteKolonner.includes(Kolonne.BOSTED_SIST_OPPDATERT)}
-                tekst={bruker.bostedSistOppdatert ? toDateString(bruker.bostedSistOppdatert)!.toString() : '-'}
+                tekst={bruker.bostedSistOppdatert ? toDateString(bruker.bostedSistOppdatert) : '-'}
             />
             <DatoKolonne
                 className="col col-xs-2"

--- a/src/utils/dato-utils.ts
+++ b/src/utils/dato-utils.ts
@@ -54,7 +54,7 @@ export function toDatePrettyPrint(dato): Maybe<string> {
     return `${days}.${months}.${years}`;
 }
 
-export const toDateString = dato =>
+export const toDateString = (dato): string =>
     new Date(dato).toLocaleDateString(['nb-no', 'nn-no', 'en-gb', 'en-us'], {
         day: '2-digit',
         month: '2-digit',

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -75,7 +75,7 @@ export function ytelsestypetekst(brukerytelse: string) {
         return 'Ordinær';
     } else if (brukerytelse === 'AAP_UNNTAK') {
         return 'Unntak';
-    }
+    } else return '-';
 }
 
 export function aapVurderingsfrist(
@@ -186,7 +186,7 @@ export function tolkBehovSpraak(
     filtervalg: FiltervalgModell,
     bruker: BrukerModell,
     tolkbehovSpraakData: Map<string, string>
-) {
+): string {
     const behovSpraak: string[] = [];
     let leggTilSpraak = leggTilSpraakInfo(filtervalg);
 
@@ -262,7 +262,7 @@ export function capitalize(str: string) {
         .replace(/(^|[^a-z\u00C0-\u017F\u0400-\u04FF'])([a-z\u00C0-\u017F\u0400-\u04FF])/g, s => s.toUpperCase());
 }
 
-export function bostedKommune(bruker: BrukerModell, geografiskbostedData) {
+export function bostedKommuneUtlandEllerUkjent(bruker: BrukerModell, geografiskbostedData) {
     if (bruker.bostedKommune) {
         return geografiskbostedData.get(bruker.bostedKommune);
     }
@@ -274,6 +274,10 @@ export function bostedKommune(bruker: BrukerModell, geografiskbostedData) {
     }
     return '-';
 }
+
+export const bostedBydelEllerUkjent = (bostedBydel: string, geografiskbostedData: Map<string, string>): string => {
+    return geografiskbostedData.get(bostedBydel) || 'Ukjent';
+};
 
 export const mapOmAktivitetsPlikt = (aktivitetsplikt?: boolean): string => {
     if (aktivitetsplikt === undefined) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -276,7 +276,7 @@ export function bostedKommuneUtlandEllerUkjent(bruker: BrukerModell, geografiskb
 }
 
 export const bostedBydelEllerUkjent = (bostedBydel: string, geografiskbostedData: Map<string, string>): string => {
-    return geografiskbostedData.get(bostedBydel) || 'Ukjent';
+    return geografiskbostedData.get(bostedBydel) ?? '–';
 };
 
 export const mapOmAktivitetsPlikt = (aktivitetsplikt?: boolean): string => {


### PR DESCRIPTION
Eit forsøk på å minske sannsynlegheita for at vi manglar celler i "tabellen" i oversikten, fordi dei ikkje har tekst å vise.

Vi har sett feil i dev før der det tilsynelatande vert returnert `null` i staden for å returnere ei tom celle når cella ikkje får inputtekst.


Kva er gjort:
Det er no obligatorisk å sende inn ein streng i tekst-celler. Strengen kan vere data, eller `"-"` dersom det ikkje er noko tekst å vise.