### PR TITLE
Oppdater @navikt frå v5.18.3 til v6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
             "dependencies": {
                 "@amplitude/analytics-browser": "2.9.3",
                 "@grafana/faro-web-sdk": "1.14.1",
-                "@navikt/aksel-icons": "5.18.3",
-                "@navikt/ds-css": "5.18.3",
-                "@navikt/ds-react": "5.18.3",
+                "@navikt/aksel-icons": "6.0.0",
+                "@navikt/ds-css": "6.0.0",
+                "@navikt/ds-react": "6.0.0",
                 "@navikt/fnrvalidator": "^1.1.3",
                 "@navikt/navspa": "5.0.1",
                 "@reduxjs/toolkit": "2.3.0",
@@ -3187,28 +3187,28 @@
             }
         },
         "node_modules/@navikt/aksel-icons": {
-            "version": "5.18.3",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/5.18.3/0e8ff38b54ec91be6c5e8d8574a3341ee87eb792",
-            "integrity": "sha512-kytq0BT1xsJBrG7/eyDuMQLddQZA4OMT3Fw3VLGHsJNqjEWEVOl3uYCGL70Thvg0+du0s/Z3mXPQUQpIaDt7rg=="
+            "version": "6.0.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/6.0.0/c43fb02f061aea1df175436345cae28d83ac8c46",
+            "integrity": "sha512-41U7tHtCfoBPoEO1FGYl2p8yDvtXOtR6CJ9d4qFbM2Wii7vt50D994W7u4Z11K3PbLKCGcHFlAPbkXU9LQvujA=="
         },
         "node_modules/@navikt/ds-css": {
-            "version": "5.18.3",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/5.18.3/cbeeddfeca6dd1efbbbb93a29a7cc3a9d5f6df86",
-            "integrity": "sha512-/BfZKrx7S5bVfjCQzm0B+3QgSHitPOAn04Bq0hAplFWXveLG0HkrVauDxL6dq9mqFN8zAJCSTXZjltRjY+JoHA=="
+            "version": "6.0.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/6.0.0/0943c7f430f62d5bbd64c21b6dd0fb19a1eb375a",
+            "integrity": "sha512-r54/kB9CYWvHFht1qUhy9iySzJU9OkzvGR8X1SMmLIHddI4GrZPfRbgtRZhFFCTl7b+ilnav6iETNgZ4tRfChw=="
         },
         "node_modules/@navikt/ds-react": {
-            "version": "5.18.3",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/5.18.3/dfa962fc74ec44189b33ad8076908f291ea91fd8",
-            "integrity": "sha512-+Ant1d6BhlOHuACttwCEiZLVPlVxEYEFGjPdr2EnDYRexmQVvY9dICnKaInBI/Cu6+cKl9BdnZbHsAs4+IPKQA==",
+            "version": "6.0.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/6.0.0/715b264e3a69856666fc1409ad85477c136b86b5",
+            "integrity": "sha512-/791FxO1L+d/G8qSpjCHAYsYcHxhRXY/lFEUScWDEOkLQt63pr3qnpjKyNX1cc2PsJVj5AAAMWiO09o4J9g/vg==",
             "dependencies": {
                 "@floating-ui/react": "0.25.4",
-                "@navikt/aksel-icons": "^5.18.3",
-                "@navikt/ds-tokens": "^5.18.3",
+                "@navikt/aksel-icons": "^6.0.0",
+                "@navikt/ds-tokens": "^6.0.0",
                 "@radix-ui/react-tabs": "1.0.0",
                 "@radix-ui/react-toggle-group": "1.0.0",
-                "clsx": "^1.2.1",
-                "date-fns": "^2.30.0",
-                "react-day-picker": "8.3.4"
+                "clsx": "^2.1.0",
+                "date-fns": "^3.0.0",
+                "react-day-picker": "8.10.0"
             },
             "peerDependencies": {
                 "@types/react": "^17.0.30 || ^18.0.0",
@@ -3410,15 +3410,15 @@
             }
         },
         "node_modules/@navikt/ds-react/node_modules/react-day-picker": {
-            "version": "8.3.4",
-            "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.3.4.tgz",
-            "integrity": "sha512-UuCbfZ69DhQmd+UhEv8nCPp5PxMk7ioNTuOLMlU0X7q3wd7o8TKDdsjduQoeBYTPTMS3LFdbA1qqbrIpRHo/Vg==",
+            "version": "8.10.0",
+            "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.0.tgz",
+            "integrity": "sha512-mz+qeyrOM7++1NCb1ARXmkjMkzWVh2GL9YiPbRjKe0zHccvekk4HE+0MPOZOrosn8r8zTHIIeOUXTmXRqmkRmg==",
             "funding": {
                 "type": "individual",
                 "url": "https://github.com/sponsors/gpbl"
             },
             "peerDependencies": {
-                "date-fns": "^2.28.0",
+                "date-fns": "^2.28.0 || ^3.0.0",
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
@@ -3428,9 +3428,9 @@
             "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
         },
         "node_modules/@navikt/ds-tokens": {
-            "version": "5.18.3",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-tokens/-/ds-tokens-5.18.3.tgz",
-            "integrity": "sha512-PMA4K1DCosKbekk/hySFnjIRaQxwExhhdV6LFED+ImlutzYKJI79Gmbw1mttp6RWNAJYeVX5z8hCXPTMq6fu6w=="
+            "version": "6.17.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/6.17.0/e80eeb7c7d6f469d6704125b5835ea95995be327",
+            "integrity": "sha512-DAibs9kIcpAf/4sRTdB0VPDK6t4seeJfqTm6qvDSUkOt/UCmvgKRUeikJqETCiGgXWv/Y/FpQ69uv1stZXBrEQ=="
         },
         "node_modules/@navikt/fnrvalidator": {
             "version": "1.3.0",
@@ -6578,9 +6578,9 @@
             }
         },
         "node_modules/clsx": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-            "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
             "engines": {
                 "node": ">=6"
             }
@@ -7388,18 +7388,12 @@
             }
         },
         "node_modules/date-fns": {
-            "version": "2.30.0",
-            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-            "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-            "dependencies": {
-                "@babel/runtime": "^7.21.0"
-            },
-            "engines": {
-                "node": ">=0.11"
-            },
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+            "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
             "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/date-fns"
+                "type": "github",
+                "url": "https://github.com/sponsors/kossnocorp"
             }
         },
         "node_modules/dayjs": {

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     },
     "dependencies": {
         "@amplitude/analytics-browser": "2.9.3",
-        "@navikt/aksel-icons": "5.18.3",
-        "@navikt/ds-css": "5.18.3",
-        "@navikt/ds-react": "5.18.3",
+        "@navikt/aksel-icons": "6.0.0",
+        "@navikt/ds-css": "6.0.0",
+        "@navikt/ds-react": "6.0.0",
         "@navikt/navspa": "5.0.1",
         "@sanity/block-content-to-react": "^3.0.0",
         "classnames": "2.5.1",

--- a/src/components/endringslogg/endringslogg.css
+++ b/src/components/endringslogg/endringslogg.css
@@ -196,9 +196,6 @@
     height: 0.668rem;
     margin-left: 0.3em;
 }
-.hyperlink-ikon {
-    stroke: var(--a-text-action);
-}
 .veiledergrupper-navet-tekst,
 .endringslogg_mine-filter {
     margin-top: 0.5rem;

--- a/src/components/endringslogg/tour-modal/tour-modal.tsx
+++ b/src/components/endringslogg/tour-modal/tour-modal.tsx
@@ -41,9 +41,15 @@ export const TourModal = ({modal, open, onClose}: TourModalProps) => {
     const modalTittel = modal?.header ? modal.header : 'Ny oppdatering';
 
     return (
-        <Modal className={'tour-modal'} open={open} onClose={lukkModal} closeOnBackdropClick={true}>
+        <Modal
+            className="tour-modal"
+            open={open}
+            onClose={lukkModal}
+            closeOnBackdropClick={true}
+            aria-labelledby="tour-modal-overskrift"
+        >
             <Modal.Header data-testid="endringslogg_tour-modal">
-                <Heading size="medium" level="1">
+                <Heading id="tour-modal-overskrift" size="medium" level="1">
                     {modalTittel}
                 </Heading>
             </Modal.Header>

--- a/src/components/fargekategori/bekreft-endre-fargekategori-pa-mange-modal.tsx
+++ b/src/components/fargekategori/bekreft-endre-fargekategori-pa-mange-modal.tsx
@@ -29,9 +29,10 @@ export const BekreftEndreFargekategoriPaMangeModal = ({
             className="bekreft-fargekategori-pa-mange-modal"
             onClose={onAvbryt}
             closeOnBackdropClick={true}
+            aria-labelledby="bekreft-fargekategori-pa-mange-modal-overskrift"
         >
             <Modal.Header>
-                <Heading size="small" level="1">
+                <Heading id="bekreft-fargekategori-pa-mange-modal-overskrift" size="small" level="1">
                     Er du sikker på at du vil endre kategori?
                 </Heading>
             </Modal.Header>

--- a/src/components/modal/egenModal.tsx
+++ b/src/components/modal/egenModal.tsx
@@ -20,9 +20,10 @@ export function EgenModal({children, className, open = true, onClose, tittel, mo
             closeOnBackdropClick={true}
             width={modalWidth}
             data-testid={testid}
+            aria-labelledby="egenmodal-overskrift"
         >
             <Modal.Header data-testid="egenmodal_header">
-                <Heading size="medium" level="1" className={className}>
+                <Heading id="egenmodal-overskrift" size="medium" level="1" className={className}>
                     {tittel}
                 </Heading>
             </Modal.Header>

--- a/src/components/modal/lastermodal/laster-modal.tsx
+++ b/src/components/modal/lastermodal/laster-modal.tsx
@@ -14,6 +14,7 @@ export const LasterModal = ({isOpen}: LasterModalProps) => {
             onClose={() => setIsOpenLoaderModal(false)}
             className="veilarbportefoljeflatefs-laster-modal"
             data-testid="veilarbportefoljeflatefs-laster-modal"
+            aria-label="Laster..."
         >
             <Loader size="2xlarge" />
         </Modal>

--- a/src/components/modal/tildel-veileder/tildel-veileder.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder.tsx
@@ -177,9 +177,14 @@ function TildelVeileder({oversiktType, closeInput}: TildelVeilederProps) {
 
     return (
         <>
-            <Modal open={visAdvarselOmSletting} onClose={lukkFjernModal} closeOnBackdropClick={true}>
+            <Modal
+                open={visAdvarselOmSletting}
+                onClose={lukkFjernModal}
+                closeOnBackdropClick={true}
+                aria-labelledby="sletting-ved-kontorbytte-overskrift"
+            >
                 <Modal.Header>
-                    <Heading size="medium" level="2">
+                    <Heading id="sletting-ved-kontorbytte-overskrift" size="medium" level="2">
                         Huskelapp og/eller kategori blir slettet
                     </Heading>
                 </Modal.Header>

--- a/src/components/modal/varselmodal/varselmodal.tsx
+++ b/src/components/modal/varselmodal/varselmodal.tsx
@@ -36,10 +36,13 @@ export function VarselModal({
             onClose={onClose}
             className={classNames('varsel-modal', portalClassName, dataTestClass)}
             closeOnBackdropClick={true}
+            aria-labelledby="varselmodal-overskrift"
         >
             <Modal.Header className="varsel-modal__header">
                 <div className="varsel-modal__ikon">{getIkon(type)}</div>
-                <Heading size="medium">{overskrift}</Heading>
+                <Heading id="varselmodal-overskrift" size="medium">
+                    {overskrift}
+                </Heading>
             </Modal.Header>
             <Modal.Body className={classNames('varsel-modal__innhold', className)}>{children}</Modal.Body>
         </Modal>

--- a/src/components/modal/veiledergruppe/valgt-veiledergruppe-liste.tsx
+++ b/src/components/modal/veiledergruppe/valgt-veiledergruppe-liste.tsx
@@ -55,7 +55,7 @@ export function ValgtVeiledergruppeListe({valgteVeileder, fjernValgtVeileder, fe
                     ))
                 )}
             </div>
-            {feil && <ErrorMessage showIcon>{feil}</ErrorMessage>}
+            {feil && <ErrorMessage>{feil}</ErrorMessage>}
         </>
     );
 }

--- a/src/components/modal/veiledergruppe/veiledergruppe-modal.tsx
+++ b/src/components/modal/veiledergruppe/veiledergruppe-modal.tsx
@@ -214,9 +214,10 @@ export function VeiledergruppeModal({
                         closeOnBackdropClick={true}
                         className={classNames('veiledergruppe-modal', className)}
                         width="medium"
+                        aria-labelledby="veiledergruppe-modal-overskrift"
                     >
                         <Modal.Header>
-                            <Heading size="medium" level="1">
+                            <Heading id="veiledergruppe-modal-overskrift" size="medium" level="1">
                                 {modalTittel}
                             </Heading>
                         </Modal.Header>

--- a/src/components/til-toppen-knapp/til-toppen-knapp.css
+++ b/src/components/til-toppen-knapp/til-toppen-knapp.css
@@ -1,7 +1,9 @@
 .veilarbportefoljeflatefs .til-toppen-knapp {
     right: 2rem;
     bottom: 2rem;
-    box-shadow: inset 0 0 0 2px var(--a-border-action), 0px 4px 6px -1px rgba(0, 0, 0, 0.3),
+    box-shadow:
+        inset 0 0 0 2px var(--a-blue-600),
+        0px 4px 6px -1px rgba(0, 0, 0, 0.3),
         0px 2px 4px -2px rgba(0, 0, 0, 0.15);
     opacity: 1;
     background-color: white;
@@ -12,7 +14,7 @@
     position: fixed;
 }
 .veilarbportefoljeflatefs .til-toppen-knapp.knapp:hover {
-    background-color: #0074df;
+    background-color: var(--a-surface-action-subtle-hover);
 }
 .veilarbportefoljeflatefs .til-toppen-knapp--skjul {
     opacity: 0;
@@ -20,7 +22,4 @@
 }
 .veilarbportefoljeflatefs .til-toppen-knapp--skjul:hover {
     cursor: unset;
-}
-.veilarbportefoljeflatefs .til-toppen-knapp:focus {
-    fill: #0074df;
 }

--- a/src/minoversikt/huskelapp/redigering/HuskelappModal.tsx
+++ b/src/minoversikt/huskelapp/redigering/HuskelappModal.tsx
@@ -29,12 +29,14 @@ export const HuskelappModal = ({isModalOpen, onModalClose, huskelapp, bruker}: P
 
     const harHuskelapp = !!huskelapp?.huskelappId;
 
-    const handleHuskelappEndret = () => {
+    // Returnerer true dersom modalen skal lukkast, false om den skal fortsette å vere open.
+    const handleHuskelappEndret = (): boolean => {
         if (huskelappEndret) {
             return window.confirm(
                 'Alle endringer blir borte hvis du ikke lagrer. Trykk avbryt for å fortsette redigering eller OK for å lukke huskelappen.'
             );
         }
+        return true;
     };
 
     const handleOnAvbryt = () => {
@@ -68,13 +70,18 @@ export const HuskelappModal = ({isModalOpen, onModalClose, huskelapp, bruker}: P
             onClose={onModalClose}
             onBeforeClose={handleHuskelappEndret}
             closeOnBackdropClick={false} // TODO sett til true når arbeidslistene er migrert, antar det er mindre sjanse for å kopiere (uten å ha endret innholdet, som vil trigge bekreftelsesmelding)
+            aria-labelledby="huskelappmodal-overskrift"
         >
             <Modal.Header>
                 <div className="rediger-huskelapp-modal-header">
                     <span className="rediger-huskelapp-modal-header-ikon">
                         <HuskelappIkon aria-hidden />
                     </span>
-                    <Heading size="small" className="rediger-huskelapp-modal-header-tekst">
+                    <Heading
+                        id="huskelappmodal-overskrift"
+                        size="small"
+                        className="rediger-huskelapp-modal-header-tekst"
+                    >
                         Huskelapp
                     </Heading>
                 </div>

--- a/src/topp-meny/topp-meny.css
+++ b/src/topp-meny/topp-meny.css
@@ -42,7 +42,7 @@
 }
 
 .veilarbportefoljeflatefs .topp-meny .oversiktslenke:hover {
-    border-bottom: 0.3rem solid var(--a-blue-600); /* Kan byttast til var(--a-border-action-hover) når vi har designsystemet v6. */
+    border-bottom: 0.3rem solid var(--a-border-action-hover);
     cursor: pointer;
     opacity: 1;
 }
@@ -54,7 +54,7 @@
 }
 
 .veilarbportefoljeflatefs .topp-meny .oversiktslenke--valgt {
-    border-bottom: 0.3rem solid var(--a-border-action); /* --a-blue-500 */
+    border-bottom: 0.3rem solid var(--a-border-action-selected); /* Same som Tabs-komponenten får når den er valgt. */
     background-color: inherit;
     text-decoration: none;
     font-weight: var(--a-font-weight-bold);


### PR DESCRIPTION
- Aria-label og -labelledby er obligatorisk på modalar
- Import-mønster har endra seg
- Ikon i feilmelding ser ikkje ut til å vere innebygd meir, så eg fjernar det sidan det var noko nytt eg la til i feilmeldingane i dag.
- Brukar oppdaterte css-variablar