### PR TITLE
Gjer at ein kan skrive inn 18 i "til-feltet" på filter

### DIFF
--- a/src/filtrering/filtrering-filter/filterform/barn-under-18-filterform.tsx
+++ b/src/filtrering/filtrering-filter/filterform/barn-under-18-filterform.tsx
@@ -97,9 +97,9 @@ function BarnUnder18FilterForm({endreFiltervalg, valg, closeDropdown, filtervalg
             } else if (inputFraNummer >= 18 && inputAlderTil.length === 0) {
                 setFeil(true);
                 setFeilTekst('Du må skrive et tall lavere enn 18 i fra-feltet.');
-            } else if (inputTilNummer >= 18) {
+            } else if (inputTilNummer > 18) {
                 setFeil(true);
-                setFeilTekst('Du må skrive et tall lavere enn 18 i til-feltet.');
+                setFeilTekst('Du kan ikke skrive større tall enn 18 i til-feltet.');
             } else {
                 setFeil(false);
                 setFeilTekst('');


### PR DESCRIPTION
Tidlegare kunne det settast som default-verdi, men ikkje skrivast inn av brukaren. Vi trur det blir mindre forvirrande om det er love å skrive inn 18 også.

Resultata vil uansett ikkje vise 18-åringar, sidan dei ikkje er under 18 år.


Trello-kort: https://trello.com/c/GIMhFkAL/923-minibug-kan-ikkje-velje-18-i-barnunder18-men-det-kan-setjast-som-default-verdi-likevel