### PR TITLE
Gjer at ein kan velje kva for nokre 14a-kolonner som skal visast

### DIFF
--- a/src/components/toolbar/velg-kolonner/velg-kolonner-config.ts
+++ b/src/components/toolbar/velg-kolonner/velg-kolonner-config.ts
@@ -47,6 +47,9 @@ alternativerConfig.set(Kolonne.TOLKEBEHOV, {tekstlabel: 'Tolkebehov'});
 alternativerConfig.set(Kolonne.TOLKESPRAK, {tekstlabel: 'Tolkespråk'});
 alternativerConfig.set(Kolonne.TOLKEBEHOV_SIST_OPPDATERT, {tekstlabel: 'Tolkebehov sist oppdatert'});
 alternativerConfig.set(Kolonne.CV_SVARFRIST, {tekstlabel: 'Frist deling av CV'});
+alternativerConfig.set(Kolonne.GJELDENDE_VEDTAK_14A_INNSATSGRUPPE, {tekstlabel: 'Innsatsgruppe $ 14 a-vedtak'});
+alternativerConfig.set(Kolonne.GJELDENDE_VEDTAK_14A_HOVEDMAL, {tekstlabel: 'Hovedmål $ 14 a-vedtak'});
+alternativerConfig.set(Kolonne.GJELDENDE_VEDTAK_14A_VEDTAKSDATO, {tekstlabel: 'Vedtaksdato $ 14 a-vedtak'});
 alternativerConfig.set(Kolonne.AVVIK_14A_VEDTAK, {
     tekstlabel: 'Status § 14 a-vedtak (sammenligning mellom Arena og ny løsning)'
 });


### PR DESCRIPTION
Tek gjerne innspel på tekstane som vert vist i velg-kolonne-menyen. Ser på desse som eit fyrsteutkast som kan justerast når Kari er attende.

![image](https://github.com/user-attachments/assets/70276cfc-3ab7-4415-9176-cd0408739bcc)
