### PR TITLE
Fiks rekkefølgja på fargekategori-filter

### DIFF
--- a/src/filtrering/filter-konstanter.ts
+++ b/src/filtrering/filter-konstanter.ts
@@ -72,10 +72,14 @@ export function lagConfig(data: any): any {
     return data;
 }
 
-/** Mappar filternamn i OpenSearch til filterlabel for filter i ferdigFilterListe
+/**
+ * Mappar filternamn i OpenSearch til filterlabel for filter i ferdigFilterListe
  *
  * Notasjonen [konstantnamn] hentar ut verdien i konstanten og gjer det
  * lettare å finne ut kvar verdien av konstanten har blitt brukt.
+ *
+ * [key]-notasjonen heiter "Computed property names" i JavaScript.
+ * Les meir her: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#computed_property_names
  * */
 export const ferdigfilterListeLabelTekst = {
     [UFORDELTE_BRUKERE]: 'Ufordelte brukere',

--- a/src/filtrering/filtrering-status/fargekategori.tsx
+++ b/src/filtrering/filtrering-status/fargekategori.tsx
@@ -55,16 +55,17 @@ export const fargekategoriUnderfilterKonfigurasjoner: readonly FargekategoriUnde
         statustallId: 'fargekategoriD'
     },
     {
-        filterLabel: fargekategorier.FARGEKATEGORI_E,
-        filterId: FARGEKATEGORI_E,
-        filterNavn: 'mineFargekategorierE',
-        statustallId: 'fargekategoriE'
-    },
-    {
         filterLabel: fargekategorier.FARGEKATEGORI_F,
         filterId: FARGEKATEGORI_F,
         filterNavn: 'mineFargekategorierF',
         statustallId: 'fargekategoriF'
+    },
+    {
+        // Denne må liggje nedst for at farge-namna ("turkis", "gul") skal visast alfabetisk
+        filterLabel: fargekategorier.FARGEKATEGORI_E,
+        filterId: FARGEKATEGORI_E,
+        filterNavn: 'mineFargekategorierE',
+        statustallId: 'fargekategoriE'
     },
     {
         filterLabel: fargekategorier.INGEN_KATEGORI,


### PR DESCRIPTION
Frå kommentar på PR (som vi ikkje fekk med oss før vi merga): https://github.com/navikt/veilarbportefoljeflatefs/pull/1128