### PR TITLE
Byttar til eksplisitt eksport av funksjonar

### DIFF
--- a/src/components/hidden-if/hidden-if.tsx
+++ b/src/components/hidden-if/hidden-if.tsx
@@ -1,10 +1,10 @@
 import {ComponentType} from 'react';
 
-export interface HiddenProps {
+interface HiddenProps {
     hidden?: boolean;
 }
 
-export default function hiddenIf<PROPS>(Component: ComponentType<PROPS>): ComponentType<PROPS & HiddenProps> {
+export function hiddenIf<PROPS>(Component: ComponentType<PROPS>): ComponentType<PROPS & HiddenProps> {
     return (props: PROPS & HiddenProps) => {
         const {hidden, ...rest} = props as any;
         if (hidden) {

--- a/src/components/modal/mine-filter/mine-filter-modal.tsx
+++ b/src/components/modal/mine-filter/mine-filter-modal.tsx
@@ -4,7 +4,7 @@ import {AppState} from '../../../reducer';
 import {OppdaterMineFilter} from './mine-filter-oppdater';
 import {LagreNyttMineFilter} from './mine-filter-nytt';
 import {OrNothing} from '../../../utils/types/types';
-import hiddenIf from '../../hidden-if/hidden-if';
+import {hiddenIf} from '../../hidden-if/hidden-if';
 import {Meny} from './mine-filter-meny';
 import {MineFilterFnrFeil} from './mine-filter-fnr-feil';
 import {lukkMineFilterModal} from '../../../ducks/lagret-filter-ui-state';

--- a/src/components/modal/mine-filter/mine-filter-utils.ts
+++ b/src/components/modal/mine-filter/mine-filter-utils.ts
@@ -1,7 +1,6 @@
 import {isEmptyArray, isObject} from 'formik';
 import {FiltervalgModell} from '../../../model-interfaces';
 import {LagretFilterValideringsError} from './mine-filter-modal';
-
 import {AktiviteterValg} from '../../../filtrering/filter-konstanter';
 
 export function lagretFilterValgModellErLik(filter1?: FiltervalgModell, filter2?: FiltervalgModell): boolean {

--- a/src/components/modal/mine-filter/mine-filter-varsel-modal.tsx
+++ b/src/components/modal/mine-filter/mine-filter-varsel-modal.tsx
@@ -1,5 +1,5 @@
-import {VarselModal, VarselModalType} from '../varselmodal/varselmodal';
 import {BodyShort, Button} from '@navikt/ds-react';
+import {VarselModal, VarselModalType} from '../varselmodal/varselmodal';
 
 export enum ErrorModalType {
     OPPDATERE,

--- a/src/components/rediger-knapp/rediger-knapp.tsx
+++ b/src/components/rediger-knapp/rediger-knapp.tsx
@@ -1,7 +1,7 @@
 import {useState} from 'react';
 import {Button} from '@navikt/ds-react';
 import {PencilFillIcon, PencilIcon} from '@navikt/aksel-icons';
-import hiddenIf from '../hidden-if/hidden-if';
+import {hiddenIf} from '../hidden-if/hidden-if';
 
 interface Props {
     aria: string;

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -9,7 +9,7 @@ import {Tiltak} from '../../ducks/enhettiltak';
 import {OversiktType} from '../../ducks/ui/listevisning';
 import {logEvent} from '../../utils/frontend-logger';
 import {finnSideNavn} from '../../middleware/metrics-middleware';
-import outsideClick from '../../hooks/use-outside-click';
+import {useOutsideClick} from '../../hooks/use-outside-click';
 import {useWindowWidth} from '../../hooks/use-window-width';
 import {SIDEBAR_TAB_ENDRET, skjulSidebar, visSidebar} from '../../ducks/sidebar-tab';
 import {StatustallForStatusfane} from '../../filtrering/filtrering-status/filtrering-status';
@@ -91,7 +91,7 @@ export const Sidebar = ({filtervalg, enhettiltak, oversiktType, statustall}: Sid
         });
     };
 
-    outsideClick(sidebarRef, () => {
+    useOutsideClick(sidebarRef, () => {
         if (windowWidth < 1200 && !isSidebarHidden && document.body.className !== 'navds-modal__document-body') {
             logEvent('portefolje.metrikker.klikk-utenfor', {
                 sideNavn: finnSideNavn()

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -7,7 +7,7 @@ import {
     fjernSorteringToast,
     ToastActionType
 } from '../../store/toast/actions';
-import hiddenIf from '../hidden-if/hidden-if';
+import {hiddenIf} from '../hidden-if/hidden-if';
 import {AppState} from '../../reducer';
 import {OrNothing} from '../../utils/types/types';
 import {TimedToast} from './timed-toast';

--- a/src/ducks/bruker-i-kontekst.ts
+++ b/src/ducks/bruker-i-kontekst.ts
@@ -1,7 +1,7 @@
 // Actions
 import {Dispatch} from 'redux';
-import {STATUS} from './utils';
 import * as Api from '../middleware/api';
+import {STATUS} from './utils';
 import {DataAction} from './types';
 
 enum BrukerIKontekstActionType {
@@ -23,7 +23,7 @@ const initialState: BrukerIKontekstState = {
 };
 
 //  Reducer
-const brukerIKontekstReducer = (
+export const brukerIKontekstReducer = (
     state: BrukerIKontekstState = initialState,
     action: DataAction<BrukerIKontekstActionType, BrukerIKontekst>
 ) => {
@@ -51,5 +51,3 @@ export const fjernBrukerIKontekst = () => {
     return (dispatch: Dispatch<BrukerIKontekstDataAction>) =>
         Api.fjernBrukerIKontekst().then(() => dispatch(fjernBruker()));
 };
-
-export default brukerIKontekstReducer;

--- a/src/ducks/brukerfeilmelding.ts
+++ b/src/ducks/brukerfeilmelding.ts
@@ -24,7 +24,7 @@ const feilBrukerfeilState: BrukerfeilState = {
 };
 
 // Reducer
-export default function reducer(state = initialBrukerfeilState, action: BrukerfeilDataAction): BrukerfeilState {
+export function brukerfeilReducer(state = initialBrukerfeilState, action: BrukerfeilDataAction): BrukerfeilState {
     switch (action.type) {
         case BrukerfeilAction.SETT_BRUKERFEILSTATE:
             action.data = feilBrukerfeilState;

--- a/src/ducks/enhettiltak.ts
+++ b/src/ducks/enhettiltak.ts
@@ -24,7 +24,7 @@ const initalState: EnhettiltakState = {
 };
 
 // Reducer
-export default function enhetTiltakReducer(state: EnhettiltakState = initalState, action) {
+export function enhetTiltakReducer(state: EnhettiltakState = initalState, action) {
     switch (action.type) {
         case PENDING:
             if (state.status === STATUS.OK) {

--- a/src/ducks/fargekategori.ts
+++ b/src/ducks/fargekategori.ts
@@ -1,5 +1,5 @@
-import {doThenDispatch, STATUS} from './utils';
 import * as Api from '../middleware/api';
+import {doThenDispatch, STATUS} from './utils';
 
 // Actions
 export const FARGEKATEGORI_OPPDATER_OK = 'veilarbportefolje/oppdater_fargekategori/OK';
@@ -12,7 +12,7 @@ const initialState = {
 };
 
 //  Reducer
-export default function fargekategoriReducer(state = initialState, action) {
+export function fargekategoriReducer(state = initialState, action) {
     switch (action.type) {
         case FARGEKATEGORI_OPPDATER_OK:
         case FARGEKATEGORI_RESET: {

--- a/src/ducks/features.ts
+++ b/src/ducks/features.ts
@@ -15,7 +15,7 @@ const initalState: FeaturesState = {
 };
 
 // Reducer
-export default function featuresReducer(state: FeaturesState = initalState, action): FeaturesState {
+export function featuresReducer(state: FeaturesState = initalState, action): FeaturesState {
     switch (action.type) {
         case ADD_FEATURE:
             return {

--- a/src/ducks/filtrering.ts
+++ b/src/ducks/filtrering.ts
@@ -100,7 +100,7 @@ export function fjern(filterId, verdi, fjernVerdi) {
     throw new Error(`Kan ikke håndtere fjerning av ${fjernVerdi} fra ${verdi}`);
 }
 
-export default function filtreringReducer(state: FiltervalgModell = initialState, action): FiltervalgModell {
+export function filtreringReducer(state: FiltervalgModell = initialState, action): FiltervalgModell {
     switch (action.type) {
         case CLEAR_FILTER:
             return initialState;

--- a/src/ducks/foedeland.ts
+++ b/src/ducks/foedeland.ts
@@ -1,6 +1,6 @@
 // Actions
-import {doThenDispatch, STATUS} from './utils';
 import * as Api from '../middleware/api';
+import {doThenDispatch, STATUS} from './utils';
 
 export const OK = 'veilarbportefoljeflatefs/foedeland/OK';
 export const FEILET = 'veilarbportefoljeflatefs/foedeland/FEILET';
@@ -28,7 +28,7 @@ const initalState: FoedelandListState = {
 };
 
 // Reducer
-export default function foedelandListReducer(state: FoedelandListState = initalState, action) {
+export function foedelandListReducer(state: FoedelandListState = initalState, action) {
     switch (action.type) {
         case PENDING:
             if (state.status === STATUS.OK) {

--- a/src/ducks/geografiskBosted.ts
+++ b/src/ducks/geografiskBosted.ts
@@ -1,6 +1,6 @@
 // Actions
-import {doThenDispatch, STATUS} from './utils';
 import * as Api from '../middleware/api';
+import {doThenDispatch, STATUS} from './utils';
 
 export const OK = 'veilarbportefoljeflatefs/geografiskbosted/OK';
 export const FEILET = 'veilarbportefoljeflatefs/geografiskbosted/FEILET';
@@ -28,7 +28,7 @@ const initalState: GeografiskBostedListState = {
 };
 
 // Reducer
-export default function geografiskbostedListReducer(state: GeografiskBostedListState = initalState, action) {
+export function geografiskbostedListReducer(state: GeografiskBostedListState = initalState, action) {
     switch (action.type) {
         case PENDING:
             if (state.status === STATUS.OK) {

--- a/src/ducks/huskelapp.ts
+++ b/src/ducks/huskelapp.ts
@@ -29,7 +29,7 @@ const initialState = {
     data: {}
 };
 
-export default function huskelappReducer(state = initialState, action) {
+export function huskelappReducer(state = initialState, action) {
     switch (action.type) {
         case HUSKELAPP_SLETT_PENDING:
         case HUSKELAPP_ENDRE_PENDING:

--- a/src/ducks/informasjonsmelding.ts
+++ b/src/ducks/informasjonsmelding.ts
@@ -17,7 +17,7 @@ export enum SesjonStatusAction {
 }
 
 // Reducer
-export default function reducer(
+export function informasjonsmeldingReducer(
     state: SesjonStatusState = initalStatusState,
     action: SesjonStatusDataAction
 ): SesjonStatusState {

--- a/src/ducks/innlogget-veileder.ts
+++ b/src/ducks/innlogget-veileder.ts
@@ -19,7 +19,7 @@ const initialState = {
 };
 
 //  Reducer
-export default function innloggetVeilederReducer(state: InnloggetVeilederState = initialState, action) {
+export function innloggetVeilederReducer(state: InnloggetVeilederState = initialState, action) {
     switch (action.type) {
         case PENDING:
             return {...state, status: STATUS.PENDING};

--- a/src/ducks/lagret-filter-ui-state.ts
+++ b/src/ducks/lagret-filter-ui-state.ts
@@ -34,7 +34,7 @@ const initialState = {
 };
 
 //  Reducer
-export default function lagretFilterReducer(state: LagretFilterUIState = initialState, action): LagretFilterUIState {
+export function lagretFilterUIStateReducer(state: LagretFilterUIState = initialState, action): LagretFilterUIState {
     switch (action.type) {
         case MARKER_MINE_FILTER:
             return {

--- a/src/ducks/mine-filter.ts
+++ b/src/ducks/mine-filter.ts
@@ -35,7 +35,7 @@ const initialState = {
 };
 
 //  Reducer
-export default function mineFilterReducer(state: LagretFilterState = initialState, action) {
+export function mineFilterReducer(state: LagretFilterState = initialState, action) {
     switch (action.type) {
         case HENT_MINEFILTER_PENDING:
             return {

--- a/src/ducks/modal-feilmelding-brukere.js
+++ b/src/ducks/modal-feilmelding-brukere.js
@@ -9,7 +9,7 @@ const initalState = {
     aarsak: undefined,
     brukereError: []
 };
-export default function feilmedlingModalReducer(state = initalState, action) {
+export function feilmedlingModalReducer(state = initalState, action) {
     switch (action.type) {
         case SKJUL_FEILMELDING_MODAL:
             return {...initalState};

--- a/src/ducks/modal-serverfeil.js
+++ b/src/ducks/modal-serverfeil.js
@@ -11,7 +11,7 @@ const initalState = {
     brukereError: []
 };
 
-export default function serverfeilModalReducer(state = initalState, action) {
+export function serverfeilModalReducer(state = initalState, action) {
     switch (action.type) {
         case SKJUL_SERVERFEIL_MODAL:
             return {...initalState};

--- a/src/ducks/modal.ts
+++ b/src/ducks/modal.ts
@@ -9,7 +9,7 @@ const initalState = {
 };
 
 // Reducer
-export default function modalReducer(state = initalState, action) {
+export function modalReducer(state = initalState, action) {
     switch (action.type) {
         case SKJUL_MODAL:
             return initalState;

--- a/src/ducks/paginering.ts
+++ b/src/ducks/paginering.ts
@@ -14,7 +14,7 @@ const initialState: PagineringState = {
 };
 
 // Reducer
-export default function pagineringReducer(state = initialState, action) {
+export function pagineringReducer(state = initialState, action) {
     switch (action.type) {
         case SETUP:
             return {...state, ...action.data};

--- a/src/ducks/portefolje.ts
+++ b/src/ducks/portefolje.ts
@@ -124,7 +124,7 @@ function updateFargekategoriForBrukere(brukere, fargekategoridata) {
     });
 }
 
-export default function portefoljeReducer(state = initialState, action): PortefoljeState {
+export function portefoljeReducer(state = initialState, action): PortefoljeState {
     switch (action.type) {
         case PENDING:
             if (state.status === STATUS.OK) {

--- a/src/ducks/portefoljestorrelser.tsx
+++ b/src/ducks/portefoljestorrelser.tsx
@@ -1,5 +1,5 @@
 import {fetchPortefoljeStorrelser} from '../middleware/api';
-import {STATUS, doThenDispatch} from './utils';
+import {doThenDispatch, STATUS} from './utils';
 
 // Actions
 const OK = 'veilarbportefolje/portefoljestorrelser/OK';
@@ -26,7 +26,7 @@ const initialState: PortefoljeStorrelser = {
 };
 
 //  Reducer
-export default function portefoljestorrelserReducer(state = initialState, action) {
+export function portefoljestorrelserReducer(state = initialState, action) {
     switch (action.type) {
         case PENDING:
             return {...state, status: STATUS.PENDING};

--- a/src/ducks/sidebar-tab.ts
+++ b/src/ducks/sidebar-tab.ts
@@ -17,7 +17,7 @@ export const SIDEBAR_TAB_ENDRET = 'sidebarTabEndret';
 export const SIDEBAR_SKJULT = 'sidebarSkjult';
 export const SIDEBAR_VISES = 'sidebarVises';
 
-export default function sidebarReducer(state = initialStateSidebar, action) {
+export function sidebarReducer(state = initialStateSidebar, action) {
     switch (action.type) {
         case SIDEBAR_TAB_ENDRET:
             return {...state, selectedTab: action.selectedTab};

--- a/src/ducks/sortering.js
+++ b/src/ducks/sortering.js
@@ -10,7 +10,7 @@ const initialState = {
 };
 
 // Reducer
-export default function sorteringReducer(state = initialState, action) {
+export function sorteringReducer(state = initialState, action) {
     switch (action.type) {
         case SORTERT_PA: {
             const {property} = action.data;

--- a/src/ducks/statustall/statustall-enhet.ts
+++ b/src/ducks/statustall/statustall-enhet.ts
@@ -56,10 +56,7 @@ export const initalStatusState: StatustallEnhetState = {
 };
 
 // Reducer
-export default function statustallEnhetReducer(
-    state: StatustallEnhetState = initalStatusState,
-    action
-): StatustallEnhetState {
+export function statustallEnhetReducer(state: StatustallEnhetState = initalStatusState, action): StatustallEnhetState {
     switch (action.type) {
         case PENDING:
             if (state.status === STATUS.OK) {

--- a/src/ducks/statustall/statustall-veileder.ts
+++ b/src/ducks/statustall/statustall-veileder.ts
@@ -44,7 +44,7 @@ export const initalStatusState: StatustallVeilederState = {
 };
 
 // Reducer
-export default function statustallVeilederReducer(
+export function statustallVeilederReducer(
     state: StatustallVeilederState = initalStatusState,
     action
 ): StatustallVeilederState {

--- a/src/ducks/systemmeldinger.ts
+++ b/src/ducks/systemmeldinger.ts
@@ -18,7 +18,7 @@ export const FEILET = 'veilarbportefoljeflatefs/systemmeldinger/FEILET';
 export const PENDING = 'veilarbportefoljeflatefs/systemmeldinger/PENDING';
 
 // Reducer
-export default function reducer(state: SystemmeldingState = initalStatusState, action): SystemmeldingState {
+export function systemmeldingerReducer(state: SystemmeldingState = initalStatusState, action): SystemmeldingState {
     switch (action.type) {
         case PENDING:
             if (state.status === STATUS.OK) {

--- a/src/ducks/tolkebehov.ts
+++ b/src/ducks/tolkebehov.ts
@@ -1,6 +1,6 @@
 // Actions
-import {doThenDispatch, STATUS} from './utils';
 import * as Api from '../middleware/api';
+import {doThenDispatch, STATUS} from './utils';
 
 export const OK = 'veilarbportefoljeflatefs/tolkebehov/OK';
 export const FEILET = 'veilarbportefoljeflatefs/tolkebehov/FEILET';
@@ -28,7 +28,7 @@ const initalState: TolkebehovSpraakListState = {
 };
 
 // Reducer
-export default function tolkebehovListReducer(state: TolkebehovSpraakListState = initalState, action) {
+export function tolkebehovListReducer(state: TolkebehovSpraakListState = initalState, action) {
     switch (action.type) {
         case PENDING:
             if (state.status === STATUS.OK) {

--- a/src/ducks/ui/listevisning.ts
+++ b/src/ducks/ui/listevisning.ts
@@ -134,8 +134,6 @@ export function listevisningReducer(state = initialStateMinOversikt, action: Lis
     }
 }
 
-export default listevisningReducer;
-
 export const velgAlternativ = (kolonne: Kolonne, oversiktType: OversiktType) => ({
     type: ActionTypeKeys.VELG_ALTERNATIV,
     kolonne,

--- a/src/ducks/valgt-enhet.ts
+++ b/src/ducks/valgt-enhet.ts
@@ -24,7 +24,7 @@ const initialState: ValgtEnhetState = {
 };
 
 //  Reducer
-export default function valgtEnhetReducer(state: ValgtEnhetState = initialState, action): ValgtEnhetState {
+export function valgtEnhetReducer(state: ValgtEnhetState = initialState, action): ValgtEnhetState {
     switch (action.type) {
         case PENDING:
             return {...state, status: STATUS.PENDING};

--- a/src/ducks/veiledere.ts
+++ b/src/ducks/veiledere.ts
@@ -22,7 +22,7 @@ const initialState = {
 };
 
 //  Reducer
-export default function veiledereReducer(state: VeiledereState = initialState, action) {
+export function veiledereReducer(state: VeiledereState = initialState, action) {
     switch (action.type) {
         case PENDING:
             return {...state, status: STATUS.PENDING};

--- a/src/ducks/veiledergrupper_filter.ts
+++ b/src/ducks/veiledergrupper_filter.ts
@@ -26,7 +26,7 @@ const initialState = {
 };
 
 //  Reducer
-export default function veiledergrupperLagretFilterReducer(state: LagretFilterState = initialState, action) {
+export function veiledergrupperLagretFilterReducer(state: LagretFilterState = initialState, action) {
     switch (action.type) {
         case HENT_VEILEDERGRUPPER_PENDING:
         case NY_VEILEDERGRUPPER_PENDING:

--- a/src/enhetsportefolje/enhet-brukerpanel.tsx
+++ b/src/enhetsportefolje/enhet-brukerpanel.tsx
@@ -1,4 +1,5 @@
 import {useLayoutEffect} from 'react';
+import {useDispatch} from 'react-redux';
 import classNames from 'classnames';
 import {Checkbox} from '@navikt/ds-react';
 import {Etiketter} from '../components/tabell/etiketter';
@@ -7,7 +8,6 @@ import {Kolonne} from '../ducks/ui/listevisning';
 import {EnhetKolonner} from './enhet-kolonner';
 import {OrNothing} from '../utils/types/types';
 import {nullstillBrukerfeil} from '../ducks/brukerfeilmelding';
-import {useDispatch} from 'react-redux';
 import './enhetsportefolje.css';
 import './brukerliste.css';
 

--- a/src/hooks/portefolje/use-fetch-portefolje-data.tsx
+++ b/src/hooks/portefolje/use-fetch-portefolje-data.tsx
@@ -1,6 +1,6 @@
 import {useEffect} from 'react';
-import {hentEnhetTiltak} from '../../ducks/enhettiltak';
 import {useDispatch, useSelector} from 'react-redux';
+import {hentEnhetTiltak} from '../../ducks/enhettiltak';
 import {AppState} from '../../reducer';
 import {useEnhetSelector} from '../redux/use-enhet-selector';
 import {hentPortefoljeStorrelser} from '../../ducks/portefoljestorrelser';

--- a/src/hooks/portefolje/use-fetch-portefolje.tsx
+++ b/src/hooks/portefolje/use-fetch-portefolje.tsx
@@ -1,6 +1,6 @@
 import {useEffect} from 'react';
-import {hentPortefoljeForEnhet, hentPortefoljeForVeileder} from '../../ducks/portefolje';
 import {useDispatch, useSelector} from 'react-redux';
+import {hentPortefoljeForEnhet, hentPortefoljeForVeileder} from '../../ducks/portefolje';
 import {useEnhetSelector} from '../redux/use-enhet-selector';
 import {usePortefoljeSelector} from '../redux/use-portefolje-selector';
 import {oppdaterKolonneAlternativer, OversiktType} from '../../ducks/ui/listevisning';

--- a/src/hooks/portefolje/use-fetch-statustall.tsx
+++ b/src/hooks/portefolje/use-fetch-statustall.tsx
@@ -1,7 +1,7 @@
+import {useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {useEnhetSelector} from '../redux/use-enhet-selector';
 import {AppState} from '../../reducer';
-import {useEffect} from 'react';
 import {hentStatustallForVeileder} from '../../ducks/statustall/statustall-veileder';
 import {hentStatustallForEnhet} from '../../ducks/statustall/statustall-enhet';
 import {OrNothing} from '../../utils/types/types';

--- a/src/hooks/portefolje/use-set-enhet-i-url.ts
+++ b/src/hooks/portefolje/use-set-enhet-i-url.ts
@@ -1,7 +1,7 @@
 import {useEffect} from 'react';
+import {useHistory, useLocation} from 'react-router';
 import queryString from 'query-string';
 import {useEnhetSelector} from '../redux/use-enhet-selector';
-import {useHistory, useLocation} from 'react-router';
 
 export function useSetEnhetIUrl() {
     const enhet = useEnhetSelector();

--- a/src/hooks/portefolje/use-set-state-from-url.ts
+++ b/src/hooks/portefolje/use-set-state-from-url.ts
@@ -1,12 +1,12 @@
+import {useCallback} from 'react';
+import {useDispatch} from 'react-redux';
+import {useLocation, useParams} from 'react-router';
 import {loggSkjermMetrikker, Side} from '../../utils/metrikker/skjerm-metrikker';
 import {loggSideVisning} from '../../utils/metrikker/side-visning-metrikker';
 import {getInitialStateFromUrl} from '../../utils/url-utils';
 import {pagineringSetup} from '../../ducks/paginering';
 import {settSortering} from '../../ducks/portefolje';
 import {useIdentSelector} from '../redux/use-innlogget-ident';
-import {useDispatch} from 'react-redux';
-import {useCallback} from 'react';
-import {useLocation, useParams} from 'react-router';
 import {useOnMount} from '../use-on-mount';
 import {logBrowserMetrikker} from '../../utils/metrikker/browser-metrikker';
 import {IdentParam} from '../../model-interfaces';

--- a/src/hooks/portefolje/use-sett-sortering.ts
+++ b/src/hooks/portefolje/use-sett-sortering.ts
@@ -1,6 +1,6 @@
+import {useDispatch} from 'react-redux';
 import {usePortefoljeSelector} from '../redux/use-portefolje-selector';
 import {OversiktType} from '../../ducks/ui/listevisning';
-import {useDispatch} from 'react-redux';
 import {STIGENDE, SYNKENDE} from '../../konstanter';
 import {settSortering} from '../../ducks/portefolje';
 

--- a/src/hooks/portefolje/use-veileder-har-portefolje.tsx
+++ b/src/hooks/portefolje/use-veileder-har-portefolje.tsx
@@ -1,5 +1,5 @@
-import {useIdentSelector} from '../redux/use-innlogget-ident';
 import {useSelector} from 'react-redux';
+import {useIdentSelector} from '../redux/use-innlogget-ident';
 import {AppState} from '../../reducer';
 
 export function useVeilederHarPortefolje() {

--- a/src/hooks/redux/use-bruker-i-kontekst-selector.tsx
+++ b/src/hooks/redux/use-bruker-i-kontekst-selector.tsx
@@ -1,5 +1,5 @@
-import {AppState} from '../../reducer';
 import {useSelector} from 'react-redux';
+import {AppState} from '../../reducer';
 
 const selectBrukerIKontekst = (state: AppState) => state.brukerIKontekst.data;
 

--- a/src/hooks/redux/use-enhet-selector.tsx
+++ b/src/hooks/redux/use-enhet-selector.tsx
@@ -1,5 +1,6 @@
 import {useSelector} from 'react-redux';
 import {AppState} from '../../reducer';
+
 const selectEnhetId = (state: AppState) => state.valgtEnhet.data.enhetId;
 
 export function useEnhetSelector(): string | null {

--- a/src/hooks/redux/use-foedeland-selector.tsx
+++ b/src/hooks/redux/use-foedeland-selector.tsx
@@ -1,5 +1,5 @@
-import {AppState} from '../../reducer';
 import {useSelector} from 'react-redux';
+import {AppState} from '../../reducer';
 
 const selectFoedelandData = (state: AppState) => state.foedelandList.data;
 

--- a/src/hooks/redux/use-geografiskbosted-selector.tsx
+++ b/src/hooks/redux/use-geografiskbosted-selector.tsx
@@ -1,5 +1,5 @@
-import {AppState} from '../../reducer';
 import {useSelector} from 'react-redux';
+import {AppState} from '../../reducer';
 
 const selectGeografiskBostedData = (state: AppState) => state.geografiskBosted.data;
 

--- a/src/hooks/redux/use-portefolje-selector.tsx
+++ b/src/hooks/redux/use-portefolje-selector.tsx
@@ -1,8 +1,8 @@
 import {useSelector} from 'react-redux';
 import {AppState} from '../../reducer';
+import {createSelector} from 'reselect';
 import {getFiltreringState, selectListeVisning} from '../../ducks/ui/listevisning-selectors';
 import {ListevisningState, OversiktType} from '../../ducks/ui/listevisning';
-import {createSelector} from 'reselect';
 import {BrukerModell, FiltervalgModell, Sorteringsfelt, Sorteringsrekkefolge} from '../../model-interfaces';
 import {OrNothing} from '../../utils/types/types';
 import {PortefoljeState} from '../../ducks/portefolje';

--- a/src/hooks/redux/use-tolkbehovspraak-selector.tsx
+++ b/src/hooks/redux/use-tolkbehovspraak-selector.tsx
@@ -1,5 +1,5 @@
-import {AppState} from '../../reducer';
 import {useSelector} from 'react-redux';
+import {AppState} from '../../reducer';
 
 const selectTolkbehovSpraakData = (state: AppState) => state.tolkbehovSpraakList.data;
 

--- a/src/hooks/use-outside-click.tsx
+++ b/src/hooks/use-outside-click.tsx
@@ -1,6 +1,6 @@
 import {useEffect} from 'react';
 
-const useOutsideClick = (ref, callback) => {
+export const useOutsideClick = (ref, callback) => {
     const handleClick = e => {
         if (!ref.current?.contains(e.target)) {
             callback();
@@ -15,5 +15,3 @@ const useOutsideClick = (ref, callback) => {
         };
     });
 };
-
-export default useOutsideClick;

--- a/src/hooks/use-query-params.ts
+++ b/src/hooks/use-query-params.ts
@@ -1,5 +1,5 @@
-import {useLocation} from 'react-router';
 import {useMemo} from 'react';
+import {useLocation} from 'react-router';
 import queryString from 'query-string';
 
 export function useQueryParams() {

--- a/src/hooks/use-request-handler.tsx
+++ b/src/hooks/use-request-handler.tsx
@@ -1,7 +1,7 @@
 import {useEffect, useState} from 'react';
+import {useSelector} from 'react-redux';
 import {STATUS} from '../ducks/utils';
 import {AppState} from '../reducer';
-import {useSelector} from 'react-redux';
 
 export function useRequestHandler(statusSelector: (state: AppState) => string, lukkModal: () => void) {
     const [saveRequestSent, setSaveRequestSent] = useState(false);

--- a/src/innholdslaster/get-feilmelding-for-reducer.tsx
+++ b/src/innholdslaster/get-feilmelding-for-reducer.tsx
@@ -1,4 +1,4 @@
-function getFeilmeldingForReducer(feilendeReducer) {
+export function getFeilmeldingForReducer(feilendeReducer) {
     const status = feilendeReducer?.data?.response?.status;
     if (status >= 500) {
         return 'Vi har dessverre tekniske problemer. Gjerne meld sak i Porten om problemet varer lenge.';
@@ -7,5 +7,3 @@ function getFeilmeldingForReducer(feilendeReducer) {
     }
     return null;
 }
-
-export default getFeilmeldingForReducer;

--- a/src/innholdslaster/innholdslaster.tsx
+++ b/src/innholdslaster/innholdslaster.tsx
@@ -1,7 +1,7 @@
 import {ReactNode, useState} from 'react';
 import {Alert, BodyShort, Loader} from '@navikt/ds-react';
 import {STATUS} from '../ducks/utils';
-import getFeilmeldingForReducer from './get-feilmelding-for-reducer';
+import {getFeilmeldingForReducer} from './get-feilmelding-for-reducer';
 import {trackAmplitude} from '../amplitude/amplitude';
 
 interface InnholdslasterProps {

--- a/src/minoversikt/huskelapp/redigering/endreHuskelapp.ts
+++ b/src/minoversikt/huskelapp/redigering/endreHuskelapp.ts
@@ -1,10 +1,10 @@
+import {AnyAction} from 'redux';
+import {ThunkDispatch} from 'redux-thunk';
+import {FormikValues} from 'formik';
 import {endreHuskelappAction} from '../../../ducks/huskelapp';
 import {hentHuskelappForBruker} from '../../../ducks/portefolje';
-import {ThunkDispatch} from 'redux-thunk';
 import {AppState} from '../../../reducer';
-import {AnyAction} from 'redux';
 import {BrukerModell} from '../../../model-interfaces';
-import {FormikValues} from 'formik';
 
 export const endreHuskelapp = async (
     dispatch: ThunkDispatch<AppState, any, AnyAction>,

--- a/src/minoversikt/huskelapp/redigering/lagreHuskelapp.ts
+++ b/src/minoversikt/huskelapp/redigering/lagreHuskelapp.ts
@@ -1,11 +1,11 @@
+import {AnyAction} from 'redux';
+import {ThunkDispatch} from 'redux-thunk';
+import {FormikValues} from 'formik';
 import {HUSKELAPP_LAGRE_OK, lagreHuskelappAction} from '../../../ducks/huskelapp';
 import {hentHuskelappForBruker} from '../../../ducks/portefolje';
 import {leggTilStatustall} from '../../../ducks/statustall/statustall-veileder';
-import {ThunkDispatch} from 'redux-thunk';
 import {AppState} from '../../../reducer';
-import {AnyAction} from 'redux';
 import {BrukerModell} from '../../../model-interfaces';
-import {FormikValues} from 'formik';
 
 export const lagreHuskelapp = async (
     dispatch: ThunkDispatch<AppState, any, AnyAction>,

--- a/src/minoversikt/huskelapp/redigering/slettHuskelapp.ts
+++ b/src/minoversikt/huskelapp/redigering/slettHuskelapp.ts
@@ -1,9 +1,9 @@
+import {AnyAction} from 'redux';
+import {ThunkDispatch} from 'redux-thunk';
 import {slettHuskelappAction} from '../../../ducks/huskelapp';
 import {leggTilStatustall} from '../../../ducks/statustall/statustall-veileder';
 import {hentHuskelappForBruker} from '../../../ducks/portefolje';
-import {ThunkDispatch} from 'redux-thunk';
 import {AppState} from '../../../reducer';
-import {AnyAction} from 'redux';
 import {HuskelappModell} from '../../../model-interfaces';
 
 export const handleSlettHuskelapp = async (

--- a/src/minoversikt/mine-filter-lagre-filter-knapp.tsx
+++ b/src/minoversikt/mine-filter-lagre-filter-knapp.tsx
@@ -1,8 +1,8 @@
 import {useEffect, useState} from 'react';
-import {erObjektValuesTomt, lagretFilterValgModellErLik} from '../components/modal/mine-filter/mine-filter-utils';
 import {useDispatch, useSelector} from 'react-redux';
 import {Button} from '@navikt/ds-react';
 import {StarIcon} from '@navikt/aksel-icons';
+import {erObjektValuesTomt, lagretFilterValgModellErLik} from '../components/modal/mine-filter/mine-filter-utils';
 import {AppState} from '../reducer';
 import {apneMineFilterModal} from '../ducks/lagret-filter-ui-state';
 import {OversiktType} from '../ducks/ui/listevisning';

--- a/src/mocks/api/modiacontextholder.ts
+++ b/src/mocks/api/modiacontextholder.ts
@@ -1,5 +1,5 @@
 import {delay, http, HttpResponse, RequestHandler} from 'msw';
-import innloggetVeileder from '../data/innloggetVeileder';
+import {innloggetVeileder} from '../data/innloggetVeileder';
 import {withAuth} from './auth';
 import {DEFAULT_DELAY_MILLISECONDS} from '../constants';
 

--- a/src/mocks/api/veilarbportefolje.ts
+++ b/src/mocks/api/veilarbportefolje.ts
@@ -1,14 +1,13 @@
 import {delay, http, HttpResponse, RequestHandler} from 'msw';
-import innloggetVeileder from '../data/innloggetVeileder';
-import me from '../data/me';
 import {fakerNB_NO as faker} from '@faker-js/faker';
+import {innloggetVeileder} from '../data/innloggetVeileder';
 import {foedelandListMockData} from '../data/foedeland';
 import {tolkebehovSpraakMockData} from '../data/tolkebehovSpraak';
 import {geografiskBostedListMockData} from '../data/geografiskBosted';
 import {statustallEnhet, statustallVeileder} from '../data/statustall';
 import {brukere, hentHuskelappForBruker, hentMockPlan} from '../data/portefolje';
-import lagPortefoljeStorrelser from '../data/portefoljestorrelser';
-import tiltak from '../data/tiltak';
+import {lagPortefoljeStorrelser} from '../data/portefoljestorrelser';
+import {tiltak} from '../data/tiltak';
 import {FargekategoriModell} from '../../model-interfaces';
 import {withAuth} from './auth';
 import {DEFAULT_DELAY_MILLISECONDS} from '../constants';
@@ -17,7 +16,7 @@ import {rnd} from '../utils';
 
 function lagPortefoljeForVeileder(queryParams, alleBrukere) {
     const enhetportefolje = lagPortefolje(queryParams, innloggetVeileder.enheter[0].enhetId, alleBrukere);
-    enhetportefolje.brukere.forEach(bruker => (bruker.veilederId = me.ident));
+    enhetportefolje.brukere.forEach(bruker => (bruker.veilederId = innloggetVeileder.ident));
     return enhetportefolje;
 }
 

--- a/src/mocks/api/veilarbveileder.ts
+++ b/src/mocks/api/veilarbveileder.ts
@@ -1,6 +1,6 @@
-import innloggetVeileder from '../data/innloggetVeileder';
-import {veilederResponse} from '../data/veiledere';
 import {http, HttpResponse, RequestHandler} from 'msw';
+import {innloggetVeileder} from '../data/innloggetVeileder';
+import {veilederResponse} from '../data/veiledere';
 import {withAuth} from './auth';
 
 export const veilarbveilederHandlers: RequestHandler[] = [

--- a/src/mocks/data/innloggetVeileder.ts
+++ b/src/mocks/data/innloggetVeileder.ts
@@ -15,9 +15,7 @@ const alternativEnhet2 = {
     navn: 'Nav Brummedal'
 };
 
-const innloggetVeileder = {
+export const innloggetVeileder = {
     ...iv,
     enheter: [innloggetEnhet, alternativEnhet, alternativEnhet2]
 };
-
-export default innloggetVeileder;

--- a/src/mocks/data/me.ts
+++ b/src/mocks/data/me.ts
@@ -1,3 +1,0 @@
-import {innloggetVeileder} from './veiledere';
-
-export default innloggetVeileder;

--- a/src/mocks/data/mine-filter.ts
+++ b/src/mocks/data/mine-filter.ts
@@ -1,5 +1,5 @@
-import {initialState} from '../../ducks/filtrering';
 import {faker} from '@faker-js/faker/locale/nb_NO';
+import {initialState} from '../../ducks/filtrering';
 import {LagretFilter} from '../../ducks/lagret-filter';
 
 export const mineFilter = (): LagretFilter[] => {

--- a/src/mocks/data/portefolje.ts
+++ b/src/mocks/data/portefolje.ts
@@ -1,6 +1,7 @@
+import moment from 'moment';
+import {fakerNB_NO as faker} from '@faker-js/faker';
 import {veiledere} from './veiledere';
 import {aktiviteter, hendelserLabels} from '../../filtrering/filter-konstanter';
-import {fakerNB_NO as faker} from '@faker-js/faker';
 import {
     BarnUnder18Aar,
     EnsligeForsorgereOvergangsstonad,
@@ -11,7 +12,6 @@ import {
     TiltakshendelseModell,
     UtgattVarselHendelse
 } from '../../model-interfaces';
-import moment from 'moment';
 import {rnd} from '../utils';
 import {MOCK_CONFIG} from '../constants';
 import {MoteData} from '../../minoversikt/moteplan/moteplan';

--- a/src/mocks/data/portefoljestorrelser.ts
+++ b/src/mocks/data/portefoljestorrelser.ts
@@ -1,5 +1,4 @@
 import {innloggetVeileder, lagTilfeldigVeilederId} from './veiledere';
-
 import {rnd} from '../utils';
 
 function lagPortefoljeStorrelse() {
@@ -9,7 +8,7 @@ function lagPortefoljeStorrelse() {
     };
 }
 
-export default function lagPortefoljeStorrelser() {
+export function lagPortefoljeStorrelser() {
     return {
         facetResults: new Array(40)
             .fill(lagPortefoljeStorrelse())

--- a/src/mocks/data/statustall.ts
+++ b/src/mocks/data/statustall.ts
@@ -1,5 +1,4 @@
 import {brukere as portefolje} from './portefolje';
-
 import {StatustallInnhold, StatustallVeileder} from '../../ducks/statustall/statustall-typer';
 
 export const statustallVeileder: {statustall: StatustallVeileder} = {

--- a/src/mocks/data/tiltak.ts
+++ b/src/mocks/data/tiltak.ts
@@ -1,4 +1,4 @@
-const tiltak = {
+export const tiltak = {
     tiltak: {
         VV: 'Varig vernet arbeid (VVA)',
         OPPLT2AAR: '2-årig opplæringstiltak',
@@ -36,5 +36,3 @@ const tiltak = {
         ENKELAMO: 'Enkeltplass AMO'
     }
 };
-
-export default tiltak;

--- a/src/mocks/data/veiledergrupper.ts
+++ b/src/mocks/data/veiledergrupper.ts
@@ -1,6 +1,6 @@
+import {fakerNB_NO as faker} from '@faker-js/faker';
 import {initialState} from '../../ducks/filtrering';
 import {veiledere} from './veiledere';
-import {fakerNB_NO as faker} from '@faker-js/faker';
 import {LagretFilter} from '../../ducks/lagret-filter';
 
 export const veiledergrupper = () => {

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -1,42 +1,43 @@
 import {Action, combineReducers} from 'redux';
-import persistentReducer, {LocalStorageScope} from './utils/persistentReducer';
-import valgtEnhetReducer, {ValgtEnhetState} from './ducks/valgt-enhet';
-import portefoljeReducer, {PortefoljeState} from './ducks/portefolje';
-import pagineringReducer from './ducks/paginering';
-import sorteringReducer from './ducks/sortering';
-import veiledereReducer, {VeiledereState} from './ducks/veiledere';
-import portefoljestorrelserReducer, {PortefoljeStorrelser} from './ducks/portefoljestorrelser';
-import filtreringReducer, {initialState} from './ducks/filtrering';
-import statustallVeilederReducer, {StatustallVeilederState} from './ducks/statustall/statustall-veileder';
-import systemmeldingerReducer, {SystemmeldingState} from './ducks/systemmeldinger';
-import modalReducer from './ducks/modal';
-import serverfeilModalReducer from './ducks/modal-serverfeil';
-import feilmedlingModalReducer from './ducks/modal-feilmelding-brukere';
-import veiledergrupperLagretFilterReducer from './ducks/veiledergrupper_filter';
-import enhetTiltakReducer, {EnhettiltakState} from './ducks/enhettiltak';
-import listevisningReducer, {
+import {persistentReducer, LocalStorageScope} from './utils/persistentReducer';
+import {valgtEnhetReducer, ValgtEnhetState} from './ducks/valgt-enhet';
+import {portefoljeReducer, PortefoljeState} from './ducks/portefolje';
+import {pagineringReducer} from './ducks/paginering';
+import {sorteringReducer} from './ducks/sortering';
+import {veiledereReducer, VeiledereState} from './ducks/veiledere';
+import {PortefoljeStorrelser, portefoljestorrelserReducer} from './ducks/portefoljestorrelser';
+import {filtreringReducer, initialState} from './ducks/filtrering';
+import {statustallVeilederReducer, StatustallVeilederState} from './ducks/statustall/statustall-veileder';
+import {systemmeldingerReducer, SystemmeldingState} from './ducks/systemmeldinger';
+import {modalReducer} from './ducks/modal';
+import {serverfeilModalReducer} from './ducks/modal-serverfeil';
+import {feilmedlingModalReducer} from './ducks/modal-feilmelding-brukere';
+import {veiledergrupperLagretFilterReducer} from './ducks/veiledergrupper_filter';
+import {enhetTiltakReducer, EnhettiltakState} from './ducks/enhettiltak';
+import {
     initialStateEnhetensOversikt,
     initialStateMinOversikt,
+    listevisningReducer,
     ListevisningState,
     OversiktType
 } from './ducks/ui/listevisning';
-import featuresReducer, {FeaturesState} from './ducks/features';
-import toastReducer, {ToastState} from './store/toast/reducer';
+import {featuresReducer, FeaturesState} from './ducks/features';
+import {toastReducer, ToastState} from './store/toast/reducer';
 import {FiltervalgModell} from './model-interfaces';
-import innloggetVeilederReducer, {InnloggetVeilederState} from './ducks/innlogget-veileder';
-import sidebarReducer, {initialStateSidebar, SidebarStateType} from './ducks/sidebar-tab';
-import mineFilterReducer from './ducks/mine-filter';
-import lagretFilterUIStateReducer, {LagretFilterUIState} from './ducks/lagret-filter-ui-state';
+import {innloggetVeilederReducer, InnloggetVeilederState} from './ducks/innlogget-veileder';
+import {initialStateSidebar, sidebarReducer, SidebarStateType} from './ducks/sidebar-tab';
+import {mineFilterReducer} from './ducks/mine-filter';
+import {LagretFilterUIState, lagretFilterUIStateReducer} from './ducks/lagret-filter-ui-state';
 import {LagretFilterState} from './ducks/lagret-filter';
-import geografiskbostedListReducer, {GeografiskBostedListState} from './ducks/geografiskBosted';
-import foedelandListReducer, {FoedelandListState} from './ducks/foedeland';
-import tolkebehovListReducer, {TolkebehovSpraakListState} from './ducks/tolkebehov';
-import informasjonsmeldingReducer, {SesjonStatusState} from './ducks/informasjonsmelding';
-import brukerfeilReducer, {BrukerfeilState} from './ducks/brukerfeilmelding';
-import statustallEnhetReducer, {StatustallEnhetState} from './ducks/statustall/statustall-enhet';
-import brukerIKontekstReducer, {BrukerIKontekstState} from './ducks/bruker-i-kontekst';
-import huskelappReducer from './ducks/huskelapp';
-import fargekategoriReducer from './ducks/fargekategori';
+import {geografiskbostedListReducer, GeografiskBostedListState} from './ducks/geografiskBosted';
+import {foedelandListReducer, FoedelandListState} from './ducks/foedeland';
+import {tolkebehovListReducer, TolkebehovSpraakListState} from './ducks/tolkebehov';
+import {informasjonsmeldingReducer, SesjonStatusState} from './ducks/informasjonsmelding';
+import {brukerfeilReducer, BrukerfeilState} from './ducks/brukerfeilmelding';
+import {statustallEnhetReducer, StatustallEnhetState} from './ducks/statustall/statustall-enhet';
+import {brukerIKontekstReducer, BrukerIKontekstState} from './ducks/bruker-i-kontekst';
+import {huskelappReducer} from './ducks/huskelapp';
+import {fargekategoriReducer} from './ducks/fargekategori';
 
 /**
  * Hjelpefunksjon for å conditionally kjøre reducere på en action

--- a/src/store/toast/reducer.ts
+++ b/src/store/toast/reducer.ts
@@ -28,5 +28,3 @@ export const toastReducer = (state: ToastState = initialState, action: ToastActi
             return state;
     }
 };
-
-export default toastReducer;

--- a/src/utils/metrikker/browser-metrikker.ts
+++ b/src/utils/metrikker/browser-metrikker.ts
@@ -1,7 +1,3 @@
-import {OrNothing} from '../types/types';
-import {VeilederModell} from '../../model-interfaces';
-import {logEvent} from '../frontend-logger';
-import {mapVeilederIdentTilNonsens} from '../../middleware/metrics-middleware';
 import {
     fullBrowserVersion,
     isChrome,
@@ -13,6 +9,10 @@ import {
     isOpera,
     isSafari
 } from 'react-device-detect';
+import {OrNothing} from '../types/types';
+import {VeilederModell} from '../../model-interfaces';
+import {logEvent} from '../frontend-logger';
+import {mapVeilederIdentTilNonsens} from '../../middleware/metrics-middleware';
 
 function getBrowserAgent(): string {
     let agent;

--- a/src/utils/persistentReducer.ts
+++ b/src/utils/persistentReducer.ts
@@ -63,7 +63,7 @@ function erFiltreringEndret(scope: LocalStorageScope, initialState) {
  * @param reducer - Reducer-funksjonen som skal brukes.
  * @param initialFilterstate - Initial state for filtrering.
  */
-export default function persistentReducer(
+export function persistentReducer(
     scope: LocalStorageScope,
     location: Location,
     reducer: (state: any, action: Action & {name: OversiktType}) => any,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -4,7 +4,6 @@ import {AktiviteterModell, BrukerModell, FiltervalgModell, Innsatsgruppe} from '
 import {Maybe} from './types';
 import {dateGreater, toDatePrettyPrint, toDateString} from './dato-utils';
 import {settBrukerIKontekst} from '../middleware/api';
-
 import {AktiviteterValg} from '../filtrering/filter-konstanter';
 
 export function range(start: number, end: number, inclusive: boolean = false): number[] {
@@ -122,15 +121,6 @@ export function aapRettighetsperiode(ytelse, maxtidukerigjen, unntakukerigjen) {
     } else if (ytelse === 'AAP_UNNTAK') {
         return unntakukerigjen;
     }
-}
-
-export default function TittelValg(ytelseSorteringHeader) {
-    if (ytelseSorteringHeader === 'Gjenstående uker vedtak') {
-        return 'Gjenstående uker på gjeldende vedtak';
-    } else if (ytelseSorteringHeader === 'Gjenstående uker rettighet') {
-        return 'Gjenstående uker av rettighetsperioden for ytelsen';
-    }
-    return '';
 }
 
 export function tolkBehov(filtervalg: FiltervalgModell, bruker: BrukerModell) {


### PR DESCRIPTION
fordi
✨ estetikk ✨

og fordi det unngår pontensielle misforståingar der ein bruker ulike namn på ein funksjon der den vert definert og der den vert importert.

Også: slettar eit par ubrukte funksjonar og sorterer eksterne importar øvst og css nedst.
