### PR TITLE
Rydd i etikettkode

### DIFF
--- a/src/components/tabell/etiketter.tsx
+++ b/src/components/tabell/etiketter.tsx
@@ -6,7 +6,7 @@ interface EtiketterProps {
     bruker: BrukerModell;
 }
 
-function Etiketter({bruker}: EtiketterProps) {
+export const Etiketter = ({bruker}: EtiketterProps) => {
     const skjermetInfo = hentSkjermetInfo(bruker.egenAnsatt, bruker.skjermetTil);
 
     return (
@@ -63,6 +63,4 @@ function Etiketter({bruker}: EtiketterProps) {
             )}
         </>
     );
-}
-
-export default Etiketter;
+};

--- a/src/enhetsportefolje/enhet-brukerpanel.tsx
+++ b/src/enhetsportefolje/enhet-brukerpanel.tsx
@@ -1,7 +1,7 @@
 import {useLayoutEffect} from 'react';
 import classNames from 'classnames';
 import {Checkbox} from '@navikt/ds-react';
-import Etiketter from '../components/tabell/etiketter';
+import {Etiketter} from '../components/tabell/etiketter';
 import {BrukerModell, FiltervalgModell, VeilederModell} from '../model-interfaces';
 import {Kolonne} from '../ducks/ui/listevisning';
 import EnhetKolonner from './enhet-kolonner';

--- a/src/minoversikt/minoversikt-bruker-panel.tsx
+++ b/src/minoversikt/minoversikt-bruker-panel.tsx
@@ -6,7 +6,7 @@ import {Collapse} from 'react-collapse';
 import classNames from 'classnames';
 import {Checkbox, Tag} from '@navikt/ds-react';
 import {BrukerpanelKnapp} from '../components/tabell/brukerpanel-knapp';
-import Etiketter from '../components/tabell/etiketter';
+import {Etiketter} from '../components/tabell/etiketter';
 import {BrukerModell, FiltervalgModell} from '../model-interfaces';
 import {MinOversiktKolonner} from './minoversikt-kolonner';
 import {Kolonne} from '../ducks/ui/listevisning';


### PR DESCRIPTION
Gjer det lettare å sjå frå koden kva etikettar som skal visast ved å snu logikken frå "skjul dersom dette er sant" til "vis dersom dette er sant".