### PR TITLE
Vis samanlikne 14a-vedtak-kolonna før kolonner for gjeldande § 14 a-vedtak

### DIFF
--- a/src/ducks/ui/listevisning-selectors.ts
+++ b/src/ducks/ui/listevisning-selectors.ts
@@ -146,6 +146,10 @@ export function getMuligeKolonner(filtervalg: FiltervalgModell, oversiktType: Ov
         filtrertPaInnsatsgruppeGjeldendeVedtak14a ||
         filtrertPaHovedmålGjeldendeVedtak14a;
 
+    /* Rekkefølgja her avgjer kva kolonner som er vist som standard,
+     * fordi dei tre første mulige kolonnene basert på valgte filter er dei som vert vist.
+     * Rekkefølga til kolonnene i tabellen er styrt av rekkefølgja på deira JSX-element i *-kolonner.tsx og *-listehode.tsx
+     * 2024-11-22, Ingrid */
     return ([] as Kolonne[])
         .concat(addHvis(Kolonne.FODELAND, filtrertPaLandgruppeEllerFoedeland))
         .concat(addHvis(Kolonne.STATSBORGERSKAP, filtrertPaLandgruppeEllerFoedeland))
@@ -175,10 +179,10 @@ export function getMuligeKolonner(filtervalg: FiltervalgModell, oversiktType: Ov
         .concat(addHvis(Kolonne.TOLKEBEHOV, filtrertPaTolkBehov))
         .concat(addHvis(Kolonne.TOLKESPRAK, filtrertPaTolkBehov))
         .concat(addHvis(Kolonne.TOLKEBEHOV_SIST_OPPDATERT, filtrertPaTolkBehov))
+        .concat(addHvis(Kolonne.AVVIK_14A_VEDTAK, filtrertPaAvvik14aVedtak))
         .concat(addHvis(Kolonne.GJELDENDE_VEDTAK_14A_INNSATSGRUPPE, filtrertPaEtGjeldendeVedtak14aFilter))
         .concat(addHvis(Kolonne.GJELDENDE_VEDTAK_14A_HOVEDMAL, filtrertPaEtGjeldendeVedtak14aFilter))
         .concat(addHvis(Kolonne.GJELDENDE_VEDTAK_14A_VEDTAKSDATO, filtrertPaEtGjeldendeVedtak14aFilter))
-        .concat(addHvis(Kolonne.AVVIK_14A_VEDTAK, filtrertPaAvvik14aVedtak))
         .concat(addHvis(Kolonne.VURDERINGSFRIST_YTELSE, filtrertPaYtelseMedVurderingsfrist))
         .concat(addHvis(Kolonne.TYPE_YTELSE, filtrertPaAAPYtelse))
         .concat(addHvis(Kolonne.VEDTAKSPERIODE, filtrertPaYtelseMedVedtaksperiode))

--- a/src/enhetsportefolje/enhet-kolonner.tsx
+++ b/src/enhetsportefolje/enhet-kolonner.tsx
@@ -334,35 +334,6 @@ function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKolonner, 
                 tekst={moteErAvtaltMedNAV ? 'Avtalt med NAV' : '-'}
                 skalVises={!!ferdigfilterListe?.includes(MOTER_IDAG) && valgteKolonner.includes(Kolonne.MOTE_ER_AVTALT)}
             />
-            {visFilter14aFraVedtaksstotte && (
-                <>
-                    <TekstKolonne
-                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_INNSATSGRUPPE)}
-                        tekst={
-                            bruker.gjeldendeVedtak14a?.innsatsgruppe
-                                ? innsatsgruppeNavn[bruker.gjeldendeVedtak14a.innsatsgruppe]
-                                : '-'
-                        }
-                        className="col col-xs-2"
-                    />
-                    <TekstKolonne
-                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_HOVEDMAL)}
-                        tekst={
-                            bruker.gjeldendeVedtak14a?.hovedmal ? HovedmalNavn[bruker.gjeldendeVedtak14a.hovedmal] : '-'
-                        }
-                        className="col col-xs-2"
-                    />
-                    <TekstKolonne
-                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_VEDTAKSDATO)}
-                        tekst={
-                            bruker.gjeldendeVedtak14a?.innsatsgruppe
-                                ? toDateString(bruker.gjeldendeVedtak14a?.fattetDato)
-                                : '-'
-                        }
-                        className="col col-xs-2-5"
-                    />
-                </>
-            )}
             <TekstKolonne
                 tekst={bruker.utkast14aStatus ?? '-'}
                 skalVises={
@@ -404,6 +375,7 @@ function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKolonner, 
                     bruker.nesteSvarfristCvStillingFraNav ? toDateString(bruker.nesteSvarfristCvStillingFraNav) : '-'
                 }
             />
+
             <TekstKolonne
                 tekst={
                     avvik14aVedtakAvhengigeFilter.hasOwnProperty(bruker.avvik14aVedtak)
@@ -413,6 +385,36 @@ function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKolonner, 
                 skalVises={valgteKolonner.includes(Kolonne.AVVIK_14A_VEDTAK)}
                 className="col col-xs-2"
             />
+            {visFilter14aFraVedtaksstotte && (
+                <>
+                    <TekstKolonne
+                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_INNSATSGRUPPE)}
+                        tekst={
+                            bruker.gjeldendeVedtak14a?.innsatsgruppe
+                                ? innsatsgruppeNavn[bruker.gjeldendeVedtak14a.innsatsgruppe]
+                                : '-'
+                        }
+                        className="col col-xs-2"
+                    />
+                    <TekstKolonne
+                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_HOVEDMAL)}
+                        tekst={
+                            bruker.gjeldendeVedtak14a?.hovedmal ? HovedmalNavn[bruker.gjeldendeVedtak14a.hovedmal] : '-'
+                        }
+                        className="col col-xs-2"
+                    />
+                    <TekstKolonne
+                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_VEDTAKSDATO)}
+                        tekst={
+                            bruker.gjeldendeVedtak14a?.innsatsgruppe
+                                ? toDateString(bruker.gjeldendeVedtak14a?.fattetDato)
+                                : '-'
+                        }
+                        className="col col-xs-2-5"
+                    />
+                </>
+            )}
+
             <DatoKolonne
                 dato={overgangsstonadUtlopsdato}
                 skalVises={valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_UTLOP_OVERGANGSSTONAD)}

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -308,13 +308,6 @@ function EnhetListehode({
                     title="Møtestatus"
                     className="col col-xs-2"
                 />
-                {visFilter14aFraVedtaksstotte && (
-                    <>
-                        <GjeldendeVedtak14aInnsatsgruppe {...sorteringTilHeadercelle} />
-                        <GjeldendeVedtak14aHovedmal {...sorteringTilHeadercelle} />
-                        <GjeldendeVedtak14aVedtaksdato {...sorteringTilHeadercelle} />
-                    </>
-                )}
                 <SorteringHeader
                     skalVises={
                         !!ferdigfilterListe?.includes(UNDER_VURDERING) && valgteKolonner.includes(Kolonne.VEDTAKSTATUS)
@@ -372,8 +365,17 @@ function EnhetListehode({
                     title="Dato personen sist gjorde endring i aktiviteter/mål"
                     className="col col-xs-2"
                 />
+
                 <SvarfristCv {...sorteringTilHeadercelle} />
+
                 <Status14AVedtak {...sorteringTilHeadercelle} />
+                {visFilter14aFraVedtaksstotte && (
+                    <>
+                        <GjeldendeVedtak14aInnsatsgruppe {...sorteringTilHeadercelle} />
+                        <GjeldendeVedtak14aHovedmal {...sorteringTilHeadercelle} />
+                        <GjeldendeVedtak14aVedtaksdato {...sorteringTilHeadercelle} />
+                    </>
+                )}
 
                 <SorteringHeader
                     skalVises={

--- a/src/minoversikt/minoversikt-kolonner.tsx
+++ b/src/minoversikt/minoversikt-kolonner.tsx
@@ -273,35 +273,6 @@ export function MinOversiktKolonner({bruker, enhetId, filtervalg, valgteKolonner
                 tekst={moteErAvtaltMedNAV ? 'Avtalt med NAV' : '-'}
                 skalVises={!!ferdigfilterListe?.includes(MOTER_IDAG) && valgteKolonner.includes(Kolonne.MOTE_ER_AVTALT)}
             />
-            {visFilter14aFraVedtaksstotte && (
-                <>
-                    <TekstKolonne
-                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_INNSATSGRUPPE)}
-                        tekst={
-                            bruker.gjeldendeVedtak14a?.innsatsgruppe
-                                ? innsatsgruppeNavn[bruker.gjeldendeVedtak14a.innsatsgruppe]
-                                : '-'
-                        }
-                        className="col col-xs-2"
-                    />
-                    <TekstKolonne
-                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_HOVEDMAL)}
-                        tekst={
-                            bruker.gjeldendeVedtak14a?.hovedmal ? HovedmalNavn[bruker.gjeldendeVedtak14a.hovedmal] : '-'
-                        }
-                        className="col col-xs-2"
-                    />
-                    <TekstKolonne
-                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_VEDTAKSDATO)}
-                        tekst={
-                            bruker.gjeldendeVedtak14a?.innsatsgruppe
-                                ? toDateString(bruker.gjeldendeVedtak14a?.fattetDato)
-                                : '-'
-                        }
-                        className="col col-xs-2-5"
-                    />
-                </>
-            )}
             <LenkeKolonne
                 className="col col-xs-3 col-break-word"
                 bruker={bruker}
@@ -401,6 +372,7 @@ export function MinOversiktKolonner({bruker, enhetId, filtervalg, valgteKolonner
                     bruker.nesteSvarfristCvStillingFraNav ? toDateString(bruker.nesteSvarfristCvStillingFraNav) : '-'
                 }
             />
+
             <TekstKolonne
                 tekst={
                     avvik14aVedtakAvhengigeFilter.hasOwnProperty(bruker.avvik14aVedtak)
@@ -410,6 +382,36 @@ export function MinOversiktKolonner({bruker, enhetId, filtervalg, valgteKolonner
                 skalVises={valgteKolonner.includes(Kolonne.AVVIK_14A_VEDTAK)}
                 className="col col-xs-2"
             />
+            {visFilter14aFraVedtaksstotte && (
+                <>
+                    <TekstKolonne
+                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_INNSATSGRUPPE)}
+                        tekst={
+                            bruker.gjeldendeVedtak14a?.innsatsgruppe
+                                ? innsatsgruppeNavn[bruker.gjeldendeVedtak14a.innsatsgruppe]
+                                : '-'
+                        }
+                        className="col col-xs-2"
+                    />
+                    <TekstKolonne
+                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_HOVEDMAL)}
+                        tekst={
+                            bruker.gjeldendeVedtak14a?.hovedmal ? HovedmalNavn[bruker.gjeldendeVedtak14a.hovedmal] : '-'
+                        }
+                        className="col col-xs-2"
+                    />
+                    <TekstKolonne
+                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_VEDTAKSDATO)}
+                        tekst={
+                            bruker.gjeldendeVedtak14a?.innsatsgruppe
+                                ? toDateString(bruker.gjeldendeVedtak14a?.fattetDato)
+                                : '-'
+                        }
+                        className="col col-xs-2-5"
+                    />
+                </>
+            )}
+
             <DatoKolonne
                 dato={overgangsstonadUtlopsdato}
                 skalVises={valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_UTLOP_OVERGANGSSTONAD)}

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -296,13 +296,6 @@ function MinOversiktListeHode({
                     title="Møtestatus"
                     className="col col-xs-2"
                 />
-                {visFilter14aFraVedtaksstotte && (
-                    <>
-                        <GjeldendeVedtak14aInnsatsgruppe {...sorteringTilHeadercelle} />
-                        <GjeldendeVedtak14aHovedmal {...sorteringTilHeadercelle} />
-                        <GjeldendeVedtak14aVedtaksdato {...sorteringTilHeadercelle} />
-                    </>
-                )}
                 <SorteringHeader
                     skalVises={
                         !!ferdigfilterListe?.includes(UNDER_VURDERING) && valgteKolonner.includes(Kolonne.VEDTAKSTATUS)
@@ -424,7 +417,15 @@ function MinOversiktListeHode({
                 />
 
                 <SvarfristCv {...sorteringTilHeadercelle} />
+
                 <Status14AVedtak {...sorteringTilHeadercelle} />
+                {visFilter14aFraVedtaksstotte && (
+                    <>
+                        <GjeldendeVedtak14aInnsatsgruppe {...sorteringTilHeadercelle} />
+                        <GjeldendeVedtak14aHovedmal {...sorteringTilHeadercelle} />
+                        <GjeldendeVedtak14aVedtaksdato {...sorteringTilHeadercelle} />
+                    </>
+                )}
 
                 <SorteringHeader
                     skalVises={


### PR DESCRIPTION
Slik at veileder slepp velje kolonna for å sjå informasjonen når dei kombinerer samanlikningsfilteret med eit av gjeldande vedtak-filtera.