### PR TITLE
Rydd i filter-koden slik at den vert lettare å lese

### DIFF
--- a/src/filtrering/filter-konstanter.ts
+++ b/src/filtrering/filter-konstanter.ts
@@ -1,5 +1,5 @@
 import {lag2Sifret, range} from '../utils/utils';
-import {FargekategoriModell, Fargekategorinavn, KategoriModell, Sorteringsfelt} from '../model-interfaces';
+import {FargekategoriModell, Fargekategorinavn, Sorteringsfelt} from '../model-interfaces';
 import {Dictionary} from '../utils/types/types';
 
 const skjemaelementInnrykkKlasse = 'skjemaelement--innrykk';
@@ -11,7 +11,7 @@ export type CheckboxFilter = {
 };
 export type CheckboxFilterMap = Dictionary<CheckboxFilter> | Dictionary<string>;
 
-/* Konstantar for filternamna brukt i OpenSearch (og som vert mappa i mapFilternavnTilFilterValue) */
+/* Konstantar for filternamna brukt i OpenSearch */
 export const UFORDELTE_BRUKERE = 'UFORDELTE_BRUKERE';
 export const NYE_BRUKERE_FOR_VEILEDER = 'NYE_BRUKERE_FOR_VEILEDER';
 export const TRENGER_VURDERING = 'TRENGER_VURDERING';
@@ -26,6 +26,12 @@ export const I_AVTALT_AKTIVITET = 'I_AVTALT_AKTIVITET';
 export const INAKTIVE_BRUKERE = 'INAKTIVE_BRUKERE';
 export const MIN_ARBEIDSLISTE = 'MIN_ARBEIDSLISTE';
 export const UTLOP_YTELSE = 'UTLOP_YTELSE';
+export const DAGPENGER_YTELSE = 'DAGPENGER';
+export const DAGPENGER_YTELSE_ORDINARE = 'ORDINARE_DAGPENGER';
+export const DAGPENGER_YTELSE_PERMITTERING = 'DAGPENGER_MED_PERMITTERING';
+export const DAGPENGER_YTELSE_PERMITTERING_FISKEINDUSTRI = 'DAGPENGER_MED_PERMITTERING_FISKEINDUSTRI';
+export const DAGPENGER_YTELSE_LONNSGARANTIMIDLER = 'LONNSGARANTIMIDLER_DAGPENGER';
+export const TILTAKSPENGER_YTELSE = 'TILTAKSPENGER';
 export const AAP_YTELSE = 'AAP';
 export const AAP_YTELSE_MAXTID = 'AAP_MAXTID';
 export const AAP_YTELSE_UNNTAK = 'AAP_UNNTAK';
@@ -47,14 +53,6 @@ export const FARGEKATEGORI_E = FargekategoriModell.FARGEKATEGORI_E;
 export const FARGEKATEGORI_F = FargekategoriModell.FARGEKATEGORI_F;
 export const INGEN_KATEGORI = FargekategoriModell.INGEN_KATEGORI;
 
-/* Konstantar for filternamna brukt i OpenSearch (ikkje mappa i mapFilternavnTilFilterValue) */
-export const DAGPENGER_YTELSE = 'DAGPENGER';
-export const DAGPENGER_YTELSE_ORDINARE = 'ORDINARE_DAGPENGER';
-export const DAGPENGER_YTELSE_PERMITTERING = 'DAGPENGER_MED_PERMITTERING';
-export const DAGPENGER_YTELSE_PERMITTERING_FISKEINDUSTRI = 'DAGPENGER_MED_PERMITTERING_FISKEINDUSTRI';
-export const DAGPENGER_YTELSE_LONNSGARANTIMIDLER = 'LONNSGARANTIMIDLER_DAGPENGER';
-export const TILTAKSPENGER_YTELSE = 'TILTAKSPENGER';
-
 export const alleFargekategoriFilterAlternativer = [
     FARGEKATEGORI_A,
     FARGEKATEGORI_B,
@@ -64,60 +62,6 @@ export const alleFargekategoriFilterAlternativer = [
     FARGEKATEGORI_F,
     INGEN_KATEGORI
 ] as const;
-
-/**
- * Dette objektet mappar:
- *      - eit sett nøklar
- *     til
- *      - eit sett konstantar som kodar for kva filtera heiter i OpenSearch
- *
- * Ikkje alle OpenSearch-konstantane er gjenbrukt i denne mappinga per 2024-10-30.
- *
- * Objektet får inn ein hardkoda streng frå filtrering-status.tsx og mappar det om til filterverdi.
- * (I staden for å berre sende inn filter-konstantane direkte.)
- *
- * Den vert også brukt til å lage enkelte av filter-til-label-mapparane.
- * */
-export const mapFilternavnTilFilterValue = {
-    ufordeltebruker: UFORDELTE_BRUKERE,
-    nyeBrukere: NYE_BRUKERE_FOR_VEILEDER,
-    trengerVurdering: TRENGER_VURDERING,
-    erSykmeldtMedArbeidsgiver: ER_SYKMELDT_MED_ARBEIDSGIVER,
-    venterPaSvarFraNAV: VENTER_PA_SVAR_FRA_NAV,
-    venterPaSvarFraBruker: VENTER_PA_SVAR_FRA_BRUKER,
-    avtaltMoteMedNav: MOTER_IDAG,
-    tiltakshendelser: TILTAKSHENDELSER,
-    utlopteAktiviteter: UTLOPTE_AKTIVITETER,
-    ikkeIavtaltAktivitet: IKKE_I_AVTALT_AKTIVITET,
-    iavtaltAktivitet: I_AVTALT_AKTIVITET,
-    inaktiveBrukere: INAKTIVE_BRUKERE,
-    minArbeidsliste: MIN_ARBEIDSLISTE,
-    minArbeidslisteBla: KategoriModell.BLA,
-    minArbeidslisteLilla: KategoriModell.LILLA,
-    minArbeidslisteGronn: KategoriModell.GRONN,
-    minArbeidslisteGul: KategoriModell.GUL,
-    utlopYtelse: UTLOP_YTELSE,
-    aapYtelse: AAP_YTELSE,
-    aapYtelseMaxtid: AAP_YTELSE_MAXTID,
-    aapYtelseUnntak: AAP_YTELSE_UNNTAK,
-    underVurdering: UNDER_VURDERING,
-    sisteEndring: SISTE_ENDRING,
-    sisteEndringDato: SISTE_ENDRING_DATO,
-    harAvvik: HAR_AVVIK,
-    hovedmalUlik: HOVEDMAL_ULIK,
-    innsatsgruppeUlik: INNSATSGRUPPE_ULIK,
-    innsatsgruppeOgHovedmalUlik: INNSATSGRUPPE_OG_HOVEDMAL_ULIK,
-    innsatsgruppeManglerINyKilde: INNSATSGRUPPE_MANGLER_I_NY_KILDE,
-    huskelapp: HUSKELAPP,
-    mineFargekategorier: MINE_FARGEKATEGORIER,
-    mineFargekategorierA: FARGEKATEGORI_A,
-    mineFargekategorierB: FARGEKATEGORI_B,
-    mineFargekategorierC: FARGEKATEGORI_C,
-    mineFargekategorierD: FARGEKATEGORI_D,
-    mineFargekategorierE: FARGEKATEGORI_E,
-    mineFargekategorierF: FARGEKATEGORI_F,
-    mineFargekategorierIngenKategori: INGEN_KATEGORI
-};
 
 export const filterSomIkkeSkalSendesTilBackend = [HAR_AVVIK, MINE_FARGEKATEGORIER];
 

--- a/src/filtrering/filter-konstanter.ts
+++ b/src/filtrering/filter-konstanter.ts
@@ -454,7 +454,7 @@ export const avvik14aVedtak = {
     ...avvik14aVedtakAvhengigeFilter
 };
 
-const filterKonstanter = {
+export const filterKonstanter = {
     ytelseUtlopsSortering,
     ferdigfilterListe: ferdigfilterListeLabelTekst,
     alder,
@@ -488,5 +488,3 @@ const filterKonstanter = {
     barnUnder18Aar,
     fargekategorier
 };
-
-export default filterKonstanter;

--- a/src/filtrering/filter-konstanter.ts
+++ b/src/filtrering/filter-konstanter.ts
@@ -119,10 +119,7 @@ export const mapFilternavnTilFilterValue = {
     mineFargekategorierIngenKategori: INGEN_KATEGORI
 };
 
-export const filterSomIkkeSkalSendesTilBackend = [
-    mapFilternavnTilFilterValue.harAvvik,
-    mapFilternavnTilFilterValue.mineFargekategorier
-];
+export const filterSomIkkeSkalSendesTilBackend = [HAR_AVVIK, MINE_FARGEKATEGORIER];
 
 export function lagConfig(data: any): any {
     if (typeof data === 'string') {

--- a/src/filtrering/filter-konstanter.ts
+++ b/src/filtrering/filter-konstanter.ts
@@ -131,23 +131,28 @@ export function lagConfig(data: any): any {
     return data;
 }
 
+/** Mappar filternamn i OpenSearch til filterlabel for filter i ferdigFilterListe
+ *
+ * Notasjonen [konstantnamn] hentar ut verdien i konstanten og gjer det
+ * lettare å finne ut kvar verdien av konstanten har blitt brukt.
+ * */
 export const ferdigfilterListeLabelTekst = {
-    UFORDELTE_BRUKERE: 'Ufordelte brukere',
-    NYE_BRUKERE_FOR_VEILEDER: 'Nye brukere',
-    TRENGER_VURDERING: 'Trenger vurdering',
-    ER_SYKMELDT_MED_ARBEIDSGIVER: 'Sykmeldt med arbeidsgiver',
-    UNDER_VURDERING: 'Under vurdering',
-    VENTER_PA_SVAR_FRA_NAV: 'Venter på svar fra NAV',
-    VENTER_PA_SVAR_FRA_BRUKER: 'Venter på svar fra bruker',
-    MOTER_IDAG: 'Møte med NAV i dag',
-    TILTAKSHENDELSER: 'Hendelser på tiltak',
-    UTLOPTE_AKTIVITETER: 'Utløpte aktiviteter',
-    IKKE_I_AVTALT_AKTIVITET: 'Ikke i avtalt aktivitet',
-    I_AVTALT_AKTIVITET: 'I avtalt aktivitet',
-    INAKTIVE_BRUKERE: 'Ikke servicebehov',
-    MIN_ARBEIDSLISTE: 'Min arbeidsliste',
-    MINE_HUSKELAPPER: 'Huskelapper',
-    MINE_FARGEKATEGORIER: 'Kategorier'
+    [UFORDELTE_BRUKERE]: 'Ufordelte brukere',
+    [NYE_BRUKERE_FOR_VEILEDER]: 'Nye brukere',
+    [TRENGER_VURDERING]: 'Trenger vurdering',
+    [ER_SYKMELDT_MED_ARBEIDSGIVER]: 'Sykmeldt med arbeidsgiver',
+    [VENTER_PA_SVAR_FRA_NAV]: 'Venter på svar fra NAV',
+    [VENTER_PA_SVAR_FRA_BRUKER]: 'Venter på svar fra bruker',
+    [MOTER_IDAG]: 'Møte med NAV i dag',
+    [TILTAKSHENDELSER]: 'Hendelser på tiltak',
+    [UTLOPTE_AKTIVITETER]: 'Utløpte aktiviteter',
+    [IKKE_I_AVTALT_AKTIVITET]: 'Ikke i avtalt aktivitet',
+    [I_AVTALT_AKTIVITET]: 'I avtalt aktivitet',
+    [INAKTIVE_BRUKERE]: 'Ikke servicebehov',
+    [MIN_ARBEIDSLISTE]: 'Min arbeidsliste',
+    [UNDER_VURDERING]: 'Under vurdering',
+    [HUSKELAPP]: 'Huskelapper',
+    [MINE_FARGEKATEGORIER]: 'Kategorier'
 };
 
 export const arbeidslisteKategori = {
@@ -430,20 +435,20 @@ export const hendelserEtikett = {
 };
 
 export const avvik14aVedtakHovedFilter = {
-    [mapFilternavnTilFilterValue.harAvvik]: {label: 'Status'}
+    [HAR_AVVIK]: {label: 'Status'}
 };
 
 export const avvik14aVedtakAvhengigeFilter = {
-    [mapFilternavnTilFilterValue.hovedmalUlik]: {label: 'Hovedmål ulikt', className: skjemaelementInnrykkKlasse},
-    [mapFilternavnTilFilterValue.innsatsgruppeUlik]: {
+    [HOVEDMAL_ULIK]: {label: 'Hovedmål ulikt', className: skjemaelementInnrykkKlasse},
+    [INNSATSGRUPPE_ULIK]: {
         label: 'Innsatsgruppe ulik',
         className: skjemaelementInnrykkKlasse
     },
-    [mapFilternavnTilFilterValue.innsatsgruppeOgHovedmalUlik]: {
+    [INNSATSGRUPPE_OG_HOVEDMAL_ULIK]: {
         label: 'Innsatsgruppe og hovedmål ulike',
         className: skjemaelementInnrykkKlasse
     },
-    [mapFilternavnTilFilterValue.innsatsgruppeManglerINyKilde]: {
+    [INNSATSGRUPPE_MANGLER_I_NY_KILDE]: {
         label: 'Innsatsgruppe mangler',
         className: skjemaelementInnrykkKlasse
     }

--- a/src/filtrering/filter-konstanter.ts
+++ b/src/filtrering/filter-konstanter.ts
@@ -11,29 +11,24 @@ export type CheckboxFilter = {
 };
 export type CheckboxFilterMap = Dictionary<CheckboxFilter> | Dictionary<string>;
 
+/* Konstantar for filternamna brukt i OpenSearch (og som vert mappa i mapFilternavnTilFilterValue) */
 export const UFORDELTE_BRUKERE = 'UFORDELTE_BRUKERE';
 export const NYE_BRUKERE_FOR_VEILEDER = 'NYE_BRUKERE_FOR_VEILEDER';
 export const TRENGER_VURDERING = 'TRENGER_VURDERING';
-export const INAKTIVE_BRUKERE = 'INAKTIVE_BRUKERE';
+export const ER_SYKMELDT_MED_ARBEIDSGIVER = 'ER_SYKMELDT_MED_ARBEIDSGIVER';
 export const VENTER_PA_SVAR_FRA_NAV = 'VENTER_PA_SVAR_FRA_NAV';
 export const VENTER_PA_SVAR_FRA_BRUKER = 'VENTER_PA_SVAR_FRA_BRUKER';
+export const MOTER_IDAG = 'MOTER_IDAG';
+export const TILTAKSHENDELSER = 'TILTAKSHENDELSER';
 export const UTLOPTE_AKTIVITETER = 'UTLOPTE_AKTIVITETER';
 export const IKKE_I_AVTALT_AKTIVITET = 'IKKE_I_AVTALT_AKTIVITET';
 export const I_AVTALT_AKTIVITET = 'I_AVTALT_AKTIVITET';
+export const INAKTIVE_BRUKERE = 'INAKTIVE_BRUKERE';
 export const MIN_ARBEIDSLISTE = 'MIN_ARBEIDSLISTE';
-export const ER_SYKMELDT_MED_ARBEIDSGIVER = 'ER_SYKMELDT_MED_ARBEIDSGIVER';
-export const MOTER_IDAG = 'MOTER_IDAG';
-export const TILTAKSHENDELSER = 'TILTAKSHENDELSER';
 export const UTLOP_YTELSE = 'UTLOP_YTELSE';
-export const DAGPENGER_YTELSE = 'DAGPENGER';
-export const DAGPENGER_YTELSE_ORDINARE = 'ORDINARE_DAGPENGER';
-export const DAGPENGER_YTELSE_PERMITTERING = 'DAGPENGER_MED_PERMITTERING';
-export const DAGPENGER_YTELSE_PERMITTERING_FISKEINDUSTRI = 'DAGPENGER_MED_PERMITTERING_FISKEINDUSTRI';
-export const DAGPENGER_YTELSE_LONNSGARANTIMIDLER = 'LONNSGARANTIMIDLER_DAGPENGER';
 export const AAP_YTELSE = 'AAP';
 export const AAP_YTELSE_MAXTID = 'AAP_MAXTID';
 export const AAP_YTELSE_UNNTAK = 'AAP_UNNTAK';
-export const TILTAKSPENGER_YTELSE = 'TILTAKSPENGER';
 export const UNDER_VURDERING = 'UNDER_VURDERING';
 export const SISTE_ENDRING = 'SISTE_ENDRING';
 export const SISTE_ENDRING_DATO = 'SISTE_ENDRING_DATO';
@@ -51,6 +46,15 @@ export const FARGEKATEGORI_D = FargekategoriModell.FARGEKATEGORI_D;
 export const FARGEKATEGORI_E = FargekategoriModell.FARGEKATEGORI_E;
 export const FARGEKATEGORI_F = FargekategoriModell.FARGEKATEGORI_F;
 export const INGEN_KATEGORI = FargekategoriModell.INGEN_KATEGORI;
+
+/* Konstantar for filternamna brukt i OpenSearch (ikkje mappa i mapFilternavnTilFilterValue) */
+export const DAGPENGER_YTELSE = 'DAGPENGER';
+export const DAGPENGER_YTELSE_ORDINARE = 'ORDINARE_DAGPENGER';
+export const DAGPENGER_YTELSE_PERMITTERING = 'DAGPENGER_MED_PERMITTERING';
+export const DAGPENGER_YTELSE_PERMITTERING_FISKEINDUSTRI = 'DAGPENGER_MED_PERMITTERING_FISKEINDUSTRI';
+export const DAGPENGER_YTELSE_LONNSGARANTIMIDLER = 'LONNSGARANTIMIDLER_DAGPENGER';
+export const TILTAKSPENGER_YTELSE = 'TILTAKSPENGER';
+
 export const alleFargekategoriFilterAlternativer = [
     FARGEKATEGORI_A,
     FARGEKATEGORI_B,
@@ -61,6 +65,19 @@ export const alleFargekategoriFilterAlternativer = [
     INGEN_KATEGORI
 ] as const;
 
+/**
+ * Dette objektet mappar:
+ *      - eit sett nøklar
+ *     til
+ *      - eit sett konstantar som kodar for kva filtera heiter i OpenSearch
+ *
+ * Ikkje alle OpenSearch-konstantane er gjenbrukt i denne mappinga per 2024-10-30.
+ *
+ * Objektet får inn ein hardkoda streng frå filtrering-status.tsx og mappar det om til filterverdi.
+ * (I staden for å berre sende inn filter-konstantane direkte.)
+ *
+ * Den vert også brukt til å lage enkelte av filter-til-label-mapparane.
+ * */
 export const mapFilternavnTilFilterValue = {
     ufordeltebruker: UFORDELTE_BRUKERE,
     nyeBrukere: NYE_BRUKERE_FOR_VEILEDER,

--- a/src/filtrering/filtrering-filter/filtrering-filter.tsx
+++ b/src/filtrering/filtrering-filter/filtrering-filter.tsx
@@ -11,11 +11,11 @@ import {
     ensligeForsorgere,
     fodselsdagIMnd,
     formidlingsgruppe,
+    HAR_AVVIK,
     hovedmal,
     innsatsgruppe,
     kjonn,
     manuellBrukerStatus,
-    mapFilternavnTilFilterValue,
     registreringstype,
     rettighetsgruppe,
     servicegruppe,
@@ -71,7 +71,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
 
         return {
             ...avvik14aVedtak,
-            [mapFilternavnTilFilterValue.harAvvik]: {
+            [HAR_AVVIK]: {
                 ...avvik14aVedtak.HAR_AVVIK,
                 indeterminate: erIndeterminate()
             }
@@ -95,11 +95,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
             const filterForEndring: string[] = filtervalg.avvik14aVedtak;
             const filterEtterEndring: string[] = filterVerdi;
 
-            const hovedfilterEndring: FilterEndring = filterEndring(
-                mapFilternavnTilFilterValue.harAvvik,
-                filterForEndring,
-                filterEtterEndring
-            );
+            const hovedfilterEndring: FilterEndring = filterEndring(HAR_AVVIK, filterForEndring, filterEtterEndring);
 
             if (hovedfilterEndring === 'FJERNET') {
                 return endreFiltervalg(form, []);
@@ -117,12 +113,7 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                 return endreFiltervalg(form, []);
             }
 
-            return endreFiltervalg(
-                form,
-                filterVerdi.includes(mapFilternavnTilFilterValue.harAvvik)
-                    ? filterVerdi
-                    : [mapFilternavnTilFilterValue.harAvvik, ...filterVerdi]
-            );
+            return endreFiltervalg(form, filterVerdi.includes(HAR_AVVIK) ? filterVerdi : [HAR_AVVIK, ...filterVerdi]);
         };
     };
 

--- a/src/filtrering/filtrering-label-container.tsx
+++ b/src/filtrering/filtrering-label-container.tsx
@@ -3,11 +3,11 @@ import {useEffect} from 'react';
 import {connect, useDispatch} from 'react-redux';
 import FiltreringLabel from './filtrering-label';
 import {
-    filterKonstanter,
     aktiviteter,
     alleFargekategoriFilterAlternativer,
+    filterKonstanter,
+    HAR_AVVIK,
     hendelserEtikett,
-    mapFilternavnTilFilterValue,
     MINE_FARGEKATEGORIER
 } from './filter-konstanter';
 import {EnhetModell, FiltervalgModell} from '../model-interfaces';
@@ -259,7 +259,7 @@ function FiltreringLabelContainer({
                 });
             } else if (key === 'avvik14aVedtak') {
                 return value.map(singleValue => {
-                    if (singleValue === mapFilternavnTilFilterValue.harAvvik) {
+                    if (singleValue === HAR_AVVIK) {
                         return null;
                     }
 
@@ -270,7 +270,7 @@ function FiltreringLabelContainer({
                     const slettAvvik14aVedtakFilter = () => {
                         if (fjernAvvik14aHovedFilter) {
                             slettEnkelt(key, singleValue);
-                            slettEnkelt(key, mapFilternavnTilFilterValue.harAvvik);
+                            slettEnkelt(key, HAR_AVVIK);
                         } else {
                             slettEnkelt(key, singleValue);
                         }

--- a/src/filtrering/filtrering-label-container.tsx
+++ b/src/filtrering/filtrering-label-container.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import {useEffect} from 'react';
 import {connect, useDispatch} from 'react-redux';
 import FiltreringLabel from './filtrering-label';
-import FilterKonstanter, {
+import {
+    filterKonstanter,
     aktiviteter,
     alleFargekategoriFilterAlternativer,
     hendelserEtikett,
@@ -65,7 +66,7 @@ function FiltreringLabelContainer({
                     return (
                         <FiltreringLabel
                             key={`utdanningBestatt-${singleValue}`}
-                            label={`Utdanning bestått: ${FilterKonstanter[key][singleValue]}`}
+                            label={`Utdanning bestått: ${filterKonstanter[key][singleValue]}`}
                             slettFilter={() => slettEnkelt(key, singleValue)}
                         />
                     );
@@ -75,7 +76,7 @@ function FiltreringLabelContainer({
                     return (
                         <FiltreringLabel
                             key={`utdanningGodkjent-${singleValue}`}
-                            label={`Utdanning godkjent: ${FilterKonstanter[key][singleValue]}`}
+                            label={`Utdanning godkjent: ${filterKonstanter[key][singleValue]}`}
                             slettFilter={() => slettEnkelt(key, singleValue)}
                         />
                     );
@@ -86,7 +87,7 @@ function FiltreringLabelContainer({
                         return (
                             <FiltreringLabel
                                 key={`utdanning-${singleValue}`}
-                                label={`Utdanning: ${FilterKonstanter[key][singleValue].label}`}
+                                label={`Utdanning: ${filterKonstanter[key][singleValue].label}`}
                                 slettFilter={() => slettEnkelt(key, singleValue)}
                             />
                         );
@@ -94,7 +95,7 @@ function FiltreringLabelContainer({
                     return (
                         <FiltreringLabel
                             key={`utdanning-${singleValue}`}
-                            label={FilterKonstanter[key][singleValue]}
+                            label={filterKonstanter[key][singleValue]}
                             slettFilter={() => slettEnkelt(key, singleValue)}
                         />
                     );
@@ -105,7 +106,7 @@ function FiltreringLabelContainer({
                         return (
                             <FiltreringLabel
                                 key={`situasjon-${singleValue}`}
-                                label={`Situasjon: ${FilterKonstanter[key][singleValue].label}`}
+                                label={`Situasjon: ${filterKonstanter[key][singleValue].label}`}
                                 slettFilter={() => slettEnkelt(key, singleValue)}
                             />
                         );
@@ -113,7 +114,7 @@ function FiltreringLabelContainer({
                     return (
                         <FiltreringLabel
                             key={`situasjon-${singleValue}`}
-                            label={FilterKonstanter[key][singleValue]}
+                            label={filterKonstanter[key][singleValue]}
                             slettFilter={() => slettEnkelt(key, singleValue)}
                         />
                     );
@@ -143,7 +144,7 @@ function FiltreringLabelContainer({
                     return (
                         <FiltreringLabel
                             key={`${key}--${singleValue.key || singleValue}`}
-                            label={FilterKonstanter[key][singleValue] || singleValue + ' år'}
+                            label={filterKonstanter[key][singleValue] || singleValue + ' år'}
                             slettFilter={() => slettEnkelt(key, singleValue.key || singleValue)}
                         />
                     );
@@ -155,13 +156,13 @@ function FiltreringLabelContainer({
                             key={singleValue}
                             label={
                                 erFargekategoriFeatureTogglePa
-                                    ? FilterKonstanter.arbeidslisteKategoriGammel[singleValue]
-                                    : FilterKonstanter.arbeidslisteKategori[singleValue]
+                                    ? filterKonstanter.arbeidslisteKategoriGammel[singleValue]
+                                    : filterKonstanter.arbeidslisteKategori[singleValue]
                             }
                             slettFilter={() => slettEnkelt(key, singleValue)}
                             ikon={<ArbeidslistekategoriVisning kategori={singleValue} />}
                             tittel={
-                                `Fjern filtervalg "Arbeidslistekategori ${FilterKonstanter.arbeidslisteKategori[singleValue]}"` +
+                                `Fjern filtervalg "Arbeidslistekategori ${filterKonstanter.arbeidslisteKategori[singleValue]}"` +
                                 (erFargekategoriFeatureTogglePa ? ' (gammel)' : '')
                             }
                         />
@@ -172,10 +173,10 @@ function FiltreringLabelContainer({
                     return (
                         <FiltreringLabelMedIkon
                             key={singleValue}
-                            label={FilterKonstanter.fargekategorier[singleValue]}
+                            label={filterKonstanter.fargekategorier[singleValue]}
                             slettFilter={() => slettEnkelt(key, singleValue)}
                             ikon={fargekategoriIkonMapper(singleValue, 'fargekategoriikon')}
-                            tittel={`Fjern filtervalg "Kategori ${FilterKonstanter.fargekategorier[singleValue]}"`}
+                            tittel={`Fjern filtervalg "Kategori ${filterKonstanter.fargekategorier[singleValue]}"`}
                         />
                     );
                 });
@@ -224,7 +225,7 @@ function FiltreringLabelContainer({
                 return [
                     <FiltreringLabel
                         key={key}
-                        label={FilterKonstanter[key]}
+                        label={filterKonstanter[key]}
                         slettFilter={() => slettEnkelt(key, false)}
                     />
                 ];
@@ -288,7 +289,7 @@ function FiltreringLabelContainer({
                     return (
                         <FiltreringLabel
                             key={`${key}--${singleValue}`}
-                            label={`${FilterKonstanter[key][singleValue]}`}
+                            label={`${filterKonstanter[key][singleValue]}`}
                             slettFilter={() => slettEnkelt(key, singleValue)}
                         />
                     );
@@ -320,7 +321,7 @@ function FiltreringLabelContainer({
                     .map(([aktivitetkey, aktivitetvalue]) => (
                         <FiltreringLabel
                             key={`aktivitet-${aktivitetkey}`}
-                            label={`${FilterKonstanter[key][aktivitetkey]}: ${aktivitetvalue}`}
+                            label={`${filterKonstanter[key][aktivitetkey]}: ${aktivitetvalue}`}
                             slettFilter={() => slettEnkelt(key, aktivitetkey)}
                         />
                     ));
@@ -335,7 +336,7 @@ function FiltreringLabelContainer({
                 return [
                     <FiltreringLabel
                         key={`${key}--${value}`}
-                        label={FilterKonstanter[key][value]}
+                        label={filterKonstanter[key][value]}
                         slettFilter={() => slettEnkelt(key, null)}
                     />
                 ];
@@ -408,11 +409,11 @@ function getLabel(singleValue: any, key: any, enhettiltak: any): string {
     if (singleValue?.label) {
         return singleValue.label;
     }
-    if (FilterKonstanter[key]?.[singleValue]) {
-        return FilterKonstanter[key][singleValue];
+    if (filterKonstanter[key]?.[singleValue]) {
+        return filterKonstanter[key][singleValue];
     }
-    if (FilterKonstanter[singleValue]) {
-        return FilterKonstanter[singleValue];
+    if (filterKonstanter[singleValue]) {
+        return filterKonstanter[singleValue];
     }
     return singleValue;
 }

--- a/src/filtrering/filtrering-status/arbeidsliste.tsx
+++ b/src/filtrering/filtrering-status/arbeidsliste.tsx
@@ -43,11 +43,11 @@ function FilterStatusMinArbeidsliste({
                 filterNavn="minArbeidsliste"
                 handleChange={handleChange}
                 antall={statusTall.minArbeidsliste}
-                filterVerdi={mapFilternavnTilFilterValue['minArbeidsliste']}
+                filterVerdi={mapFilternavnTilFilterValue.minArbeidsliste}
                 labelTekst={
                     erHuskelappFeatureTogglePa
                         ? 'Gamle arbeidslister'
-                        : ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue['minArbeidsliste']]
+                        : ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.minArbeidsliste]
                 }
             />
             {checked && (
@@ -69,7 +69,7 @@ function FilterStatusMinArbeidsliste({
                         handleChange={handleChangeCheckbox}
                         checked={checked && ferdigfilterListe.includes(KategoriModell.BLA)}
                         antall={statusTall.minArbeidslisteBla}
-                        filterVerdi={mapFilternavnTilFilterValue['minArbeidslisteBla']}
+                        filterVerdi={mapFilternavnTilFilterValue.minArbeidslisteBla}
                     />
                     <BarInputCheckbox
                         labelTekst={
@@ -88,7 +88,7 @@ function FilterStatusMinArbeidsliste({
                         handleChange={handleChangeCheckbox}
                         checked={checked && ferdigfilterListe.includes(KategoriModell.GRONN)}
                         antall={statusTall.minArbeidslisteGronn}
-                        filterVerdi={mapFilternavnTilFilterValue['minArbeidslisteGronn']}
+                        filterVerdi={mapFilternavnTilFilterValue.minArbeidslisteGronn}
                     />
                     <BarInputCheckbox
                         labelTekst={
@@ -107,7 +107,7 @@ function FilterStatusMinArbeidsliste({
                         handleChange={handleChangeCheckbox}
                         checked={checked && ferdigfilterListe.includes(KategoriModell.GUL)}
                         antall={statusTall.minArbeidslisteGul}
-                        filterVerdi={mapFilternavnTilFilterValue['minArbeidslisteGul']}
+                        filterVerdi={mapFilternavnTilFilterValue.minArbeidslisteGul}
                     />
                     <BarInputCheckbox
                         labelTekst={
@@ -126,7 +126,7 @@ function FilterStatusMinArbeidsliste({
                         handleChange={handleChangeCheckbox}
                         checked={checked && ferdigfilterListe.includes(KategoriModell.LILLA)}
                         antall={statusTall.minArbeidslisteLilla}
-                        filterVerdi={mapFilternavnTilFilterValue['minArbeidslisteLilla']}
+                        filterVerdi={mapFilternavnTilFilterValue.minArbeidslisteLilla}
                     />
                 </div>
             )}

--- a/src/filtrering/filtrering-status/arbeidsliste.tsx
+++ b/src/filtrering/filtrering-status/arbeidsliste.tsx
@@ -5,7 +5,7 @@ import {useStatustallVeilederSelector} from '../../hooks/redux/use-statustall';
 import {KategoriModell} from '../../model-interfaces';
 import {BarInputRadio} from '../../components/barinput/barinput-radio';
 import BarInputCheckbox from '../../components/barinput/barinput-checkbox';
-import {ferdigfilterListeLabelTekst, mapFilternavnTilFilterValue} from '../filter-konstanter';
+import {ferdigfilterListeLabelTekst, MIN_ARBEIDSLISTE} from '../filter-konstanter';
 import {useFeatureSelector} from '../../hooks/redux/use-feature-selector';
 import {HUSKELAPP, SKJUL_ARBEIDSLISTEFUNKSJONALITET} from '../../konstanter';
 import {ReactComponent as FargekategoriIkonBlaHalvsirkel} from '../../components/ikoner/fargekategorier/Fargekategoriikon_bla_halvsirkel.svg';
@@ -43,11 +43,9 @@ function FilterStatusMinArbeidsliste({
                 filterNavn="minArbeidsliste"
                 handleChange={handleChange}
                 antall={statusTall.minArbeidsliste}
-                filterVerdi={mapFilternavnTilFilterValue.minArbeidsliste}
+                filterVerdi={MIN_ARBEIDSLISTE}
                 labelTekst={
-                    erHuskelappFeatureTogglePa
-                        ? 'Gamle arbeidslister'
-                        : ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.minArbeidsliste]
+                    erHuskelappFeatureTogglePa ? 'Gamle arbeidslister' : ferdigfilterListeLabelTekst[MIN_ARBEIDSLISTE]
                 }
             />
             {checked && (
@@ -69,7 +67,7 @@ function FilterStatusMinArbeidsliste({
                         handleChange={handleChangeCheckbox}
                         checked={checked && ferdigfilterListe.includes(KategoriModell.BLA)}
                         antall={statusTall.minArbeidslisteBla}
-                        filterVerdi={mapFilternavnTilFilterValue.minArbeidslisteBla}
+                        filterVerdi={KategoriModell.BLA}
                     />
                     <BarInputCheckbox
                         labelTekst={
@@ -88,7 +86,7 @@ function FilterStatusMinArbeidsliste({
                         handleChange={handleChangeCheckbox}
                         checked={checked && ferdigfilterListe.includes(KategoriModell.GRONN)}
                         antall={statusTall.minArbeidslisteGronn}
-                        filterVerdi={mapFilternavnTilFilterValue.minArbeidslisteGronn}
+                        filterVerdi={KategoriModell.GRONN}
                     />
                     <BarInputCheckbox
                         labelTekst={
@@ -107,7 +105,7 @@ function FilterStatusMinArbeidsliste({
                         handleChange={handleChangeCheckbox}
                         checked={checked && ferdigfilterListe.includes(KategoriModell.GUL)}
                         antall={statusTall.minArbeidslisteGul}
-                        filterVerdi={mapFilternavnTilFilterValue.minArbeidslisteGul}
+                        filterVerdi={KategoriModell.GUL}
                     />
                     <BarInputCheckbox
                         labelTekst={
@@ -126,7 +124,7 @@ function FilterStatusMinArbeidsliste({
                         handleChange={handleChangeCheckbox}
                         checked={checked && ferdigfilterListe.includes(KategoriModell.LILLA)}
                         antall={statusTall.minArbeidslisteLilla}
-                        filterVerdi={mapFilternavnTilFilterValue.minArbeidslisteLilla}
+                        filterVerdi={KategoriModell.LILLA}
                     />
                 </div>
             )}

--- a/src/filtrering/filtrering-status/fargekategori.tsx
+++ b/src/filtrering/filtrering-status/fargekategori.tsx
@@ -13,7 +13,6 @@ import {
     fargekategorier,
     ferdigfilterListeLabelTekst,
     INGEN_KATEGORI,
-    mapFilternavnTilFilterValue,
     MINE_FARGEKATEGORIER
 } from '../filter-konstanter';
 import {usePortefoljeSelector} from '../../hooks/redux/use-portefolje-selector';
@@ -56,16 +55,16 @@ export const fargekategoriUnderfilterKonfigurasjoner: readonly FargekategoriUnde
         statustallId: 'fargekategoriD'
     },
     {
-        filterLabel: fargekategorier.FARGEKATEGORI_F,
-        filterId: FARGEKATEGORI_F,
-        filterNavn: 'mineFargekategorierF',
-        statustallId: 'fargekategoriF'
-    },
-    {
         filterLabel: fargekategorier.FARGEKATEGORI_E,
         filterId: FARGEKATEGORI_E,
         filterNavn: 'mineFargekategorierE',
         statustallId: 'fargekategoriE'
+    },
+    {
+        filterLabel: fargekategorier.FARGEKATEGORI_F,
+        filterId: FARGEKATEGORI_F,
+        filterNavn: 'mineFargekategorierF',
+        statustallId: 'fargekategoriF'
     },
     {
         filterLabel: fargekategorier.INGEN_KATEGORI,
@@ -109,7 +108,7 @@ function FilterStatusMineFargekategorier() {
                 checked={hovedfilterChecked}
                 labelTekst={ferdigfilterListeLabelTekst.MINE_FARGEKATEGORIER}
                 indeterminate={hovedfilterIndeterminate}
-                filterVerdi={mapFilternavnTilFilterValue.mineFargekategorier}
+                filterVerdi={MINE_FARGEKATEGORIER}
             />
             <div className="fargekategorier--underfilter">
                 {fargekategoriUnderfilterKonfigurasjoner.map(fargekategori => (
@@ -127,7 +126,7 @@ function FilterStatusMineFargekategorier() {
                         handleChange={handleUnderfilterEndret}
                         checked={fargekategoriFilter.includes(fargekategori.filterId)}
                         antall={statusTall[fargekategori.statustallId]}
-                        filterVerdi={mapFilternavnTilFilterValue[fargekategori.filterNavn]}
+                        filterVerdi={fargekategori.filterId}
                     />
                 ))}
             </div>

--- a/src/filtrering/filtrering-status/fargekategori.tsx
+++ b/src/filtrering/filtrering-status/fargekategori.tsx
@@ -109,7 +109,7 @@ function FilterStatusMineFargekategorier() {
                 checked={hovedfilterChecked}
                 labelTekst={ferdigfilterListeLabelTekst.MINE_FARGEKATEGORIER}
                 indeterminate={hovedfilterIndeterminate}
-                filterVerdi={mapFilternavnTilFilterValue['mineFargekategorier']}
+                filterVerdi={mapFilternavnTilFilterValue.mineFargekategorier}
             />
             <div className="fargekategorier--underfilter">
                 {fargekategoriUnderfilterKonfigurasjoner.map(fargekategori => (

--- a/src/filtrering/filtrering-status/filtrering-status.tsx
+++ b/src/filtrering/filtrering-status/filtrering-status.tsx
@@ -149,7 +149,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         handleChange={handleCheckboxChange}
                         checked={ferdigfilterListe.includes(NYE_BRUKERE_FOR_VEILEDER)}
                         labelTekst={'Nye brukere'}
-                        filterVerdi={mapFilternavnTilFilterValue['nyeBrukere']}
+                        filterVerdi={mapFilternavnTilFilterValue.nyeBrukere}
                     />
                 ) : (
                     <BarInputCheckbox
@@ -158,7 +158,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         handleChange={handleCheckboxChange}
                         checked={ferdigfilterListe.includes(UFORDELTE_BRUKERE)}
                         labelTekst={'Ufordelte brukere'}
-                        filterVerdi={mapFilternavnTilFilterValue['ufordeltebruker']}
+                        filterVerdi={mapFilternavnTilFilterValue.ufordeltebruker}
                     />
                 )}
             </div>
@@ -172,25 +172,23 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         filterNavn="trengerVurdering"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.trengerVurdering}
-                        filterVerdi={mapFilternavnTilFilterValue['trengerVurdering']}
-                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue['trengerVurdering']]}
+                        filterVerdi={mapFilternavnTilFilterValue.trengerVurdering}
+                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.trengerVurdering]}
                     />
                     <BarInputRadio
                         filterNavn="erSykmeldtMedArbeidsgiver"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.erSykmeldtMedArbeidsgiver}
-                        filterVerdi={mapFilternavnTilFilterValue['erSykmeldtMedArbeidsgiver']}
-                        labelTekst={
-                            ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue['erSykmeldtMedArbeidsgiver']]
-                        }
+                        filterVerdi={mapFilternavnTilFilterValue.erSykmeldtMedArbeidsgiver}
+                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.erSykmeldtMedArbeidsgiver]}
                     />
                     {erVedtaksStotteFeatureTogglePa && (
                         <BarInputRadio
                             filterNavn="underVurdering"
                             handleChange={handleRadioButtonChange}
                             antall={statustallMedBrukerinnsyn.underVurdering}
-                            filterVerdi={mapFilternavnTilFilterValue['underVurdering']}
-                            labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue['underVurdering']]}
+                            filterVerdi={mapFilternavnTilFilterValue.underVurdering}
+                            labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.underVurdering]}
                         />
                     )}
                 </div>
@@ -199,30 +197,30 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         filterNavn="venterPaSvarFraNAV"
                         antall={statustallMedBrukerinnsyn.venterPaSvarFraNAV}
                         handleChange={handleRadioButtonChange}
-                        filterVerdi={mapFilternavnTilFilterValue['venterPaSvarFraNAV']}
-                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue['venterPaSvarFraNAV']]}
+                        filterVerdi={mapFilternavnTilFilterValue.venterPaSvarFraNAV}
+                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.venterPaSvarFraNAV]}
                     />
                     <BarInputRadio
                         filterNavn="venterPaSvarFraBruker"
                         antall={statustallMedBrukerinnsyn.venterPaSvarFraBruker}
                         handleChange={handleRadioButtonChange}
-                        filterVerdi={mapFilternavnTilFilterValue['venterPaSvarFraBruker']}
-                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue['venterPaSvarFraBruker']]}
+                        filterVerdi={mapFilternavnTilFilterValue.venterPaSvarFraBruker}
+                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.venterPaSvarFraBruker]}
                     />
                     <BarInputRadio
                         filterNavn="avtaltMoteMedNav"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.moterMedNAVIdag}
-                        filterVerdi={mapFilternavnTilFilterValue['avtaltMoteMedNav']}
-                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue['avtaltMoteMedNav']]}
+                        filterVerdi={mapFilternavnTilFilterValue.avtaltMoteMedNav}
+                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.avtaltMoteMedNav]}
                     />
                     {erStatusfilterTiltakshendelseFeatureTogglePa && (
                         <BarInputRadio
                             filterNavn="tiltakshendelse"
                             handleChange={handleRadioButtonChange}
                             antall={statustallMedBrukerinnsyn.tiltakshendelser}
-                            filterVerdi={mapFilternavnTilFilterValue['tiltakshendelser']}
-                            labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue['tiltakshendelser']]}
+                            filterVerdi={mapFilternavnTilFilterValue.tiltakshendelser}
+                            labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.tiltakshendelser]}
                         />
                     )}
                 </div>
@@ -231,22 +229,22 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         filterNavn="utlopteAktiviteter"
                         antall={statustallMedBrukerinnsyn.utlopteAktiviteter}
                         handleChange={handleRadioButtonChange}
-                        filterVerdi={mapFilternavnTilFilterValue['utlopteAktiviteter']}
-                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue['utlopteAktiviteter']]}
+                        filterVerdi={mapFilternavnTilFilterValue.utlopteAktiviteter}
+                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.utlopteAktiviteter]}
                     />
                     <BarInputRadio
                         filterNavn="ikkeIavtaltAktivitet"
                         antall={statustallMedBrukerinnsyn.ikkeIavtaltAktivitet}
                         handleChange={handleRadioButtonChange}
-                        filterVerdi={mapFilternavnTilFilterValue['ikkeIavtaltAktivitet']}
-                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue['ikkeIavtaltAktivitet']]}
+                        filterVerdi={mapFilternavnTilFilterValue.ikkeIavtaltAktivitet}
+                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.ikkeIavtaltAktivitet]}
                     />
                     <BarInputRadio
                         filterNavn="iavtaltAktivitet"
                         antall={statustallMedBrukerinnsyn.iavtaltAktivitet}
                         handleChange={handleRadioButtonChange}
-                        filterVerdi={mapFilternavnTilFilterValue['iavtaltAktivitet']}
-                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue['iavtaltAktivitet']]}
+                        filterVerdi={mapFilternavnTilFilterValue.iavtaltAktivitet}
+                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.iavtaltAktivitet]}
                     />
                 </div>
                 <div className="forste-barlabel-i-gruppe">
@@ -254,8 +252,8 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         filterNavn="inaktiveBrukere"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.inaktiveBrukere}
-                        filterVerdi={mapFilternavnTilFilterValue['inaktiveBrukere']}
-                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue['inaktiveBrukere']]}
+                        filterVerdi={mapFilternavnTilFilterValue.inaktiveBrukere}
+                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.inaktiveBrukere]}
                     />
                 </div>
                 {oversiktType === OversiktType.minOversikt && (
@@ -293,8 +291,8 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                                 filterNavn="huskelapp"
                                 antall={statustallMedBrukerinnsyn.mineHuskelapper}
                                 handleChange={handleRadioButtonChange}
-                                filterVerdi={mapFilternavnTilFilterValue['huskelapp']}
-                                labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue['huskelapp']]}
+                                filterVerdi={mapFilternavnTilFilterValue.huskelapp}
+                                labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.huskelapp]}
                             />
                         )}
                         {!arbeidslistefunksjonalitetSkalVises && erHuskelappFeatureTogglePa && (

--- a/src/filtrering/filtrering-status/filtrering-status.tsx
+++ b/src/filtrering/filtrering-status/filtrering-status.tsx
@@ -7,11 +7,21 @@ import {CHECKBOX_FILTER, fjernFerdigfilter, leggTilFerdigFilter} from './filter-
 import {FiltervalgModell, KategoriModell} from '../../model-interfaces';
 import {pagineringSetup} from '../../ducks/paginering';
 import {
+    ER_SYKMELDT_MED_ARBEIDSGIVER,
     ferdigfilterListeLabelTekst,
-    mapFilternavnTilFilterValue,
+    I_AVTALT_AKTIVITET,
+    IKKE_I_AVTALT_AKTIVITET,
+    INAKTIVE_BRUKERE,
     MIN_ARBEIDSLISTE,
+    MOTER_IDAG,
     NYE_BRUKERE_FOR_VEILEDER,
-    UFORDELTE_BRUKERE
+    TILTAKSHENDELSER,
+    TRENGER_VURDERING,
+    UFORDELTE_BRUKERE,
+    UNDER_VURDERING,
+    UTLOPTE_AKTIVITETER,
+    VENTER_PA_SVAR_FRA_BRUKER,
+    VENTER_PA_SVAR_FRA_NAV
 } from '../filter-konstanter';
 import FilterStatusMinArbeidsliste from './arbeidsliste';
 import {oppdaterKolonneAlternativer, OversiktType} from '../../ducks/ui/listevisning';
@@ -149,7 +159,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         handleChange={handleCheckboxChange}
                         checked={ferdigfilterListe.includes(NYE_BRUKERE_FOR_VEILEDER)}
                         labelTekst={'Nye brukere'}
-                        filterVerdi={mapFilternavnTilFilterValue.nyeBrukere}
+                        filterVerdi={NYE_BRUKERE_FOR_VEILEDER}
                     />
                 ) : (
                     <BarInputCheckbox
@@ -158,7 +168,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         handleChange={handleCheckboxChange}
                         checked={ferdigfilterListe.includes(UFORDELTE_BRUKERE)}
                         labelTekst={'Ufordelte brukere'}
-                        filterVerdi={mapFilternavnTilFilterValue.ufordeltebruker}
+                        filterVerdi={UFORDELTE_BRUKERE}
                     />
                 )}
             </div>
@@ -172,23 +182,23 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         filterNavn="trengerVurdering"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.trengerVurdering}
-                        filterVerdi={mapFilternavnTilFilterValue.trengerVurdering}
-                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.trengerVurdering]}
+                        filterVerdi={TRENGER_VURDERING}
+                        labelTekst={ferdigfilterListeLabelTekst[TRENGER_VURDERING]}
                     />
                     <BarInputRadio
                         filterNavn="erSykmeldtMedArbeidsgiver"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.erSykmeldtMedArbeidsgiver}
-                        filterVerdi={mapFilternavnTilFilterValue.erSykmeldtMedArbeidsgiver}
-                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.erSykmeldtMedArbeidsgiver]}
+                        filterVerdi={ER_SYKMELDT_MED_ARBEIDSGIVER}
+                        labelTekst={ferdigfilterListeLabelTekst[ER_SYKMELDT_MED_ARBEIDSGIVER]}
                     />
                     {erVedtaksStotteFeatureTogglePa && (
                         <BarInputRadio
                             filterNavn="underVurdering"
                             handleChange={handleRadioButtonChange}
                             antall={statustallMedBrukerinnsyn.underVurdering}
-                            filterVerdi={mapFilternavnTilFilterValue.underVurdering}
-                            labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.underVurdering]}
+                            filterVerdi={UNDER_VURDERING}
+                            labelTekst={ferdigfilterListeLabelTekst[UNDER_VURDERING]}
                         />
                     )}
                 </div>
@@ -197,30 +207,30 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         filterNavn="venterPaSvarFraNAV"
                         antall={statustallMedBrukerinnsyn.venterPaSvarFraNAV}
                         handleChange={handleRadioButtonChange}
-                        filterVerdi={mapFilternavnTilFilterValue.venterPaSvarFraNAV}
-                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.venterPaSvarFraNAV]}
+                        filterVerdi={VENTER_PA_SVAR_FRA_NAV}
+                        labelTekst={ferdigfilterListeLabelTekst[VENTER_PA_SVAR_FRA_NAV]}
                     />
                     <BarInputRadio
                         filterNavn="venterPaSvarFraBruker"
                         antall={statustallMedBrukerinnsyn.venterPaSvarFraBruker}
                         handleChange={handleRadioButtonChange}
-                        filterVerdi={mapFilternavnTilFilterValue.venterPaSvarFraBruker}
-                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.venterPaSvarFraBruker]}
+                        filterVerdi={VENTER_PA_SVAR_FRA_BRUKER}
+                        labelTekst={ferdigfilterListeLabelTekst[VENTER_PA_SVAR_FRA_BRUKER]}
                     />
                     <BarInputRadio
                         filterNavn="avtaltMoteMedNav"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.moterMedNAVIdag}
-                        filterVerdi={mapFilternavnTilFilterValue.avtaltMoteMedNav}
-                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.avtaltMoteMedNav]}
+                        filterVerdi={MOTER_IDAG}
+                        labelTekst={ferdigfilterListeLabelTekst[MOTER_IDAG]}
                     />
                     {erStatusfilterTiltakshendelseFeatureTogglePa && (
                         <BarInputRadio
                             filterNavn="tiltakshendelse"
                             handleChange={handleRadioButtonChange}
                             antall={statustallMedBrukerinnsyn.tiltakshendelser}
-                            filterVerdi={mapFilternavnTilFilterValue.tiltakshendelser}
-                            labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.tiltakshendelser]}
+                            filterVerdi={TILTAKSHENDELSER}
+                            labelTekst={ferdigfilterListeLabelTekst[TILTAKSHENDELSER]}
                         />
                     )}
                 </div>
@@ -229,22 +239,22 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         filterNavn="utlopteAktiviteter"
                         antall={statustallMedBrukerinnsyn.utlopteAktiviteter}
                         handleChange={handleRadioButtonChange}
-                        filterVerdi={mapFilternavnTilFilterValue.utlopteAktiviteter}
-                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.utlopteAktiviteter]}
+                        filterVerdi={UTLOPTE_AKTIVITETER}
+                        labelTekst={ferdigfilterListeLabelTekst[UTLOPTE_AKTIVITETER]}
                     />
                     <BarInputRadio
                         filterNavn="ikkeIavtaltAktivitet"
                         antall={statustallMedBrukerinnsyn.ikkeIavtaltAktivitet}
                         handleChange={handleRadioButtonChange}
-                        filterVerdi={mapFilternavnTilFilterValue.ikkeIavtaltAktivitet}
-                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.ikkeIavtaltAktivitet]}
+                        filterVerdi={IKKE_I_AVTALT_AKTIVITET}
+                        labelTekst={ferdigfilterListeLabelTekst[IKKE_I_AVTALT_AKTIVITET]}
                     />
                     <BarInputRadio
                         filterNavn="iavtaltAktivitet"
                         antall={statustallMedBrukerinnsyn.iavtaltAktivitet}
                         handleChange={handleRadioButtonChange}
-                        filterVerdi={mapFilternavnTilFilterValue.iavtaltAktivitet}
-                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.iavtaltAktivitet]}
+                        filterVerdi={I_AVTALT_AKTIVITET}
+                        labelTekst={ferdigfilterListeLabelTekst[I_AVTALT_AKTIVITET]}
                     />
                 </div>
                 <div className="forste-barlabel-i-gruppe">
@@ -252,8 +262,8 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         filterNavn="inaktiveBrukere"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.inaktiveBrukere}
-                        filterVerdi={mapFilternavnTilFilterValue.inaktiveBrukere}
-                        labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.inaktiveBrukere]}
+                        filterVerdi={INAKTIVE_BRUKERE}
+                        labelTekst={ferdigfilterListeLabelTekst[INAKTIVE_BRUKERE]}
                     />
                 </div>
                 {oversiktType === OversiktType.minOversikt && (
@@ -291,8 +301,8 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                                 filterNavn="huskelapp"
                                 antall={statustallMedBrukerinnsyn.mineHuskelapper}
                                 handleChange={handleRadioButtonChange}
-                                filterVerdi={mapFilternavnTilFilterValue.huskelapp}
-                                labelTekst={ferdigfilterListeLabelTekst[mapFilternavnTilFilterValue.huskelapp]}
+                                filterVerdi={HUSKELAPP}
+                                labelTekst={ferdigfilterListeLabelTekst[HUSKELAPP]}
                             />
                         )}
                         {!arbeidslistefunksjonalitetSkalVises && erHuskelappFeatureTogglePa && (

--- a/src/model-interfaces.ts
+++ b/src/model-interfaces.ts
@@ -278,6 +278,7 @@ export enum Fargekategorinavn {
     INGEN_KATEGORI = 'Ingen kategori'
 }
 
+/** OpenSearch-verdiar for å filtrere på arbeidslista sine fargekategoriar */
 export enum KategoriModell {
     BLA = 'BLA',
     LILLA = 'LILLA',


### PR DESCRIPTION
Skriv oss bort frå eit objekt som wrappa opensearch-filter-konstantane. 

Mål: 
- om vi uansett skal hardkode ting kan vi liksågodt gjere det direkte, ikkje via ein mapper
- gjere det lettare å finne ut kvar ulike opensearch-filterverdiar var i bruk. I IntelliJ kunne ein ikkje finne all bruk av nøkkelen i eit objekt, men ein kan det om konstanten vert brukt direkte.

Bonus:
No kan vi sjå at enkelte av konstantane for opensearch-filter ikkje er i bruk. Desse kan ryddast opp i på sikt.