### PR TITLE
Bruk same feature-toggle for §14a som veilarbdetaljerfs

### DIFF
--- a/src/konstanter.ts
+++ b/src/konstanter.ts
@@ -15,7 +15,7 @@ export const VIS_MELDING_OM_BRUKERE_MED_ADRESSEBESKYTTELSE_ELLER_SKJERMING =
     'veilarbportefoljeflatefs.vis_melding_om_brukere_med_adressebeskyttelse_eller_skjerming';
 export const VIS_AAP_VURDERINGSFRISTKOLONNER = 'veilarbportefoljeflatefs.vis_kolonner_for_vurderingsfrist_aap';
 export const FILTER_FOR_PERSONER_MED_BARN_UNDER_18 = 'veilarbportefoljeflatefs.filter_for_personer_med_barn_under_18';
-export const VIS_FILTER_14A_FRA_VEDTAKSSTOTTE = 'veilarbportefoljeflatefs.vis_filter_14a_fra_vedtaksstotte';
+export const VIS_FILTER_14A_FRA_VEDTAKSSTOTTE = 'veilarbdetaljerfs.vis_innsatsgruppe_hovedmal_fra_veilarbvedtaksstotte';
 export const VIS_HENDELSESFILTER = 'veilarbportefoljeflatefs.vis_hendelsesfilter';
 
 //HUSK Å LEGG TIL FEATURE-TOGGLE HER OGSÅ!!!!!!!!!


### PR DESCRIPTION
Til å bestemme om filter skal visast for $ 14 a-ting.

Då slepp vi skru på to ulike feature-togglar ved lansering.


For meir om denne vurderinga, sjå trellokort: https://trello.com/c/OWeW5rEq/831-bruk-same-featuretoggle-i-oversikten-visittkort-for-%C3%A5-vise-data-fr%C3%A5-eiga-kjelde