### PR TITLE
Lag gjenbrukbare komponentar for fleire kolonneoverskrifter

### DIFF
--- a/src/components/tabell/headerceller/AvtaltAktivitet.tsx
+++ b/src/components/tabell/headerceller/AvtaltAktivitet.tsx
@@ -1,0 +1,18 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const AvtaltAktivitet = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.AVTALT_AKTIVITET)}
+        sortering={Sorteringsfelt.I_AVTALT_AKTIVITET}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.I_AVTALT_AKTIVITET}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Neste utløpsdato aktivitet"
+        title='Neste utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
+        headerTestId="sorteringheader_i-avtalt-aktivitet"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/EnsligeForsorgereAktivitetsplikt.tsx
+++ b/src/components/tabell/headerceller/EnsligeForsorgereAktivitetsplikt.tsx
@@ -1,0 +1,22 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const EnsligeForsorgereAktivitetsplikt = ({
+    gjeldendeSorteringsfelt,
+    valgteKolonner,
+    rekkefolge,
+    onClick
+}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_AKIVITETSPLIKT)}
+        sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_AKTIVITETSPLIKT}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_AKTIVITETSPLIKT}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Om aktivitetsplikt overgangsstønad"
+        title="Om bruker har aktivitetsplikt på overgangsstønad"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/EnsligeForsorgereOmBarnet.tsx
+++ b/src/components/tabell/headerceller/EnsligeForsorgereOmBarnet.tsx
@@ -1,0 +1,23 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const EnsligeForsorgereOmBarnet = ({
+    gjeldendeSorteringsfelt,
+    valgteKolonner,
+    rekkefolge,
+    onClick
+}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_OM_BARNET)}
+        sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_OM_BARNET}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_OM_BARNET}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Om barnet"
+        title="Dato når barnet er hhv. 6 mnd/1 år gammelt"
+        headerTestId="sorteringheader_enslige-forsorgere-om-barnet"
+        className="col col-xs-3"
+    />
+);

--- a/src/components/tabell/headerceller/EnsligeForsorgereUtlopOvergangsstonad.tsx
+++ b/src/components/tabell/headerceller/EnsligeForsorgereUtlopOvergangsstonad.tsx
@@ -1,0 +1,23 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const EnsligeForsorgereUtlopOvergangsstonad = ({
+    gjeldendeSorteringsfelt,
+    valgteKolonner,
+    rekkefolge,
+    onClick
+}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_UTLOP_OVERGANGSSTONAD)}
+        sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_UTLOP_YTELSE}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_UTLOP_YTELSE}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Utløp overgangsstønad"
+        title="Utløpsdato for overgangsstønad"
+        headerTestId="sorteringheader_utlop_overgangsstonad"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/EnsligeForsorgereVedtaksperiode.tsx
+++ b/src/components/tabell/headerceller/EnsligeForsorgereVedtaksperiode.tsx
@@ -1,0 +1,22 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const EnsligeForsorgereVedtaksperiode = ({
+    gjeldendeSorteringsfelt,
+    valgteKolonner,
+    rekkefolge,
+    onClick
+}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_VEDTAKSPERIODE)}
+        sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Type vedtaksperiode overgangsstønad"
+        title="Type vedtaksperiode for overgangsstønad"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/MoteVarighet.tsx
+++ b/src/components/tabell/headerceller/MoteVarighet.tsx
@@ -1,0 +1,13 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import Header from '../header';
+
+export const MoteVarighet = ({valgteKolonner}: HeadercelleProps) => (
+    <Header
+        skalVises={valgteKolonner.includes(Kolonne.MOTER_VARIGHET)}
+        title="Varighet på møtet"
+        className="col col-xs-2"
+    >
+        Varighet møte
+    </Header>
+);

--- a/src/components/tabell/headerceller/MoterIDag.tsx
+++ b/src/components/tabell/headerceller/MoterIDag.tsx
@@ -1,0 +1,17 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const MoterIDag = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.MOTER_IDAG)}
+        sortering={Sorteringsfelt.MOTER_MED_NAV_IDAG}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.MOTER_MED_NAV_IDAG}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Klokkeslett møte"
+        title="Tidspunktet møtet starter"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/Motestatus.tsx
+++ b/src/components/tabell/headerceller/Motestatus.tsx
@@ -1,0 +1,17 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const Motestatus = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.MOTE_ER_AVTALT)}
+        sortering={Sorteringsfelt.MOTESTATUS}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.MOTESTATUS}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Avtalt med NAV"
+        title="Møtestatus"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/SisteEndring.tsx
+++ b/src/components/tabell/headerceller/SisteEndring.tsx
@@ -1,0 +1,14 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import Header from '../header';
+
+export const SisteEndring = ({valgteKolonner}: HeadercelleProps) => (
+    // Dette er siste endring frå under "Hendelser", i aktiviteter personen sjølv har oppretta.
+    <Header
+        skalVises={valgteKolonner.includes(Kolonne.SISTE_ENDRING)}
+        title="Personens siste endring av aktiviteter/mål"
+        className="col col-xs-2"
+    >
+        Siste endring
+    </Header>
+);

--- a/src/components/tabell/headerceller/SisteEndringDato.tsx
+++ b/src/components/tabell/headerceller/SisteEndringDato.tsx
@@ -1,0 +1,18 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const SisteEndringDato = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
+    // Dette er siste endring frå under "Hendelser", i aktiviteter personen sjølv har oppretta.
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.SISTE_ENDRING_DATO)}
+        sortering={Sorteringsfelt.SISTE_ENDRING_DATO}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.SISTE_ENDRING_DATO}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Dato siste endring"
+        title="Dato personen sist gjorde endring i aktiviteter/mål"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/Status14AVedtak.tsx
+++ b/src/components/tabell/headerceller/Status14AVedtak.tsx
@@ -1,7 +1,6 @@
 import {HeadercelleProps} from './HeadercelleProps';
 import {Kolonne} from '../../../ducks/ui/listevisning';
 import Header from '../header';
-import * as React from 'react';
 
 export const Status14AVedtak = ({valgteKolonner}: HeadercelleProps) => (
     // Dette er den som samanliknar gjeldande vedtak og "den i Arena". Viser om det er skilnad mellom kjeldene.

--- a/src/components/tabell/headerceller/TiltakshendelseDatoOpprettet.tsx
+++ b/src/components/tabell/headerceller/TiltakshendelseDatoOpprettet.tsx
@@ -1,0 +1,22 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const TiltakshendelseDatoOpprettet = ({
+    gjeldendeSorteringsfelt,
+    valgteKolonner,
+    rekkefolge,
+    onClick
+}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.TILTAKSHENDELSE_DATO_OPPRETTET)}
+        sortering={Sorteringsfelt.TILTAKSHENDELSE_DATO_OPPRETTET}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.TILTAKSHENDELSE_DATO_OPPRETTET}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Dato for hendelse"
+        title="Dato da hendelsen ble opprettet"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/TiltakshendelseLenke.tsx
+++ b/src/components/tabell/headerceller/TiltakshendelseLenke.tsx
@@ -1,0 +1,22 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const TiltakshendelseLenke = ({
+    gjeldendeSorteringsfelt,
+    valgteKolonner,
+    rekkefolge,
+    onClick
+}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.TILTAKSHENDELSE_LENKE)}
+        sortering={Sorteringsfelt.TILTAKSHENDELSE_TEKST}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.TILTAKSHENDELSE_TEKST}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Hendelse på tiltak"
+        title="Lenke til hendelsen"
+        className="col col-xs-3"
+    />
+);

--- a/src/components/tabell/headerceller/UnderVurderingAnsvarligVeileder.tsx
+++ b/src/components/tabell/headerceller/UnderVurderingAnsvarligVeileder.tsx
@@ -1,0 +1,22 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const UnderVurderingAnsvarligVeileder = ({
+    gjeldendeSorteringsfelt,
+    valgteKolonner,
+    rekkefolge,
+    onClick
+}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.ANSVARLIG_VEILEDER_FOR_VEDTAK)}
+        sortering={Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Ansvarlig for vedtak"
+        title="Ansvarlig veileder for utkast til § 14 a-vedtak"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/UnderVurderingVedtaksstatus.tsx
+++ b/src/components/tabell/headerceller/UnderVurderingVedtaksstatus.tsx
@@ -1,0 +1,22 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const UnderVurderingVedtaksstatus = ({
+    gjeldendeSorteringsfelt,
+    valgteKolonner,
+    rekkefolge,
+    onClick
+}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.VEDTAKSTATUS)}
+        sortering={Sorteringsfelt.UTKAST_14A_STATUS}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Status § 14 a-vedtak"
+        title="Status oppfølgingvedtak"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/UnderVurderingVedtaksstatusEndret.tsx
+++ b/src/components/tabell/headerceller/UnderVurderingVedtaksstatusEndret.tsx
@@ -1,0 +1,22 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const UnderVurderingVedtaksstatusEndret = ({
+    gjeldendeSorteringsfelt,
+    valgteKolonner,
+    rekkefolge,
+    onClick
+}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.VEDTAKSTATUS_ENDRET)}
+        sortering={Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Statusendring"
+        title="Dager siden statusendring på utkast for § 14 a-vedtak"
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/UtlopteAktiviteter.tsx
+++ b/src/components/tabell/headerceller/UtlopteAktiviteter.tsx
@@ -1,0 +1,22 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const UtlopteAktiviteter = ({
+    gjeldendeSorteringsfelt,
+    valgteKolonner,
+    rekkefolge,
+    onClick
+}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.UTLOPTE_AKTIVITETER)}
+        sortering={Sorteringsfelt.UTLOPTE_AKTIVITETER}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.UTLOPTE_AKTIVITETER}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Utløpsdato aktivitet"
+        title='Utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/VenterPaSvarFraBruker.tsx
+++ b/src/components/tabell/headerceller/VenterPaSvarFraBruker.tsx
@@ -1,0 +1,22 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const VenterPaSvarFraBruker = ({
+    gjeldendeSorteringsfelt,
+    valgteKolonner,
+    rekkefolge,
+    onClick
+}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.VENTER_SVAR_FRA_BRUKER_DATO)}
+        sortering={Sorteringsfelt.VENTER_PA_SVAR_FRA_BRUKER}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.VENTER_PA_SVAR_FRA_BRUKER}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Dato på melding"
+        title='Dato på meldingen som er merket "Venter på svar fra bruker"'
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/VenterPaSvarFraNav.tsx
+++ b/src/components/tabell/headerceller/VenterPaSvarFraNav.tsx
@@ -1,0 +1,22 @@
+import {HeadercelleProps} from './HeadercelleProps';
+import {Sorteringsfelt} from '../../../model-interfaces';
+import {Kolonne} from '../../../ducks/ui/listevisning';
+import SorteringHeader from '../sortering-header';
+
+export const VenterPaSvarFraNav = ({
+    gjeldendeSorteringsfelt,
+    valgteKolonner,
+    rekkefolge,
+    onClick
+}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.VENTER_SVAR_FRA_NAV_DATO)}
+        sortering={Sorteringsfelt.VENTER_PA_SVAR_FRA_NAV}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.VENTER_PA_SVAR_FRA_NAV}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="Dato på melding"
+        title='Dato på meldingen som er merket "Venter på svar fra NAV"'
+        className="col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/enhetens-oversikt/VeilederNavident.tsx
+++ b/src/components/tabell/headerceller/enhetens-oversikt/VeilederNavident.tsx
@@ -1,0 +1,17 @@
+import {HeadercelleProps} from '../HeadercelleProps';
+import {Sorteringsfelt} from '../../../../model-interfaces';
+import {Kolonne} from '../../../../ducks/ui/listevisning';
+import SorteringHeader from '../../sortering-header';
+
+export const VeilederNavident = ({gjeldendeSorteringsfelt, valgteKolonner, rekkefolge, onClick}: HeadercelleProps) => (
+    <SorteringHeader
+        skalVises={valgteKolonner.includes(Kolonne.NAVIDENT)}
+        sortering={Sorteringsfelt.NAVIDENT}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.NAVIDENT}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        tekst="NAV-ident"
+        title="NAV-ident på tildelt veileder"
+        className="header__veilederident col col-xs-2"
+    />
+);

--- a/src/components/tabell/headerceller/enhetens-oversikt/VeilederNavn.tsx
+++ b/src/components/tabell/headerceller/enhetens-oversikt/VeilederNavn.tsx
@@ -1,0 +1,13 @@
+import {HeadercelleProps} from '../HeadercelleProps';
+import {Kolonne} from '../../../../ducks/ui/listevisning';
+import Header from '../../header';
+
+export const VeilederNavn = ({valgteKolonner}: HeadercelleProps) => (
+    <Header
+        skalVises={valgteKolonner.includes(Kolonne.VEILEDER)}
+        headerTestId="sorteringheader_veileder"
+        className="col col-xs-2"
+    >
+        Veileder
+    </Header>
+);

--- a/src/components/tabell/headerceller/min-oversikt/Fargekategori.tsx
+++ b/src/components/tabell/headerceller/min-oversikt/Fargekategori.tsx
@@ -1,0 +1,16 @@
+import {HeadercelleProps} from '../HeadercelleProps';
+import {Sorteringsfelt} from '../../../../model-interfaces';
+import SorteringHeaderIkon from '../../sortering-header-ikon';
+import {ReactComponent as FargekategoriIkonTomtBokmerke} from '../../../../components/ikoner/fargekategorier/Fargekategoriikon_bokmerke.svg';
+
+export const Fargekategori = ({gjeldendeSorteringsfelt, rekkefolge, onClick}: HeadercelleProps) => (
+    <SorteringHeaderIkon
+        ikon={<FargekategoriIkonTomtBokmerke aria-hidden />}
+        sortering={Sorteringsfelt.FARGEKATEGORI}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.FARGEKATEGORI}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        title="Fargekategori-sortering"
+        headerId="fargekategori"
+    />
+);

--- a/src/components/tabell/headerceller/min-oversikt/Huskelapp.tsx
+++ b/src/components/tabell/headerceller/min-oversikt/Huskelapp.tsx
@@ -1,0 +1,17 @@
+import {HeadercelleProps} from '../HeadercelleProps';
+import {Sorteringsfelt} from '../../../../model-interfaces';
+import SorteringHeaderIkon from '../../sortering-header-ikon';
+import {ReactComponent as HuskelappIkon} from '../../../../components/ikoner/huskelapp/Huskelappikon.svg';
+
+export const Huskelapp = ({gjeldendeSorteringsfelt, rekkefolge, onClick}: HeadercelleProps) => (
+    <SorteringHeaderIkon
+        ikon={<HuskelappIkon aria-hidden />}
+        sortering={Sorteringsfelt.HUSKELAPP}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.HUSKELAPP}
+        rekkefolge={rekkefolge}
+        onClick={onClick}
+        title="Huskelapp-sortering"
+        headerId="huskelapp"
+        className="huskelapp__sorteringsheader"
+    />
+);

--- a/src/components/toolbar/velg-kolonner/velg-kolonner-config.ts
+++ b/src/components/toolbar/velg-kolonner/velg-kolonner-config.ts
@@ -32,7 +32,10 @@ alternativerConfig.set(Kolonne.MOTER_VARIGHET, {tekstlabel: 'Varighet møte'});
 alternativerConfig.set(Kolonne.MOTE_ER_AVTALT, {tekstlabel: 'Møte er avtalt med NAV'});
 alternativerConfig.set(Kolonne.VEDTAKSTATUS, {tekstlabel: 'Status § 14 a-vedtak (ny løsning)'});
 alternativerConfig.set(Kolonne.VEDTAKSTATUS_ENDRET, {
-    tekstlabel: 'Tidspunkt for endring av status § 14 a-vedtak (ny løsning)'
+    tekstlabel: 'Dager siden statusendring på utkast for § 14 a-vedtak (ny løsning)'
+});
+alternativerConfig.set(Kolonne.ANSVARLIG_VEILEDER_FOR_VEDTAK, {
+    tekstlabel: 'Ansvarlig veileder på utkast for § 14 a-vedtak (ny løsning)'
 });
 alternativerConfig.set(Kolonne.SISTE_ENDRING, {tekstlabel: 'Siste endring personen har gjort på aktivitet/mål'});
 alternativerConfig.set(Kolonne.SISTE_ENDRING_DATO, {

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -41,6 +41,19 @@ import {FilterhendelseLenke} from '../components/tabell/headerceller/Filterhende
 import {FilterhendelseDatoOpprettet} from '../components/tabell/headerceller/FilterhendelseDatoOpprettet';
 import {TiltakshendelseDatoOpprettet} from '../components/tabell/headerceller/TiltakshendelseDatoOpprettet';
 import {TiltakshendelseLenke} from '../components/tabell/headerceller/TiltakshendelseLenke';
+import {EnsligeForsorgereOmBarnet} from '../components/tabell/headerceller/EnsligeForsorgereOmBarnet';
+import {EnsligeForsorgereAktivitetsplikt} from '../components/tabell/headerceller/EnsligeForsorgereAktivitetsplikt';
+import {EnsligeForsorgereVedtaksperiode} from '../components/tabell/headerceller/EnsligeForsorgereVedtaksperiode';
+import {EnsligeForsorgereUtlopOvergangsstonad} from '../components/tabell/headerceller/EnsligeForsorgereUtlopOvergangsstonad';
+import {SisteEndringDato} from '../components/tabell/headerceller/SisteEndringDato';
+import {SisteEndring} from '../components/tabell/headerceller/SisteEndring';
+import {VenterPaSvarFraNav} from '../components/tabell/headerceller/VenterPaSvarFraNav';
+import {VenterPaSvarFraBruker} from '../components/tabell/headerceller/VenterPaSvarFraBruker';
+import {UtlopteAktiviteter} from '../components/tabell/headerceller/UtlopteAktiviteter';
+import {AvtaltAktivitet} from '../components/tabell/headerceller/AvtaltAktivitet';
+import {MoterIDag} from '../components/tabell/headerceller/MoterIDag';
+import {MoteVarighet} from '../components/tabell/headerceller/MoteVarighet';
+import {Motestatus} from '../components/tabell/headerceller/Motestatus';
 
 function harValgteAktiviteter(aktiviteter) {
     if (aktiviteter && Object.keys(aktiviteter).length > 0) {
@@ -211,53 +224,20 @@ function EnhetListehode({
                     title="Gjenstående uker av rettighetsperioden for AAP"
                     className="col col-xs-2"
                 />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.VENTER_SVAR_FRA_NAV_DATO)}
-                    sortering={Sorteringsfelt.VENTER_PA_SVAR_FRA_NAV}
-                    erValgt={sorteringsfelt === Sorteringsfelt.VENTER_PA_SVAR_FRA_NAV}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Dato på melding"
-                    title='Dato på meldingen som er merket "Venter på svar fra NAV"'
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.VENTER_SVAR_FRA_BRUKER_DATO)}
-                    sortering={Sorteringsfelt.VENTER_PA_SVAR_FRA_BRUKER}
-                    erValgt={sorteringsfelt === Sorteringsfelt.VENTER_PA_SVAR_FRA_BRUKER}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Dato på melding"
-                    title='Dato på meldingen som er merket "Venter på svar fra bruker"'
-                    className="col col-xs-2"
-                />
+
+                <VenterPaSvarFraNav {...sorteringTilHeadercelle} />
+                <VenterPaSvarFraBruker {...sorteringTilHeadercelle} />
+
                 {visKolonnerForHendelsesfilter && (
                     <>
                         <FilterhendelseLenke {...sorteringTilHeadercelle} />
                         <FilterhendelseDatoOpprettet {...sorteringTilHeadercelle} />
                     </>
                 )}
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.UTLOPTE_AKTIVITETER)}
-                    sortering={Sorteringsfelt.UTLOPTE_AKTIVITETER}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTLOPTE_AKTIVITETER}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Utløpsdato aktivitet"
-                    title='Utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.AVTALT_AKTIVITET)}
-                    sortering={Sorteringsfelt.I_AVTALT_AKTIVITET}
-                    erValgt={sorteringsfelt === Sorteringsfelt.I_AVTALT_AKTIVITET}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Neste utløpsdato aktivitet"
-                    title='Neste utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
-                    headerTestId="sorteringheader_i-avtalt-aktivitet"
-                    className="col col-xs-2"
-                />
+
+                <UtlopteAktiviteter {...sorteringTilHeadercelle} />
+                <AvtaltAktivitet {...sorteringTilHeadercelle} />
+
                 <SorteringHeader
                     skalVises={avansertAktivitet || forenkletAktivitet || tiltaksType}
                     sortering={Sorteringsfelt.VALGTE_AKTIVITETER}
@@ -269,33 +249,9 @@ function EnhetListehode({
                     className="col col-xs-2"
                 />
 
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.MOTER_IDAG)}
-                    sortering={Sorteringsfelt.MOTER_MED_NAV_IDAG}
-                    erValgt={sorteringsfelt === Sorteringsfelt.MOTER_MED_NAV_IDAG}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Klokkeslett møte"
-                    title="Tidspunktet møtet starter"
-                    className="col col-xs-2"
-                />
-                <Header
-                    skalVises={valgteKolonner.includes(Kolonne.MOTER_VARIGHET)}
-                    title="Varighet på møtet"
-                    className="col col-xs-2"
-                >
-                    Varighet møte
-                </Header>
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.MOTE_ER_AVTALT)}
-                    sortering={Sorteringsfelt.MOTESTATUS}
-                    erValgt={sorteringsfelt === Sorteringsfelt.MOTESTATUS}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Avtalt med NAV"
-                    title="Møtestatus"
-                    className="col col-xs-2"
-                />
+                <MoterIDag {...sorteringTilHeadercelle} />
+                <MoteVarighet {...sorteringTilHeadercelle} />
+                <Motestatus {...sorteringTilHeadercelle} />
 
                 <SorteringHeader
                     skalVises={valgteKolonner.includes(Kolonne.VEDTAKSTATUS)}
@@ -327,25 +283,9 @@ function EnhetListehode({
                     title="Ansvarlig veileder for vedtak"
                     className="col col-xs-2"
                 />
-                <Header
-                    // Dette er siste endring frå under "Hendelser", i aktiviteter personen sjølv har oppretta.
-                    skalVises={valgteKolonner.includes(Kolonne.SISTE_ENDRING)}
-                    title="Personens siste endring av aktiviteter/mål"
-                    className="col col-xs-2"
-                >
-                    Siste endring
-                </Header>
-                <SorteringHeader
-                    // Dette er siste endring frå under "Hendelser", i aktiviteter personen sjølv har oppretta.
-                    skalVises={valgteKolonner.includes(Kolonne.SISTE_ENDRING_DATO)}
-                    sortering={Sorteringsfelt.SISTE_ENDRING_DATO}
-                    erValgt={sorteringsfelt === Sorteringsfelt.SISTE_ENDRING_DATO}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Dato siste endring"
-                    title="Dato personen sist gjorde endring i aktiviteter/mål"
-                    className="col col-xs-2"
-                />
+
+                <SisteEndring {...sorteringTilHeadercelle} />
+                <SisteEndringDato {...sorteringTilHeadercelle} />
 
                 <SvarfristCv {...sorteringTilHeadercelle} />
 
@@ -358,48 +298,10 @@ function EnhetListehode({
                     </>
                 )}
 
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_UTLOP_OVERGANGSSTONAD)}
-                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_UTLOP_YTELSE}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_UTLOP_YTELSE}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Utløp overgangsstønad"
-                    title="Utløpsdato for overgangsstønad"
-                    headerTestId="sorteringheader_utlop_overgangsstonad"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_VEDTAKSPERIODE)}
-                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Type vedtaksperiode overgangsstønad"
-                    title="Type vedtaksperiode for overgangsstønad"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_AKIVITETSPLIKT)}
-                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_AKTIVITETSPLIKT}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_AKTIVITETSPLIKT}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Om aktivitetsplikt overgangsstønad"
-                    title="Om bruker har aktivitetsplikt på overgangsstønad"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_OM_BARNET)}
-                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_OM_BARNET}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_OM_BARNET}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Om barnet"
-                    title="Dato når barnet er hhv. 6 mnd/1 år gammelt"
-                    headerTestId="sorteringheader_enslige-forsorgere-om-barnet"
-                    className="col col-xs-3"
-                />
+                <EnsligeForsorgereUtlopOvergangsstonad {...sorteringTilHeadercelle} />
+                <EnsligeForsorgereVedtaksperiode {...sorteringTilHeadercelle} />
+                <EnsligeForsorgereAktivitetsplikt {...sorteringTilHeadercelle} />
+                <EnsligeForsorgereOmBarnet {...sorteringTilHeadercelle} />
 
                 <BarnUnder18Aar {...sorteringTilHeadercelle} />
 

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -39,6 +39,8 @@ import {GjeldendeVedtak14aHovedmal} from '../components/tabell/headerceller/Gjel
 import {GjeldendeVedtak14aVedtaksdato} from '../components/tabell/headerceller/GjeldendeVedtak14aVedtaksdato';
 import {FilterhendelseLenke} from '../components/tabell/headerceller/FilterhendelseLenke';
 import {FilterhendelseDatoOpprettet} from '../components/tabell/headerceller/FilterhendelseDatoOpprettet';
+import {TiltakshendelseDatoOpprettet} from '../components/tabell/headerceller/TiltakshendelseDatoOpprettet';
+import {TiltakshendelseLenke} from '../components/tabell/headerceller/TiltakshendelseLenke';
 
 function harValgteAktiviteter(aktiviteter) {
     if (aktiviteter && Object.keys(aktiviteter).length > 0) {
@@ -403,26 +405,8 @@ function EnhetListehode({
 
                 <UtdanningOgSituasjonSistEndret {...sorteringTilHeadercelle} />
 
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.TILTAKSHENDELSE_LENKE)}
-                    sortering={Sorteringsfelt.TILTAKSHENDELSE_TEKST}
-                    erValgt={sorteringsfelt === Sorteringsfelt.TILTAKSHENDELSE_TEKST}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Hendelse på tiltak"
-                    title="Lenke til hendelsen"
-                    className="col col-xs-3"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.TILTAKSHENDELSE_DATO_OPPRETTET)}
-                    sortering={Sorteringsfelt.TILTAKSHENDELSE_DATO_OPPRETTET}
-                    erValgt={sorteringsfelt === Sorteringsfelt.TILTAKSHENDELSE_DATO_OPPRETTET}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Dato for hendelse"
-                    title="Dato da hendelsen ble opprettet"
-                    className="col col-xs-2"
-                />
+                <TiltakshendelseLenke {...sorteringTilHeadercelle} />
+                <TiltakshendelseDatoOpprettet {...sorteringTilHeadercelle} />
             </div>
             <div className="brukerliste__gutter-right" />
         </div>

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -54,6 +54,9 @@ import {AvtaltAktivitet} from '../components/tabell/headerceller/AvtaltAktivitet
 import {MoterIDag} from '../components/tabell/headerceller/MoterIDag';
 import {MoteVarighet} from '../components/tabell/headerceller/MoteVarighet';
 import {Motestatus} from '../components/tabell/headerceller/Motestatus';
+import {UnderVurderingVedtaksstatus} from '../components/tabell/headerceller/UnderVurderingVedtaksstatus';
+import {UnderVurderingVedtaksstatusEndret} from '../components/tabell/headerceller/UnderVurderingVedtaksstatusEndret';
+import {UnderVurderingAnsvarligVeileder} from '../components/tabell/headerceller/UnderVurderingAnsvarligVeileder';
 
 function harValgteAktiviteter(aktiviteter) {
     if (aktiviteter && Object.keys(aktiviteter).length > 0) {
@@ -253,36 +256,9 @@ function EnhetListehode({
                 <MoteVarighet {...sorteringTilHeadercelle} />
                 <Motestatus {...sorteringTilHeadercelle} />
 
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.VEDTAKSTATUS)}
-                    sortering={Sorteringsfelt.UTKAST_14A_STATUS}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Status § 14a-vedtak"
-                    title="Status oppfølgingvedtak"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.VEDTAKSTATUS_ENDRET)}
-                    sortering={Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Statusendring"
-                    title="Dager siden fikk status"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.ANSVARLIG_VEILEDER_FOR_VEDTAK)}
-                    sortering={Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Ansvarlig for vedtak"
-                    title="Ansvarlig veileder for vedtak"
-                    className="col col-xs-2"
-                />
+                <UnderVurderingVedtaksstatus {...sorteringTilHeadercelle} />
+                <UnderVurderingVedtaksstatusEndret {...sorteringTilHeadercelle} />
+                <UnderVurderingAnsvarligVeileder {...sorteringTilHeadercelle} />
 
                 <SisteEndring {...sorteringTilHeadercelle} />
                 <SisteEndringDato {...sorteringTilHeadercelle} />

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -11,7 +11,6 @@ import {
 import {FiltervalgModell, Sorteringsfelt, Sorteringsrekkefolge} from '../model-interfaces';
 import {Kolonne} from '../ducks/ui/listevisning';
 import {AktiviteterValg} from '../ducks/filtrering';
-import Header from '../components/tabell/header';
 import VelgalleCheckboks from '../components/toolbar/velgalle-checkboks';
 import './enhetsportefolje.css';
 import './brukerliste.css';
@@ -57,6 +56,8 @@ import {Motestatus} from '../components/tabell/headerceller/Motestatus';
 import {UnderVurderingVedtaksstatus} from '../components/tabell/headerceller/UnderVurderingVedtaksstatus';
 import {UnderVurderingVedtaksstatusEndret} from '../components/tabell/headerceller/UnderVurderingVedtaksstatusEndret';
 import {UnderVurderingAnsvarligVeileder} from '../components/tabell/headerceller/UnderVurderingAnsvarligVeileder';
+import {VeilederNavident} from '../components/tabell/headerceller/enhetens-oversikt/VeilederNavident';
+import {VeilederNavn} from '../components/tabell/headerceller/enhetens-oversikt/VeilederNavn';
 
 function harValgteAktiviteter(aktiviteter) {
     if (aktiviteter && Object.keys(aktiviteter).length > 0) {
@@ -139,23 +140,9 @@ function EnhetListehode({
 
                 <OppfolgingStartet {...sorteringTilHeadercelle} />
 
-                <Header
-                    skalVises={valgteKolonner.includes(Kolonne.VEILEDER)}
-                    headerTestId="sorteringheader_veileder"
-                    className="col col-xs-2"
-                >
-                    Veileder
-                </Header>
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.NAVIDENT)}
-                    sortering={Sorteringsfelt.NAVIDENT}
-                    erValgt={sorteringsfelt === Sorteringsfelt.NAVIDENT}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="NAV-ident"
-                    title="NAV-ident på tildelt veileder"
-                    className="header__veilederident col col-xs-2"
-                />
+                <VeilederNavn {...sorteringTilHeadercelle} />
+                <VeilederNavident {...sorteringTilHeadercelle} />
+
                 <SorteringHeader
                     skalVises={
                         erDagpengerYtelse && valgteKolonner.includes(Kolonne.GJENSTAENDE_UKER_RETTIGHET_DAGPENGER)

--- a/src/minoversikt/minoversikt-kolonner.tsx
+++ b/src/minoversikt/minoversikt-kolonner.tsx
@@ -417,7 +417,7 @@ export function MinOversiktKolonner({bruker, enhetId, filtervalg, valgteKolonner
             <TekstKolonne
                 tekst={oppfolingsdatoEnsligeForsorgere(bruker.ensligeForsorgereOvergangsstonad?.yngsteBarnsFodselsdato)}
                 skalVises={valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_OM_BARNET)}
-                className="col col-xs-2"
+                className="col col-xs-3"
             />
             <TekstKolonne
                 className="col col-xs-2"

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -438,7 +438,7 @@ function MinOversiktListeHode({
                     tekst="Om barnet"
                     title="Dato når barnet er hhv. 6 mnd/1 år gammelt"
                     headerTestId="sorteringheader_enslige-forsorgere-om-barnet"
-                    className="col col-xs-2"
+                    className="col col-xs-3"
                 />
                 <BarnUnder18Aar {...sorteringTilHeadercelle} />
 

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -1,5 +1,4 @@
 import SorteringHeader from '../components/tabell/sortering-header';
-import SorteringHeaderIkon from '../components/tabell/sortering-header-ikon';
 import {FiltervalgModell, Sorteringsfelt, Sorteringsrekkefolge} from '../model-interfaces';
 import {AktiviteterValg} from '../ducks/filtrering';
 import {
@@ -16,8 +15,6 @@ import VelgalleCheckboks from '../components/toolbar/velgalle-checkboks';
 import {OrNothing} from '../utils/types/types';
 import {useFeatureSelector} from '../hooks/redux/use-feature-selector';
 import {VIS_AAP_VURDERINGSFRISTKOLONNER, VIS_FILTER_14A_FRA_VEDTAKSSTOTTE, VIS_HENDELSESFILTER} from '../konstanter';
-import {ReactComponent as FargekategoriIkonTomtBokmerke} from '../components/ikoner/fargekategorier/Fargekategoriikon_bokmerke.svg';
-import {ReactComponent as HuskelappIkon} from '../components/ikoner/huskelapp/Huskelappikon.svg';
 import {Navn} from '../components/tabell/headerceller/Navn';
 import {Fnr} from '../components/tabell/headerceller/Fnr';
 import {Fodeland} from '../components/tabell/headerceller/Fodeland';
@@ -59,6 +56,8 @@ import {Motestatus} from '../components/tabell/headerceller/Motestatus';
 import {UnderVurderingVedtaksstatus} from '../components/tabell/headerceller/UnderVurderingVedtaksstatus';
 import {UnderVurderingVedtaksstatusEndret} from '../components/tabell/headerceller/UnderVurderingVedtaksstatusEndret';
 import {UnderVurderingAnsvarligVeileder} from '../components/tabell/headerceller/UnderVurderingAnsvarligVeileder';
+import {Fargekategori} from '../components/tabell/headerceller/min-oversikt/Fargekategori';
+import {Huskelapp} from '../components/tabell/headerceller/min-oversikt/Huskelapp';
 import './minoversikt.css';
 
 function harValgteAktiviteter(aktiviteter) {
@@ -124,27 +123,12 @@ function MinOversiktListeHode({
     return (
         <div className="brukerliste__header brukerliste__sorteringheader">
             <VelgalleCheckboks />
+
             <div className="brukerliste__minoversikt-ikonknapper">
-                <SorteringHeaderIkon
-                    ikon={<FargekategoriIkonTomtBokmerke aria-hidden />}
-                    sortering={Sorteringsfelt.FARGEKATEGORI}
-                    erValgt={sorteringsfelt === Sorteringsfelt.FARGEKATEGORI}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    title="Fargekategori-sortering"
-                    headerId="fargekategori"
-                />
-                <SorteringHeaderIkon
-                    ikon={<HuskelappIkon aria-hidden />}
-                    sortering={Sorteringsfelt.HUSKELAPP}
-                    erValgt={sorteringsfelt === Sorteringsfelt.HUSKELAPP}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    title="Huskelapp-sortering"
-                    headerId="huskelapp"
-                    className="huskelapp__sorteringsheader"
-                />
+                <Fargekategori {...sorteringTilHeadercelle} />
+                <Huskelapp {...sorteringTilHeadercelle} />
             </div>
+
             <div className="brukerliste__innhold" data-testid="brukerliste_innhold">
                 <Navn {...sorteringTilHeadercelle} />
                 <Fnr {...sorteringTilHeadercelle} />

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -42,6 +42,8 @@ import {GjeldendeVedtak14aHovedmal} from '../components/tabell/headerceller/Gjel
 import {GjeldendeVedtak14aVedtaksdato} from '../components/tabell/headerceller/GjeldendeVedtak14aVedtaksdato';
 import {FilterhendelseLenke} from '../components/tabell/headerceller/FilterhendelseLenke';
 import {FilterhendelseDatoOpprettet} from '../components/tabell/headerceller/FilterhendelseDatoOpprettet';
+import {TiltakshendelseDatoOpprettet} from '../components/tabell/headerceller/TiltakshendelseDatoOpprettet';
+import {TiltakshendelseLenke} from '../components/tabell/headerceller/TiltakshendelseLenke';
 import './minoversikt.css';
 
 function harValgteAktiviteter(aktiviteter) {
@@ -445,26 +447,8 @@ function MinOversiktListeHode({
                 <HuskelappKommentar {...sorteringTilHeadercelle} />
                 <HuskelappFrist {...sorteringTilHeadercelle} />
 
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.TILTAKSHENDELSE_LENKE)}
-                    sortering={Sorteringsfelt.TILTAKSHENDELSE_TEKST}
-                    erValgt={sorteringsfelt === Sorteringsfelt.TILTAKSHENDELSE_TEKST}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Hendelse på tiltak"
-                    title="Lenke til hendelsen"
-                    className="col col-xs-3"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.TILTAKSHENDELSE_DATO_OPPRETTET)}
-                    sortering={Sorteringsfelt.TILTAKSHENDELSE_DATO_OPPRETTET}
-                    erValgt={sorteringsfelt === Sorteringsfelt.TILTAKSHENDELSE_DATO_OPPRETTET}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Dato for hendelse"
-                    title="Dato da hendelsen ble opprettet"
-                    className="col col-xs-2"
-                />
+                <TiltakshendelseLenke {...sorteringTilHeadercelle} />
+                <TiltakshendelseDatoOpprettet {...sorteringTilHeadercelle} />
             </div>
             <div className="brukerliste__gutter-right" />
         </div>

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -12,7 +12,6 @@ import {
     ytelseUtlopsSortering
 } from '../filtrering/filter-konstanter';
 import {Kolonne} from '../ducks/ui/listevisning';
-import Header from '../components/tabell/header';
 import VelgalleCheckboks from '../components/toolbar/velgalle-checkboks';
 import {OrNothing} from '../utils/types/types';
 import {useFeatureSelector} from '../hooks/redux/use-feature-selector';
@@ -44,6 +43,19 @@ import {FilterhendelseLenke} from '../components/tabell/headerceller/Filterhende
 import {FilterhendelseDatoOpprettet} from '../components/tabell/headerceller/FilterhendelseDatoOpprettet';
 import {TiltakshendelseDatoOpprettet} from '../components/tabell/headerceller/TiltakshendelseDatoOpprettet';
 import {TiltakshendelseLenke} from '../components/tabell/headerceller/TiltakshendelseLenke';
+import {EnsligeForsorgereOmBarnet} from '../components/tabell/headerceller/EnsligeForsorgereOmBarnet';
+import {EnsligeForsorgereAktivitetsplikt} from '../components/tabell/headerceller/EnsligeForsorgereAktivitetsplikt';
+import {EnsligeForsorgereVedtaksperiode} from '../components/tabell/headerceller/EnsligeForsorgereVedtaksperiode';
+import {EnsligeForsorgereUtlopOvergangsstonad} from '../components/tabell/headerceller/EnsligeForsorgereUtlopOvergangsstonad';
+import {SisteEndringDato} from '../components/tabell/headerceller/SisteEndringDato';
+import {SisteEndring} from '../components/tabell/headerceller/SisteEndring';
+import {VenterPaSvarFraNav} from '../components/tabell/headerceller/VenterPaSvarFraNav';
+import {VenterPaSvarFraBruker} from '../components/tabell/headerceller/VenterPaSvarFraBruker';
+import {UtlopteAktiviteter} from '../components/tabell/headerceller/UtlopteAktiviteter';
+import {AvtaltAktivitet} from '../components/tabell/headerceller/AvtaltAktivitet';
+import {MoterIDag} from '../components/tabell/headerceller/MoterIDag';
+import {MoteVarighet} from '../components/tabell/headerceller/MoteVarighet';
+import {Motestatus} from '../components/tabell/headerceller/Motestatus';
 import './minoversikt.css';
 
 function harValgteAktiviteter(aktiviteter) {
@@ -219,81 +231,23 @@ function MinOversiktListeHode({
                     title="Gjenstående uker av rettighetsperioden for AAP"
                     className="col col-xs-2"
                 />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.VENTER_SVAR_FRA_NAV_DATO)}
-                    sortering={Sorteringsfelt.VENTER_PA_SVAR_FRA_NAV}
-                    erValgt={sorteringsfelt === Sorteringsfelt.VENTER_PA_SVAR_FRA_NAV}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Dato på melding"
-                    title='Dato på meldingen som er merket "Venter på svar fra NAV"'
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.VENTER_SVAR_FRA_BRUKER_DATO)}
-                    sortering={Sorteringsfelt.VENTER_PA_SVAR_FRA_BRUKER}
-                    erValgt={sorteringsfelt === Sorteringsfelt.VENTER_PA_SVAR_FRA_BRUKER}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Dato på melding"
-                    title='Dato på meldingen som er merket "Venter på svar fra bruker"'
-                    className="col col-xs-2"
-                />
+
+                <VenterPaSvarFraNav {...sorteringTilHeadercelle} />
+                <VenterPaSvarFraBruker {...sorteringTilHeadercelle} />
+
                 {visKolonnerForHendelsesfilter && (
                     <>
                         <FilterhendelseLenke {...sorteringTilHeadercelle} />
                         <FilterhendelseDatoOpprettet {...sorteringTilHeadercelle} />
                     </>
                 )}
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.UTLOPTE_AKTIVITETER)}
-                    sortering={Sorteringsfelt.UTLOPTE_AKTIVITETER}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTLOPTE_AKTIVITETER}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Utløpsdato aktivitet"
-                    title='Utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.AVTALT_AKTIVITET)}
-                    sortering={Sorteringsfelt.I_AVTALT_AKTIVITET}
-                    erValgt={sorteringsfelt === Sorteringsfelt.I_AVTALT_AKTIVITET}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Neste utløpsdato aktivitet"
-                    title='Neste utløpsdato på avtalt aktivitet under "Planlegger" eller "Gjennomfører"'
-                    headerTestId="sorteringheader_i-avtalt-aktivitet"
-                    className="col col-xs-2"
-                />
 
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.MOTER_IDAG)}
-                    sortering={Sorteringsfelt.MOTER_MED_NAV_IDAG}
-                    erValgt={sorteringsfelt === Sorteringsfelt.MOTER_MED_NAV_IDAG}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Klokkeslett møte"
-                    title="Tidspunktet møtet starter"
-                    className="col col-xs-2"
-                />
-                <Header
-                    skalVises={valgteKolonner.includes(Kolonne.MOTER_VARIGHET)}
-                    title="Varighet på møtet"
-                    className="col col-xs-2"
-                >
-                    Varighet møte
-                </Header>
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.MOTE_ER_AVTALT)}
-                    sortering={Sorteringsfelt.MOTESTATUS}
-                    erValgt={sorteringsfelt === Sorteringsfelt.MOTESTATUS}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Avtalt med NAV"
-                    title="Møtestatus"
-                    className="col col-xs-2"
-                />
+                <UtlopteAktiviteter {...sorteringTilHeadercelle} />
+                <AvtaltAktivitet {...sorteringTilHeadercelle} />
+
+                <MoterIDag {...sorteringTilHeadercelle} />
+                <MoteVarighet {...sorteringTilHeadercelle} />
+                <Motestatus {...sorteringTilHeadercelle} />
 
                 <SorteringHeader
                     skalVises={valgteKolonner.includes(Kolonne.VEDTAKSTATUS)}
@@ -367,25 +321,8 @@ function MinOversiktListeHode({
                     className="col col-xs-2"
                 />
 
-                <Header
-                    // Dette er siste endring frå under "Hendelser", i aktiviteter personen sjølv har oppretta.
-                    skalVises={valgteKolonner.includes(Kolonne.SISTE_ENDRING)}
-                    title="Personens siste endring av aktiviteter/mål"
-                    className="col col-xs-2"
-                >
-                    Siste endring
-                </Header>
-                <SorteringHeader
-                    // Dette er siste endring frå under "Hendelser", i aktiviteter personen sjølv har oppretta.
-                    skalVises={valgteKolonner.includes(Kolonne.SISTE_ENDRING_DATO)}
-                    sortering={Sorteringsfelt.SISTE_ENDRING_DATO}
-                    erValgt={sorteringsfelt === Sorteringsfelt.SISTE_ENDRING_DATO}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Dato personen sist gjorde endring i aktiviteter/mål"
-                    title="Dato siste endring"
-                    className="col col-xs-2"
-                />
+                <SisteEndring {...sorteringTilHeadercelle} />
+                <SisteEndringDato {...sorteringTilHeadercelle} />
 
                 <SvarfristCv {...sorteringTilHeadercelle} />
 
@@ -398,48 +335,11 @@ function MinOversiktListeHode({
                     </>
                 )}
 
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_UTLOP_OVERGANGSSTONAD)}
-                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_UTLOP_YTELSE}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_UTLOP_YTELSE}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Utløp overgangsstønad"
-                    title="Utløpsdato for overgangsstønad"
-                    headerTestId="sorteringheader_utlop_overgangsstonad"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_VEDTAKSPERIODE)}
-                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Type vedtaksperiode overgangsstønad"
-                    title="Type vedtaksperiode for overgangsstønad"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_AKIVITETSPLIKT)}
-                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_AKTIVITETSPLIKT}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_AKTIVITETSPLIKT}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Om aktivitetsplikt overgangsstønad"
-                    title="Om bruker har aktivitetsplikt på overgangsstønad"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.ENSLIGE_FORSORGERE_OM_BARNET)}
-                    sortering={Sorteringsfelt.ENSLIGE_FORSORGERE_OM_BARNET}
-                    erValgt={sorteringsfelt === Sorteringsfelt.ENSLIGE_FORSORGERE_OM_BARNET}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Om barnet"
-                    title="Dato når barnet er hhv. 6 mnd/1 år gammelt"
-                    headerTestId="sorteringheader_enslige-forsorgere-om-barnet"
-                    className="col col-xs-3"
-                />
+                <EnsligeForsorgereUtlopOvergangsstonad {...sorteringTilHeadercelle} />
+                <EnsligeForsorgereVedtaksperiode {...sorteringTilHeadercelle} />
+                <EnsligeForsorgereAktivitetsplikt {...sorteringTilHeadercelle} />
+                <EnsligeForsorgereOmBarnet {...sorteringTilHeadercelle} />
+
                 <BarnUnder18Aar {...sorteringTilHeadercelle} />
 
                 <UtdanningOgSituasjonSistEndret {...sorteringTilHeadercelle} />

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -56,6 +56,9 @@ import {AvtaltAktivitet} from '../components/tabell/headerceller/AvtaltAktivitet
 import {MoterIDag} from '../components/tabell/headerceller/MoterIDag';
 import {MoteVarighet} from '../components/tabell/headerceller/MoteVarighet';
 import {Motestatus} from '../components/tabell/headerceller/Motestatus';
+import {UnderVurderingVedtaksstatus} from '../components/tabell/headerceller/UnderVurderingVedtaksstatus';
+import {UnderVurderingVedtaksstatusEndret} from '../components/tabell/headerceller/UnderVurderingVedtaksstatusEndret';
+import {UnderVurderingAnsvarligVeileder} from '../components/tabell/headerceller/UnderVurderingAnsvarligVeileder';
 import './minoversikt.css';
 
 function harValgteAktiviteter(aktiviteter) {
@@ -249,36 +252,9 @@ function MinOversiktListeHode({
                 <MoteVarighet {...sorteringTilHeadercelle} />
                 <Motestatus {...sorteringTilHeadercelle} />
 
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.VEDTAKSTATUS)}
-                    sortering={Sorteringsfelt.UTKAST_14A_STATUS}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Status § 14a-vedtak"
-                    title="Status oppfølgingvedtak"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.VEDTAKSTATUS_ENDRET)}
-                    sortering={Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Dager siden status"
-                    title="Dager siden status"
-                    className="col col-xs-2"
-                />
-                <SorteringHeader
-                    skalVises={valgteKolonner.includes(Kolonne.ANSVARLIG_VEILEDER_FOR_VEDTAK)}
-                    sortering={Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
-                    erValgt={sorteringsfelt === Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
-                    rekkefolge={sorteringsrekkefolge}
-                    onClick={sorteringOnClick}
-                    tekst="Ansvarlig for vedtak"
-                    title="Ansvarlig veileder for vedtak"
-                    className="col col-xs-2"
-                />
+                <UnderVurderingVedtaksstatus {...sorteringTilHeadercelle} />
+                <UnderVurderingVedtaksstatusEndret {...sorteringTilHeadercelle} />
+                <UnderVurderingAnsvarligVeileder {...sorteringTilHeadercelle} />
 
                 <SorteringHeader
                     skalVises={avansertAktivitet || forenkletAktivitet || tiltaksType}


### PR DESCRIPTION
Målet her er å lage gjenbrukbare komponentar i staden for å hardkode verdiar for kolonneoverskrifter i to filer.
I tillegg vert "listehode"-filene lettare å få oversikt i når dei ikkje har like mykje detaljar.

Eg oppdaga nokre skilnadar mellom kolonner i Min oversikt og Enhetens oversikt:
- Ulik kolonnebreidd på "Om barnet"-kolonne
- Ulik tekst i "Under vurdering"-kolonner
Retting av desse har eigne commitar.


#### Dette har eg sett på i eigen-review:
- At komponentnamn samsvarar med kolonne/sorteringsfelt
- At rekkefølgja på kolonner før/etter er lik i begge oversiktene
- At eg har kopiert over rett felt då eg oppretta komponentane
