### PR TITLE
Fiks lukkeknapp for sidepanel frå Mine filter

### DIFF
--- a/src/components/sidebar/fanevelger.tsx
+++ b/src/components/sidebar/fanevelger.tsx
@@ -69,6 +69,7 @@ export const Fanevelger = ({
                     fanetittel={fanetittel}
                     enhettiltak={enhettiltak}
                     oversiktType={oversiktType}
+                    lukkSidemeny={lukkSidemeny}
                 />
             );
         default:

--- a/src/components/sidebar/fanevelger.tsx
+++ b/src/components/sidebar/fanevelger.tsx
@@ -45,7 +45,7 @@ export const Fanevelger = ({
         case SidebarTabs.FILTER:
         case SidebarTabs.VEILEDERGRUPPER:
             return (
-                <SidebarTab tittel={fanetittel} lukkSidemeny={lukkSidemeny} tab={valgtFane}>
+                <SidebarTab tittel={fanetittel} tab={valgtFane} oversiktType={oversiktType}>
                     {valgtFane === SidebarTabs.STATUS && (
                         <FiltreringStatus oversiktType={oversiktType} filtervalg={filtervalg} statustall={statustall} />
                     )}
@@ -69,7 +69,6 @@ export const Fanevelger = ({
                     fanetittel={fanetittel}
                     enhettiltak={enhettiltak}
                     oversiktType={oversiktType}
-                    lukkSidemeny={lukkSidemeny}
                 />
             );
         default:

--- a/src/components/sidebar/mine-filter-tab.tsx
+++ b/src/components/sidebar/mine-filter-tab.tsx
@@ -1,8 +1,7 @@
-import React, {useState} from 'react';
-import {useDispatch, useSelector} from 'react-redux';
+import {useState} from 'react';
+import {useSelector} from 'react-redux';
 import {HelpText} from '@navikt/ds-react';
 import {SidebarTab} from './sidebar-tab';
-import {skjulSidebar} from '../../ducks/sidebar-tab';
 import {OversiktType} from '../../ducks/ui/listevisning';
 import ToggleSwitch from '../../filtrering/filtrering-mine-filter/toggle-switch/toggle-switch';
 import FiltreringMineFilter from '../../filtrering/filtrering-mine-filter/filtrering-mine-filter';
@@ -31,15 +30,15 @@ interface Props {
     fanetittel: string;
     oversiktType: OversiktType;
     enhettiltak: OrNothing<Tiltak>;
+    lukkSidemeny: () => void;
 }
 
-export const MineFilterTab = ({valgtFane, fanetittel, oversiktType, enhettiltak}: Props) => {
+export const MineFilterTab = ({valgtFane, fanetittel, oversiktType, enhettiltak, lukkSidemeny}: Props) => {
     const [isMinefiltereDraggable, setIsMinefiltereDraggable] = useState(false);
     const mineFilterState = useSelector((state: AppState) => state.mineFilter);
     const mineFilter = mineFilterState.data;
     const erPaMinOversikt = oversiktType === OversiktType.minOversikt;
     const erPaEnhetensOversikt = oversiktType === OversiktType.enhetensOversikt;
-    const dispatch = useDispatch();
 
     const fjernUtilgjengeligeFilter = (elem: LagretFilter) => {
         const arbeidsliste = elem.filterValg.ferdigfilterListe.includes('MIN_ARBEIDSLISTE');
@@ -69,7 +68,7 @@ export const MineFilterTab = ({valgtFane, fanetittel, oversiktType, enhettiltak}
     return (
         <SidebarTab
             tittel={fanetittel}
-            lukkSidemeny={() => dispatch(skjulSidebar(oversiktType))}
+            lukkSidemeny={lukkSidemeny}
             tab={valgtFane}
             headingChildren={
                 <>

--- a/src/components/sidebar/mine-filter-tab.tsx
+++ b/src/components/sidebar/mine-filter-tab.tsx
@@ -30,10 +30,9 @@ interface Props {
     fanetittel: string;
     oversiktType: OversiktType;
     enhettiltak: OrNothing<Tiltak>;
-    lukkSidemeny: () => void;
 }
 
-export const MineFilterTab = ({valgtFane, fanetittel, oversiktType, enhettiltak, lukkSidemeny}: Props) => {
+export const MineFilterTab = ({valgtFane, fanetittel, oversiktType, enhettiltak}: Props) => {
     const [isMinefiltereDraggable, setIsMinefiltereDraggable] = useState(false);
     const mineFilterState = useSelector((state: AppState) => state.mineFilter);
     const mineFilter = mineFilterState.data;
@@ -68,8 +67,8 @@ export const MineFilterTab = ({valgtFane, fanetittel, oversiktType, enhettiltak,
     return (
         <SidebarTab
             tittel={fanetittel}
-            lukkSidemeny={lukkSidemeny}
             tab={valgtFane}
+            oversiktType={oversiktType}
             headingChildren={
                 <>
                     <HelpText placement="right" strategy="fixed">

--- a/src/components/sidebar/sidebar-tab.tsx
+++ b/src/components/sidebar/sidebar-tab.tsx
@@ -1,25 +1,36 @@
-import React from 'react';
+import {useDispatch} from 'react-redux';
 import {Button, Heading} from '@navikt/ds-react';
 import {XMarkIcon} from '@navikt/aksel-icons';
+import {endreValgtSidebarTab} from './sidebar';
 import {SidebarTabs} from '../../store/sidebar/sidebar-view-store';
 import {logEvent} from '../../utils/frontend-logger';
 import {finnSideNavn} from '../../middleware/metrics-middleware';
+import {skjulSidebar} from '../../ducks/sidebar-tab';
+import {OversiktType} from '../../ducks/ui/listevisning';
 
 interface TabProps {
     tab: SidebarTabs;
     tittel: string;
-    lukkSidemeny: () => void;
+    oversiktType: OversiktType;
     headingChildren?: React.ReactNode;
     children: React.ReactNode;
 }
 
-export const SidebarTab = ({tab, tittel, lukkSidemeny, headingChildren, children}: TabProps) => {
-    const lukkTab = () => {
+export const SidebarTab = ({tab, tittel, oversiktType, headingChildren, children}: TabProps) => {
+    const dispatch = useDispatch();
+
+    const lukkSidemenyOgNullstillValgtFane = () => {
         logEvent('portefolje.metrikker.lukk-pa-kryss', {
             tab: tab,
             sideNavn: finnSideNavn()
         });
-        lukkSidemeny();
+
+        dispatch(skjulSidebar(oversiktType));
+        endreValgtSidebarTab({
+            dispatch: dispatch,
+            currentOversiktType: oversiktType,
+            requestedTab: ''
+        });
     };
 
     return (
@@ -32,7 +43,7 @@ export const SidebarTab = ({tab, tittel, lukkSidemeny, headingChildren, children
                 {headingChildren}
 
                 <Button
-                    onClick={lukkTab}
+                    onClick={lukkSidemenyOgNullstillValgtFane}
                     variant="tertiary-neutral"
                     size="small"
                     icon={<XMarkIcon title="Lukk panel" fontSize="1.5rem" />}


### PR DESCRIPTION
Lukking av sidepanel fjerner ikkje Mine filter som valgt fane. Dette gjorde at ein ikkje kunne opne Mine faner etter å ha lukka den, utan å først velje ei anna fane.



https://trello.com/c/MBOqVHvC/866-fiks-bug-i-lukking-av-sidepanel-fr%C3%A5-mine-filter

Før:

https://github.com/user-attachments/assets/4765d5fa-b91b-4c5e-918b-125fbb5d6725


Etter:

https://github.com/user-attachments/assets/9faa8503-b4f4-4960-8844-0a890256e4b3



