### PR TITLE
Legge til årstall på dato i møteplan

### DIFF
--- a/src/minoversikt/moteplan/motetabell.tsx
+++ b/src/minoversikt/moteplan/motetabell.tsx
@@ -13,7 +13,7 @@ function MoteTabell({dato, moter, enhetId}: MoteTabellProps) {
     return (
         <li>
             <Heading className="moteplan_tittel" size="small" level="2">
-                {dato.toLocaleString(['no'], {weekday: 'long', day: 'numeric', month: 'long'})}
+                {dato.toLocaleString(['no'], {weekday: 'long', day: 'numeric', month: 'long', year: 'numeric'})}
             </Heading>
             <Table size="small">
                 <Table.Header>


### PR DESCRIPTION
Har kommet inn en jirasak på at veiledere trenger årstall inn i møtepln for å holde oversikt over møteplan
![Screenshot 2024-11-19 at 15 55 41](https://github.com/user-attachments/assets/4886de73-e595-42b2-931a-1eb98c857a8b)
![Screenshot 2024-11-19 at 15 56 03](https://github.com/user-attachments/assets/045ac258-3785-467d-8af9-fd63034d1daf)
