### PR TITLE
Ta bort feature-toggle rundt Gjeldende-vedtak-kolonner

### DIFF
--- a/src/enhetsportefolje/enhet-kolonner.tsx
+++ b/src/enhetsportefolje/enhet-kolonner.tsx
@@ -45,8 +45,6 @@ import {TekstKolonne} from '../components/tabell/kolonner/tekstkolonne';
 import SisteEndringKategori from '../components/tabell/sisteendringkategori';
 import {useGeografiskbostedSelector} from '../hooks/redux/use-geografiskbosted-selector';
 import {useTolkbehovSelector} from '../hooks/redux/use-tolkbehovspraak-selector';
-import {useFeatureSelector} from '../hooks/redux/use-feature-selector';
-import {VIS_FILTER_14A_FRA_VEDTAKSSTOTTE} from '../konstanter';
 import {LenkeKolonne} from '../components/tabell/kolonner/lenkekolonne';
 import './enhetsportefolje.css';
 import './brukerliste.css';
@@ -61,8 +59,6 @@ interface EnhetKolonnerProps {
 }
 
 function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKolonner, brukersVeileder}: EnhetKolonnerProps) {
-    const visFilter14aFraVedtaksstotte = useFeatureSelector()(VIS_FILTER_14A_FRA_VEDTAKSSTOTTE);
-
     const moteStartTid = klokkeslettTilMinutter(bruker.alleMoterStartTid);
     const varighet = minuttDifferanse(bruker.alleMoterSluttTid, bruker.alleMoterStartTid);
     const moteErAvtaltMedNAV = moment(bruker.moteStartTid).isSame(new Date(), 'day');
@@ -358,35 +354,28 @@ function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKolonner, 
                 skalVises={valgteKolonner.includes(Kolonne.AVVIK_14A_VEDTAK)}
                 className="col col-xs-2"
             />
-            {visFilter14aFraVedtaksstotte && (
-                <>
-                    <TekstKolonne
-                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_INNSATSGRUPPE)}
-                        tekst={
-                            bruker.gjeldendeVedtak14a?.innsatsgruppe
-                                ? innsatsgruppeNavn[bruker.gjeldendeVedtak14a.innsatsgruppe]
-                                : '-'
-                        }
-                        className="col col-xs-2"
-                    />
-                    <TekstKolonne
-                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_HOVEDMAL)}
-                        tekst={
-                            bruker.gjeldendeVedtak14a?.hovedmal ? HovedmalNavn[bruker.gjeldendeVedtak14a.hovedmal] : '-'
-                        }
-                        className="col col-xs-2"
-                    />
-                    <TekstKolonne
-                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_VEDTAKSDATO)}
-                        tekst={
-                            bruker.gjeldendeVedtak14a?.innsatsgruppe
-                                ? toDateString(bruker.gjeldendeVedtak14a?.fattetDato)
-                                : '-'
-                        }
-                        className="col col-xs-2-5"
-                    />
-                </>
-            )}
+
+            <TekstKolonne
+                skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_INNSATSGRUPPE)}
+                tekst={
+                    bruker.gjeldendeVedtak14a?.innsatsgruppe
+                        ? innsatsgruppeNavn[bruker.gjeldendeVedtak14a.innsatsgruppe]
+                        : '-'
+                }
+                className="col col-xs-2"
+            />
+            <TekstKolonne
+                skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_HOVEDMAL)}
+                tekst={bruker.gjeldendeVedtak14a?.hovedmal ? HovedmalNavn[bruker.gjeldendeVedtak14a.hovedmal] : '-'}
+                className="col col-xs-2"
+            />
+            <TekstKolonne
+                skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_VEDTAKSDATO)}
+                tekst={
+                    bruker.gjeldendeVedtak14a?.innsatsgruppe ? toDateString(bruker.gjeldendeVedtak14a?.fattetDato) : '-'
+                }
+                className="col col-xs-2-5"
+            />
 
             <DatoKolonne
                 dato={overgangsstonadUtlopsdato}

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -15,8 +15,6 @@ import VelgalleCheckboks from '../components/toolbar/velgalle-checkboks';
 import './enhetsportefolje.css';
 import './brukerliste.css';
 import {OrNothing} from '../utils/types/types';
-import {useFeatureSelector} from '../hooks/redux/use-feature-selector';
-import {VIS_FILTER_14A_FRA_VEDTAKSSTOTTE} from '../konstanter';
 import {Navn} from '../components/tabell/headerceller/Navn';
 import {Fnr} from '../components/tabell/headerceller/Fnr';
 import {Fodeland} from '../components/tabell/headerceller/Fodeland';
@@ -84,8 +82,6 @@ function EnhetListehode({
     sorteringsfelt,
     valgteKolonner
 }: EnhetListehodeProps) {
-    const visFilter14aFraVedtaksstotte = useFeatureSelector()(VIS_FILTER_14A_FRA_VEDTAKSSTOTTE);
-
     const {ytelse} = filtervalg;
     const erAapYtelse = Object.keys(ytelseAapSortering).includes(ytelse!);
     const aapPeriodetype = erAapYtelse ? ytelseAapSortering[ytelse!].periodetype : '';
@@ -243,13 +239,10 @@ function EnhetListehode({
                 <SvarfristCv {...sorteringTilHeadercelle} />
 
                 <Status14AVedtak {...sorteringTilHeadercelle} />
-                {visFilter14aFraVedtaksstotte && (
-                    <>
-                        <GjeldendeVedtak14aInnsatsgruppe {...sorteringTilHeadercelle} />
-                        <GjeldendeVedtak14aHovedmal {...sorteringTilHeadercelle} />
-                        <GjeldendeVedtak14aVedtaksdato {...sorteringTilHeadercelle} />
-                    </>
-                )}
+
+                <GjeldendeVedtak14aInnsatsgruppe {...sorteringTilHeadercelle} />
+                <GjeldendeVedtak14aHovedmal {...sorteringTilHeadercelle} />
+                <GjeldendeVedtak14aVedtaksdato {...sorteringTilHeadercelle} />
 
                 <EnsligeForsorgereUtlopOvergangsstonad {...sorteringTilHeadercelle} />
                 <EnsligeForsorgereVedtaksperiode {...sorteringTilHeadercelle} />

--- a/src/minoversikt/minoversikt-kolonner.tsx
+++ b/src/minoversikt/minoversikt-kolonner.tsx
@@ -36,8 +36,6 @@ import {TekstKolonne} from '../components/tabell/kolonner/tekstkolonne';
 import SisteEndringKategori from '../components/tabell/sisteendringkategori';
 import {useGeografiskbostedSelector} from '../hooks/redux/use-geografiskbosted-selector';
 import {useTolkbehovSelector} from '../hooks/redux/use-tolkbehovspraak-selector';
-import {useFeatureSelector} from '../hooks/redux/use-feature-selector';
-import {VIS_FILTER_14A_FRA_VEDTAKSSTOTTE} from '../konstanter';
 import {truncateTekst} from '../utils/tekst-utils';
 import {LenkeKolonne} from '../components/tabell/kolonner/lenkekolonne';
 import './minoversikt.css';
@@ -50,8 +48,6 @@ interface MinOversiktKolonnerProps {
 }
 
 export function MinOversiktKolonner({bruker, enhetId, filtervalg, valgteKolonner}: MinOversiktKolonnerProps) {
-    const visFilter14aFraVedtaksstotte = useFeatureSelector()(VIS_FILTER_14A_FRA_VEDTAKSSTOTTE);
-
     const moteStartTid = klokkeslettTilMinutter(bruker.alleMoterStartTid);
     const varighet = minuttDifferanse(bruker.alleMoterSluttTid, bruker.alleMoterStartTid);
     const moteErAvtaltMedNAV = moment(bruker.moteStartTid).isSame(new Date(), 'day');
@@ -358,35 +354,28 @@ export function MinOversiktKolonner({bruker, enhetId, filtervalg, valgteKolonner
                 skalVises={valgteKolonner.includes(Kolonne.AVVIK_14A_VEDTAK)}
                 className="col col-xs-2"
             />
-            {visFilter14aFraVedtaksstotte && (
-                <>
-                    <TekstKolonne
-                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_INNSATSGRUPPE)}
-                        tekst={
-                            bruker.gjeldendeVedtak14a?.innsatsgruppe
-                                ? innsatsgruppeNavn[bruker.gjeldendeVedtak14a.innsatsgruppe]
-                                : '-'
-                        }
-                        className="col col-xs-2"
-                    />
-                    <TekstKolonne
-                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_HOVEDMAL)}
-                        tekst={
-                            bruker.gjeldendeVedtak14a?.hovedmal ? HovedmalNavn[bruker.gjeldendeVedtak14a.hovedmal] : '-'
-                        }
-                        className="col col-xs-2"
-                    />
-                    <TekstKolonne
-                        skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_VEDTAKSDATO)}
-                        tekst={
-                            bruker.gjeldendeVedtak14a?.innsatsgruppe
-                                ? toDateString(bruker.gjeldendeVedtak14a?.fattetDato)
-                                : '-'
-                        }
-                        className="col col-xs-2-5"
-                    />
-                </>
-            )}
+
+            <TekstKolonne
+                skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_INNSATSGRUPPE)}
+                tekst={
+                    bruker.gjeldendeVedtak14a?.innsatsgruppe
+                        ? innsatsgruppeNavn[bruker.gjeldendeVedtak14a.innsatsgruppe]
+                        : '-'
+                }
+                className="col col-xs-2"
+            />
+            <TekstKolonne
+                skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_HOVEDMAL)}
+                tekst={bruker.gjeldendeVedtak14a?.hovedmal ? HovedmalNavn[bruker.gjeldendeVedtak14a.hovedmal] : '-'}
+                className="col col-xs-2"
+            />
+            <TekstKolonne
+                skalVises={valgteKolonner.includes(Kolonne.GJELDENDE_VEDTAK_14A_VEDTAKSDATO)}
+                tekst={
+                    bruker.gjeldendeVedtak14a?.innsatsgruppe ? toDateString(bruker.gjeldendeVedtak14a?.fattetDato) : '-'
+                }
+                className="col col-xs-2-5"
+            />
 
             <DatoKolonne
                 dato={overgangsstonadUtlopsdato}

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -13,8 +13,6 @@ import {
 import {Kolonne} from '../ducks/ui/listevisning';
 import VelgalleCheckboks from '../components/toolbar/velgalle-checkboks';
 import {OrNothing} from '../utils/types/types';
-import {useFeatureSelector} from '../hooks/redux/use-feature-selector';
-import {VIS_FILTER_14A_FRA_VEDTAKSSTOTTE} from '../konstanter';
 import {Navn} from '../components/tabell/headerceller/Navn';
 import {Fnr} from '../components/tabell/headerceller/Fnr';
 import {Fodeland} from '../components/tabell/headerceller/Fodeland';
@@ -85,8 +83,6 @@ function MinOversiktListeHode({
     filtervalg,
     valgteKolonner
 }: MinOversiktListehodeProps) {
-    const visFilter14aFraVedtaksstotte = useFeatureSelector()(VIS_FILTER_14A_FRA_VEDTAKSSTOTTE);
-
     const {ytelse} = filtervalg;
     const erAapYtelse = Object.keys(ytelseAapSortering).includes(ytelse!);
     const aapPeriodetype = erAapYtelse ? ytelseAapSortering[ytelse!].periodetype : '';
@@ -277,13 +273,10 @@ function MinOversiktListeHode({
                 <SvarfristCv {...sorteringTilHeadercelle} />
 
                 <Status14AVedtak {...sorteringTilHeadercelle} />
-                {visFilter14aFraVedtaksstotte && (
-                    <>
-                        <GjeldendeVedtak14aInnsatsgruppe {...sorteringTilHeadercelle} />
-                        <GjeldendeVedtak14aHovedmal {...sorteringTilHeadercelle} />
-                        <GjeldendeVedtak14aVedtaksdato {...sorteringTilHeadercelle} />
-                    </>
-                )}
+
+                <GjeldendeVedtak14aInnsatsgruppe {...sorteringTilHeadercelle} />
+                <GjeldendeVedtak14aHovedmal {...sorteringTilHeadercelle} />
+                <GjeldendeVedtak14aVedtaksdato {...sorteringTilHeadercelle} />
 
                 <EnsligeForsorgereUtlopOvergangsstonad {...sorteringTilHeadercelle} />
                 <EnsligeForsorgereVedtaksperiode {...sorteringTilHeadercelle} />


### PR DESCRIPTION

Ta bort feature-toggle rundt Gjeldende-vedtak-kolonner slik at det er "valgt kolonne"-logikken som styrer om dei vert vist. Dette gjer at ein kan sjå relevante kolonner om ein bruker eit Mine filter som har blitt migrert til nye filterverdiar. 

Det er kun når eit gjeldande-vedtakfilter er valgt at ein kan sjå kolonnene, og den einaste måten å gjere det på er gjennom migrerte Mine filter.

Sjølve filtera er framleis bak toggle og vert ikkje synlege før vi lanserer. 

Dette er naudsynt når vi migrerer gamle hovedmål-/innsatsgruppefilter til tilsvarande filter for § 14 a.