### PR TITLE
Skjul gamle § 14 a-filter når dei nye er skrudd på

### DIFF
--- a/src/filtrering/filtrering-filter/filtrering-filter.tsx
+++ b/src/filtrering/filtrering-filter/filtrering-filter.tsx
@@ -316,6 +316,33 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                             />
                         )}
                     />
+                    {/* Mellom her kjem det nye hovedmål-filteret */}
+                    <Dropdown
+                        name="Sammenlign gjeldende vedtak og Arena"
+                        id="status-14a-vedtak-filter"
+                        render={() => (
+                            <>
+                                <Alert variant="info" size="small" className="registrering-alert">
+                                    Filteret viser brukere der hovedmål/ innsatsgruppe er ulikt i Arena og det
+                                    iverksatte § 14 a-vedtaket.{' '}
+                                    <Link
+                                        href="https://navno.sharepoint.com/sites/fag-og-ytelser-arbeid-arbeidsrettet-brukeroppfolging/SitePages/Ulike-hovedm%C3%A5l-og-innsatsgruppe-i-Arena,-og-i-iverksatte-%C2%A7-14-a-vedtak(1).aspx"
+                                        target="_blank"
+                                        rel="noreferrer noopener"
+                                    >
+                                        Se mer informasjon på Navet
+                                        <ExternalLinkIcon title="Åpne lenken i ny fane" fontSize="1.2em" />
+                                    </Link>
+                                </Alert>
+                                <CheckboxFilterform
+                                    valg={avvik14aVedtakValg()}
+                                    endreFiltervalg={endreAvvik14aVedtakFilterValg()}
+                                    filtervalg={filtervalg}
+                                    form="avvik14aVedtak"
+                                />
+                            </>
+                        )}
+                    />
                 </div>
             )}
             {!visFilter14aFraVedtaksstotte && (

--- a/src/filtrering/filtrering-filter/filtrering-filter.tsx
+++ b/src/filtrering/filtrering-filter/filtrering-filter.tsx
@@ -318,35 +318,37 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                     />
                 </div>
             )}
-            <div className="filtrering-filter__kolonne">
-                <Label size="small">Utfasing av Arena</Label>
-                <Dropdown
-                    name="Status § 14 a-vedtak"
-                    id="status-14a-vedtak-filter"
-                    render={() => (
-                        <>
-                            <Alert variant="info" size="small" className="registrering-alert">
-                                Filteret viser brukere der hovedmål/ innsatsgruppe er ulikt i Arena og det iverksatte §
-                                14 a-vedtaket.{' '}
-                                <Link
-                                    href="https://navno.sharepoint.com/sites/fag-og-ytelser-arbeid-arbeidsrettet-brukeroppfolging/SitePages/Ulike-hovedm%C3%A5l-og-innsatsgruppe-i-Arena,-og-i-iverksatte-%C2%A7-14-a-vedtak(1).aspx"
-                                    target="_blank"
-                                    rel="noreferrer noopener"
-                                >
-                                    Se mer informasjon på Navet
-                                    <ExternalLinkIcon title="Åpne lenken i ny fane" fontSize="1.2em" />
-                                </Link>
-                            </Alert>
-                            <CheckboxFilterform
-                                valg={avvik14aVedtakValg()}
-                                endreFiltervalg={endreAvvik14aVedtakFilterValg()}
-                                filtervalg={filtervalg}
-                                form="avvik14aVedtak"
-                            />
-                        </>
-                    )}
-                />
-            </div>
+            {!visFilter14aFraVedtaksstotte && (
+                <div className="filtrering-filter__kolonne">
+                    <Label size="small">Utfasing av Arena</Label>
+                    <Dropdown
+                        name="Status § 14 a-vedtak"
+                        id="status-14a-vedtak-filter"
+                        render={() => (
+                            <>
+                                <Alert variant="info" size="small" className="registrering-alert">
+                                    Filteret viser brukere der hovedmål/ innsatsgruppe er ulikt i Arena og det
+                                    iverksatte § 14 a-vedtaket.{' '}
+                                    <Link
+                                        href="https://navno.sharepoint.com/sites/fag-og-ytelser-arbeid-arbeidsrettet-brukeroppfolging/SitePages/Ulike-hovedm%C3%A5l-og-innsatsgruppe-i-Arena,-og-i-iverksatte-%C2%A7-14-a-vedtak(1).aspx"
+                                        target="_blank"
+                                        rel="noreferrer noopener"
+                                    >
+                                        Se mer informasjon på Navet
+                                        <ExternalLinkIcon title="Åpne lenken i ny fane" fontSize="1.2em" />
+                                    </Link>
+                                </Alert>
+                                <CheckboxFilterform
+                                    valg={avvik14aVedtakValg()}
+                                    endreFiltervalg={endreAvvik14aVedtakFilterValg()}
+                                    filtervalg={filtervalg}
+                                    form="avvik14aVedtak"
+                                />
+                            </>
+                        )}
+                    />
+                </div>
+            )}
             <div className="filtrering-filter__kolonne">
                 <Label size="small">Status og brukergrupper</Label>
                 <Dropdown

--- a/src/filtrering/filtrering-filter/filtrering-filter.tsx
+++ b/src/filtrering/filtrering-filter/filtrering-filter.tsx
@@ -361,30 +361,34 @@ function FiltreringFilter({filtervalg, endreFiltervalg, enhettiltak, oversiktTyp
                         />
                     )}
                 />
-                <Dropdown
-                    name="Innsatsgruppe"
-                    id="innsatsgruppe"
-                    render={() => (
-                        <CheckboxFilterform
-                            form="innsatsgruppe"
-                            valg={innsatsgruppe}
-                            filtervalg={filtervalg}
-                            endreFiltervalg={endreFiltervalg}
+                {!visFilter14aFraVedtaksstotte && (
+                    <>
+                        <Dropdown
+                            name="Innsatsgruppe"
+                            id="innsatsgruppe"
+                            render={() => (
+                                <CheckboxFilterform
+                                    form="innsatsgruppe"
+                                    valg={innsatsgruppe}
+                                    filtervalg={filtervalg}
+                                    endreFiltervalg={endreFiltervalg}
+                                />
+                            )}
                         />
-                    )}
-                />
-                <Dropdown
-                    name="Hovedmål"
-                    id="hovedmal"
-                    render={() => (
-                        <CheckboxFilterform
-                            form="hovedmal"
-                            valg={hovedmal}
-                            filtervalg={filtervalg}
-                            endreFiltervalg={endreFiltervalg}
+                        <Dropdown
+                            name="Hovedmål"
+                            id="hovedmal"
+                            render={() => (
+                                <CheckboxFilterform
+                                    form="hovedmal"
+                                    valg={hovedmal}
+                                    filtervalg={filtervalg}
+                                    endreFiltervalg={endreFiltervalg}
+                                />
+                            )}
                         />
-                    )}
-                />
+                    </>
+                )}
                 <Dropdown
                     name="Formidlingsgruppe"
                     id="formidlingsgruppe"


### PR DESCRIPTION
- Legg gamle innsatsgruppe-, hovedmål- og avvikfilter "utanfor" feature-toggle slik at dei berre er synlege når den er av.
- Legg til ein ny versjon av avvik-filteret (oppdatert tekst) i same filterbolk som dei nye filtera. Denne skal berre vere synleg når toggle er på.