### PR TITLE
Oppdater avhengigheiter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
                 "cypress": "13.17.0",
                 "husky": "8.0.3",
                 "lint-staged": "15.3.0",
-                "msw": "2.3.1",
+                "msw": "2.7.0",
                 "prettier": "3.3.2"
             }
         },
@@ -2164,6 +2164,16 @@
                 "statuses": "^2.0.1"
             }
         },
+        "node_modules/@bundled-es-modules/tough-cookie": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz",
+            "integrity": "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==",
+            "dev": true,
+            "dependencies": {
+                "@types/tough-cookie": "^4.0.5",
+                "tough-cookie": "^4.1.4"
+            }
+        },
         "node_modules/@colors/colors": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -2665,37 +2675,36 @@
             "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="
         },
         "node_modules/@inquirer/confirm": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.6.tgz",
-            "integrity": "sha512-Mj4TU29g6Uy+37UtpA8UpEOI2icBfpCwSW1QDtfx60wRhUy90s/kHPif2OXSSvuwDQT1lhAYRWUfkNf9Tecxvg==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.1.tgz",
+            "integrity": "sha512-vVLSbGci+IKQvDOtzpPTCOiEJCNidHcAq9JYVoWTW0svb5FiwSLotkM+JXNXejfjnzVYV9n0DTBythl9+XgTxg==",
             "dev": true,
             "dependencies": {
-                "@inquirer/core": "^8.1.0",
-                "@inquirer/type": "^1.3.1"
+                "@inquirer/core": "^10.1.2",
+                "@inquirer/type": "^3.0.2"
             },
             "engines": {
                 "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
             }
         },
         "node_modules/@inquirer/core": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-8.1.0.tgz",
-            "integrity": "sha512-kfx0SU9nWgGe1f03ao/uXc85SFH1v2w3vQVH7QDGjKxdtJz+7vPitFtG++BTyJMYyYgH8MpXigutcXJeiQwVRw==",
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.2.tgz",
+            "integrity": "sha512-bHd96F3ezHg1mf/J0Rb4CV8ndCN0v28kUlrHqP7+ECm1C/A+paB7Xh2lbMk6x+kweQC+rZOxM/YeKikzxco8bQ==",
             "dev": true,
             "dependencies": {
-                "@inquirer/figures": "^1.0.1",
-                "@inquirer/type": "^1.3.1",
-                "@types/mute-stream": "^0.0.4",
-                "@types/node": "^20.12.7",
-                "@types/wrap-ansi": "^3.0.0",
+                "@inquirer/figures": "^1.0.9",
+                "@inquirer/type": "^3.0.2",
                 "ansi-escapes": "^4.3.2",
-                "chalk": "^4.1.2",
-                "cli-spinners": "^2.9.2",
                 "cli-width": "^4.1.0",
-                "mute-stream": "^1.0.0",
+                "mute-stream": "^2.0.0",
                 "signal-exit": "^4.1.0",
                 "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^6.2.0"
+                "wrap-ansi": "^6.2.0",
+                "yoctocolors-cjs": "^2.1.2"
             },
             "engines": {
                 "node": ">=18"
@@ -2728,21 +2737,24 @@
             }
         },
         "node_modules/@inquirer/figures": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.1.tgz",
-            "integrity": "sha512-mtup3wVKia3ZwULPHcbs4Mor8Voi+iIXEWD7wCNbIO6lYR62oPCTQyrddi5OMYVXHzeCSoneZwJuS8sBvlEwDw==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.9.tgz",
+            "integrity": "sha512-BXvGj0ehzrngHTPTDqUoDT3NXL8U0RxUk2zJm2A66RhCEIWdtU1v6GuUqNAgArW4PQ9CinqIWyHdQgdwOj06zQ==",
             "dev": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@inquirer/type": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.3.1.tgz",
-            "integrity": "sha512-Pe3PFccjPVJV1vtlfVvm9OnlbxqdnP5QcscFEFEnK5quChf1ufZtM0r8mR5ToWHMxZOh0s8o/qp9ANGRTo/DAw==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.2.tgz",
+            "integrity": "sha512-ZhQ4TvhwHZF+lGhQ2O/rsjo80XoZR5/5qhOY3t6FJuX5XBg5Be8YzYTvaUGJnc12AUGI2nr4QSUE4PhKSigx7g==",
             "dev": true,
             "engines": {
                 "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -3153,26 +3165,17 @@
             "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
             "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
         },
-        "node_modules/@mswjs/cookies": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
-            "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
-            "dev": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/@mswjs/interceptors": {
-            "version": "0.29.1",
-            "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.29.1.tgz",
-            "integrity": "sha512-3rDakgJZ77+RiQUuSK69t1F0m8BQKA8Vh5DCS5V0DWvNY67zob2JhhQrhCO0AKLGINTRSFd1tBaHcJTkhefoSw==",
+            "version": "0.37.3",
+            "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.3.tgz",
+            "integrity": "sha512-USvgCL/uOGFtVa6SVyRrC8kIAedzRohxIXN5LISlg5C5vLZCn7dgMFVSNhSF9cuBEFrm/O2spDWEZeMnw4ZXYg==",
             "dev": true,
             "dependencies": {
                 "@open-draft/deferred-promise": "^2.2.0",
                 "@open-draft/logger": "^0.3.0",
                 "@open-draft/until": "^2.0.0",
                 "is-node-process": "^1.2.0",
-                "outvariant": "^1.2.1",
+                "outvariant": "^1.4.3",
                 "strict-event-emitter": "^0.5.1"
             },
             "engines": {
@@ -4549,15 +4552,6 @@
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
             "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
         },
-        "node_modules/@types/mute-stream": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
-            "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/node": {
             "version": "20.12.10",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.10.tgz",
@@ -4735,16 +4729,16 @@
             "integrity": "sha512-eqNDvZsCNY49OAXB0Firg/Sc2BgoWsntsLUdybGFOhAfCD6QJ2n9HXUIHGqt5qjrxmMv4wS8WLAw43ZkKcJ8Pw==",
             "dev": true
         },
+        "node_modules/@types/tough-cookie": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+            "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+            "dev": true
+        },
         "node_modules/@types/trusted-types": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
             "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
-        },
-        "node_modules/@types/wrap-ansi": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
-            "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
-            "dev": true
         },
         "node_modules/@types/ws": {
             "version": "8.5.3",
@@ -6472,18 +6466,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/cli-spinners": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-            "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/cli-table3": {
@@ -13415,28 +13397,29 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node_modules/msw": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/msw/-/msw-2.3.1.tgz",
-            "integrity": "sha512-ocgvBCLn/5l3jpl1lssIb3cniuACJLoOfZu01e3n5dbJrpA5PeeWn28jCLgQDNt6d7QT8tF2fYRzm9JoEHtiig==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/msw/-/msw-2.7.0.tgz",
+            "integrity": "sha512-BIodwZ19RWfCbYTxWTUfTXc+sg4OwjCAgxU1ZsgmggX/7S3LdUifsbUPJs61j0rWb19CZRGY5if77duhc0uXzw==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "@bundled-es-modules/cookie": "^2.0.0",
+                "@bundled-es-modules/cookie": "^2.0.1",
                 "@bundled-es-modules/statuses": "^1.0.1",
-                "@inquirer/confirm": "^3.0.0",
-                "@mswjs/cookies": "^1.1.0",
-                "@mswjs/interceptors": "^0.29.0",
+                "@bundled-es-modules/tough-cookie": "^0.1.6",
+                "@inquirer/confirm": "^5.0.0",
+                "@mswjs/interceptors": "^0.37.0",
+                "@open-draft/deferred-promise": "^2.2.0",
                 "@open-draft/until": "^2.1.0",
                 "@types/cookie": "^0.6.0",
                 "@types/statuses": "^2.0.4",
-                "chalk": "^4.1.2",
                 "graphql": "^16.8.1",
                 "headers-polyfill": "^4.0.2",
                 "is-node-process": "^1.2.0",
-                "outvariant": "^1.4.2",
-                "path-to-regexp": "^6.2.0",
+                "outvariant": "^1.4.3",
+                "path-to-regexp": "^6.3.0",
+                "picocolors": "^1.1.1",
                 "strict-event-emitter": "^0.5.1",
-                "type-fest": "^4.9.0",
+                "type-fest": "^4.26.1",
                 "yargs": "^17.7.2"
             },
             "bin": {
@@ -13449,7 +13432,7 @@
                 "url": "https://github.com/sponsors/mswjs"
             },
             "peerDependencies": {
-                "typescript": ">= 4.7.x"
+                "typescript": ">= 4.8.x"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -13472,15 +13455,15 @@
             }
         },
         "node_modules/msw/node_modules/path-to-regexp": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-            "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
             "dev": true
         },
         "node_modules/msw/node_modules/type-fest": {
-            "version": "4.18.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
-            "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
+            "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
             "dev": true,
             "engines": {
                 "node": ">=16"
@@ -13529,12 +13512,12 @@
             }
         },
         "node_modules/mute-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-            "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+            "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
             "dev": true,
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/nanoid": {
@@ -14048,9 +14031,9 @@
             "dev": true
         },
         "node_modules/outvariant": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.2.tgz",
-            "integrity": "sha512-Ou3dJ6bA/UJ5GVHxah4LnqDwZRwAmWxrG3wtrHrbGnP4RnLCtA64A4F+ae7Y8ww660JaddSoArUR5HjipWSHAQ==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+            "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
             "dev": true
         },
         "node_modules/p-limit": {
@@ -14242,9 +14225,9 @@
             "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
         },
         "node_modules/picocolors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-            "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -17822,9 +17805,9 @@
             }
         },
         "node_modules/tough-cookie": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
-            "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+            "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
             "dependencies": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
@@ -19112,6 +19095,18 @@
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/yoctocolors-cjs": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+            "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
                 "@types/react-router": "5.1.20",
                 "@types/react-router-dom": "5.3.3",
                 "@types/react-transition-group": "4.4.10",
-                "cypress": "13.14.2",
+                "cypress": "13.17.0",
                 "husky": "8.0.3",
                 "lint-staged": "15.3.0",
                 "msw": "2.3.1",
@@ -2415,9 +2415,9 @@
             }
         },
         "node_modules/@cypress/request": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
-            "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.7.tgz",
+            "integrity": "sha512-LzxlLEMbBOPYB85uXrDqvD4MgcenjRBLIns3zyhx7vTPj/0u2eQhzXvPiGcaJrV38Q9dbkExWp6cOHPJ+EtFYg==",
             "dev": true,
             "dependencies": {
                 "aws-sign2": "~0.7.0",
@@ -2426,21 +2426,33 @@
                 "combined-stream": "~1.0.6",
                 "extend": "~3.0.2",
                 "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "http-signature": "~1.3.6",
+                "form-data": "~4.0.0",
+                "http-signature": "~1.4.0",
                 "is-typedarray": "~1.0.0",
                 "isstream": "~0.1.2",
                 "json-stringify-safe": "~5.0.1",
                 "mime-types": "~2.1.19",
                 "performance-now": "^2.1.0",
-                "qs": "6.10.4",
+                "qs": "6.13.1",
                 "safe-buffer": "^5.1.2",
-                "tough-cookie": "^4.1.3",
+                "tough-cookie": "^5.0.0",
                 "tunnel-agent": "^0.6.0",
                 "uuid": "^8.3.2"
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/@cypress/request/node_modules/tough-cookie": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
+            "integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
+            "dev": true,
+            "dependencies": {
+                "tldts": "^6.1.32"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/@cypress/xvfb": {
@@ -5618,9 +5630,9 @@
             }
         },
         "node_modules/aws4": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-            "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+            "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
             "dev": true
         },
         "node_modules/axe-core": {
@@ -7232,14 +7244,13 @@
             "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
         },
         "node_modules/cypress": {
-            "version": "13.14.2",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.14.2.tgz",
-            "integrity": "sha512-lsiQrN17vHMB2fnvxIrKLAjOr9bPwsNbPZNrWf99s4u+DVmCY6U+w7O3GGG9FvP4EUVYaDu+guWeNLiUzBrqvA==",
+            "version": "13.17.0",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.17.0.tgz",
+            "integrity": "sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==",
             "dev": true,
             "hasInstallScript": true,
-            "license": "MIT",
             "dependencies": {
-                "@cypress/request": "^3.0.1",
+                "@cypress/request": "^3.0.6",
                 "@cypress/xvfb": "^1.2.4",
                 "@types/sinonjs__fake-timers": "8.1.1",
                 "@types/sizzle": "^2.3.2",
@@ -7250,6 +7261,7 @@
                 "cachedir": "^2.3.0",
                 "chalk": "^4.1.0",
                 "check-more-types": "^2.24.0",
+                "ci-info": "^4.0.0",
                 "cli-cursor": "^3.1.0",
                 "cli-table3": "~0.6.1",
                 "commander": "^6.2.1",
@@ -7264,7 +7276,6 @@
                 "figures": "^3.2.0",
                 "fs-extra": "^9.1.0",
                 "getos": "^3.2.1",
-                "is-ci": "^3.0.1",
                 "is-installed-globally": "~0.4.0",
                 "lazy-ass": "^1.6.0",
                 "listr2": "^3.8.3",
@@ -7279,6 +7290,7 @@
                 "semver": "^7.5.3",
                 "supports-color": "^8.1.1",
                 "tmp": "~0.2.3",
+                "tree-kill": "1.2.2",
                 "untildify": "^4.0.0",
                 "yauzl": "^2.10.0"
             },
@@ -7287,6 +7299,21 @@
             },
             "engines": {
                 "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+            }
+        },
+        "node_modules/cypress/node_modules/ci-info": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
+            "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/damerau-levenshtein": {
@@ -9372,17 +9399,17 @@
             }
         },
         "node_modules/form-data": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+            "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
             "dev": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
+                "combined-stream": "^1.0.8",
                 "mime-types": "^2.1.12"
             },
             "engines": {
-                "node": ">= 0.12"
+                "node": ">= 6"
             }
         },
         "node_modules/formik": {
@@ -10141,14 +10168,14 @@
             }
         },
         "node_modules/http-signature": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
-            "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
+            "integrity": "sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==",
             "dev": true,
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^2.0.2",
-                "sshpk": "^1.14.1"
+                "sshpk": "^1.18.0"
             },
             "engines": {
                 "node": ">=0.10"
@@ -10425,18 +10452,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-ci": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-            "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-            "dev": true,
-            "dependencies": {
-                "ci-info": "^3.2.0"
-            },
-            "bin": {
-                "is-ci": "bin.js"
             }
         },
         "node_modules/is-core-module": {
@@ -15704,12 +15719,12 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.10.4",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
-            "integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
+            "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
             "dev": true,
             "dependencies": {
-                "side-channel": "^1.0.4"
+                "side-channel": "^1.0.6"
             },
             "engines": {
                 "node": ">=0.6"
@@ -17091,9 +17106,9 @@
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
         },
         "node_modules/sshpk": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-            "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+            "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
             "dev": true,
             "dependencies": {
                 "asn1": "~0.2.3",
@@ -17746,6 +17761,24 @@
             "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
             "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
         },
+        "node_modules/tldts": {
+            "version": "6.1.70",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.70.tgz",
+            "integrity": "sha512-/W1YVgYVJd9ZDjey5NXadNh0mJXkiUMUue9Zebd0vpdo1sU+H4zFFTaJ1RKD4N6KFoHfcXy6l+Vu7bh+bdWCzA==",
+            "dev": true,
+            "dependencies": {
+                "tldts-core": "^6.1.70"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "6.1.70",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.70.tgz",
+            "integrity": "sha512-RNnIXDB1FD4T9cpQRErEqw6ZpjLlGdMOitdV+0xtbsnwr4YFka1zpc7D4KD+aAn8oSG5JyFrdasZTE04qDE9Yg==",
+            "dev": true
+        },
         "node_modules/tmp": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
@@ -17819,6 +17852,15 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/tree-kill": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+            "dev": true,
+            "bin": {
+                "tree-kill": "cli.js"
             }
         },
         "node_modules/tryer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
                 "@types/react-transition-group": "4.4.10",
                 "cypress": "13.14.2",
                 "husky": "8.0.3",
-                "lint-staged": "15.2.10",
+                "lint-staged": "15.3.0",
                 "msw": "2.3.1",
                 "prettier": "3.3.2"
             }
@@ -7340,9 +7340,9 @@
             "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A=="
         },
         "node_modules/debug": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -9529,9 +9529,9 @@
             }
         },
         "node_modules/get-east-asian-width": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
-            "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+            "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
             "dev": true,
             "engines": {
                 "node": ">=18"
@@ -12478,21 +12478,21 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
         },
         "node_modules/lint-staged": {
-            "version": "15.2.10",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.10.tgz",
-            "integrity": "sha512-5dY5t743e1byO19P9I4b3x8HJwalIznL5E1FWYnU6OWw33KxNBSLAc6Cy7F2PsFEO8FKnLwjwm5hx7aMF0jzZg==",
+            "version": "15.3.0",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.3.0.tgz",
+            "integrity": "sha512-vHFahytLoF2enJklgtOtCtIjZrKD/LoxlaUusd5nh7dWv/dkKQJY74ndFSzxCdv7g0ueGg1ORgTSt4Y9LPZn9A==",
             "dev": true,
             "dependencies": {
-                "chalk": "~5.3.0",
+                "chalk": "~5.4.1",
                 "commander": "~12.1.0",
-                "debug": "~4.3.6",
+                "debug": "~4.4.0",
                 "execa": "~8.0.1",
-                "lilconfig": "~3.1.2",
-                "listr2": "~8.2.4",
+                "lilconfig": "~3.1.3",
+                "listr2": "~8.2.5",
                 "micromatch": "~4.0.8",
                 "pidtree": "~0.6.0",
                 "string-argv": "~0.3.2",
-                "yaml": "~2.5.0"
+                "yaml": "~2.6.1"
             },
             "bin": {
                 "lint-staged": "bin/lint-staged.js"
@@ -12544,9 +12544,9 @@
             }
         },
         "node_modules/lint-staged/node_modules/chalk": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-            "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+            "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
             "dev": true,
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -12676,9 +12676,9 @@
             }
         },
         "node_modules/lint-staged/node_modules/lilconfig": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
-            "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+            "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
             "dev": true,
             "engines": {
                 "node": ">=14"
@@ -12688,9 +12688,9 @@
             }
         },
         "node_modules/lint-staged/node_modules/listr2": {
-            "version": "8.2.4",
-            "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.2.4.tgz",
-            "integrity": "sha512-opevsywziHd3zHCVQGAj8zu+Z3yHNkkoYhWIGnq54RrCVwLz0MozotJEDnKsIBLvkfLGN6BLOyAeRrYI0pKA4g==",
+            "version": "8.2.5",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.2.5.tgz",
+            "integrity": "sha512-iyAZCeyD+c1gPyE9qpFu8af0Y+MRtmKOncdGoA2S5EY8iFq99dmmvkNnHiWo+pj0s7yH7l3KPIgee77tKpXPWQ==",
             "dev": true,
             "dependencies": {
                 "cli-truncate": "^4.0.0",
@@ -12929,9 +12929,9 @@
             }
         },
         "node_modules/lint-staged/node_modules/yaml": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-            "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+            "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
             "dev": true,
             "bin": {
                 "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "cypress": "13.17.0",
         "husky": "8.0.3",
         "lint-staged": "15.3.0",
-        "msw": "2.3.1",
+        "msw": "2.7.0",
         "prettier": "3.3.2"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@types/react-transition-group": "4.4.10",
         "cypress": "13.14.2",
         "husky": "8.0.3",
-        "lint-staged": "15.2.10",
+        "lint-staged": "15.3.0",
         "msw": "2.3.1",
         "prettier": "3.3.2"
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "@types/react-router": "5.1.20",
         "@types/react-router-dom": "5.3.3",
         "@types/react-transition-group": "4.4.10",
-        "cypress": "13.14.2",
+        "cypress": "13.17.0",
         "husky": "8.0.3",
         "lint-staged": "15.3.0",
         "msw": "2.3.1",

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -8,8 +8,8 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.3.1'
-const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
+const PACKAGE_VERSION = '2.7.0'
+const INTEGRITY_CHECKSUM = '00729d72e3b82faf54ca8b9621dbb96f'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
 
@@ -62,7 +62,12 @@ self.addEventListener('message', async function (event) {
 
       sendToClient(client, {
         type: 'MOCKING_ENABLED',
-        payload: true,
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
       })
       break
     }
@@ -155,6 +160,10 @@ async function handleRequest(event, requestId) {
 async function resolveMainClient(event) {
   const client = await self.clients.get(event.clientId)
 
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
   if (client?.frameType === 'top-level') {
     return client
   }
@@ -183,12 +192,26 @@ async function getResponse(event, client, requestId) {
   const requestClone = request.clone()
 
   function passthrough() {
-    const headers = Object.fromEntries(requestClone.headers.entries())
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
 
-    // Remove internal MSW request header so the passthrough request
-    // complies with any potential CORS preflight checks on the server.
-    // Some servers forbid unknown request headers.
-    delete headers['x-msw-intention']
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
 
     return fetch(requestClone, { headers })
   }


### PR DESCRIPTION
Oppdaterer avhengigheiter som har `path-to-regexp` eller `cross-spawn` som underavhengigheit, fordi vi har sikkerheitsvarsel på desse underbiblioteka.

React-router er også omfatta av dette, men sidan den skal oppdaterast til ny hovudversjon (major version) tek eg det i ein eigen PR.