### PR TITLE
Legg til info om at veilarbfilter må oppdaterast ved filterendringar

### DIFF
--- a/src/model-interfaces.ts
+++ b/src/model-interfaces.ts
@@ -64,6 +64,14 @@ export enum Sorteringsfelt {
     TILTAKSHENDELSE_DATO_OPPRETTET = 'tiltakshendelse_dato_opprettet'
 }
 
+/**
+ * * * * * VIKTIG! * * * * * VIKTIG! * * * * * VIKTIG! * * * * * VIKTIG! * * * * * VIKTIG! * * * * *
+ * Om FiltervalgModell får endringar må ein også oppdatere Portefoljefilter i veilarbfilter.       *
+ * Begge repoa må deployast samstundes, elles knekk ein Mine filter i prod.                        *
+ *                                                                                                 *
+ * Relevant fil: https://github.com/navikt/veilarbfilter/blob/dev/src/main/java/no/nav/pto/veilarbfilter/domene/PortefoljeFilter.java (2024-11-05)
+ * Eksempel-PR frå huskelapp: https://github.com/navikt/veilarbfilter/pull/283                     *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 export interface FiltervalgModell {
     ferdigfilterListe: string[];
     nyeBrukereForVeileder?: boolean;


### PR DESCRIPTION
Vi lagar filter så sjeldan at dette er lett å gløyme. Difor legg vi inn ei påminning i koden om at vi må halde filtermodellane i dei to repoa synkronisert,