### PR TITLE
Trekk ut hjelpefunksjonar for enslig forsørger til eiga fil

### DIFF
--- a/src/enhetsportefolje/enhet-kolonner.tsx
+++ b/src/enhetsportefolje/enhet-kolonner.tsx
@@ -19,9 +19,7 @@ import {
     bostedBydelEllerUkjent,
     bostedKommuneUtlandEllerUkjent,
     capitalize,
-    mapOmAktivitetsPlikt,
     nesteUtlopsdatoEllerNull,
-    oppfolingsdatoEnsligeForsorgere,
     parseDatoString,
     tolkBehov,
     tolkBehovSpraak,
@@ -46,6 +44,7 @@ import {SisteEndringKategori} from '../components/tabell/sisteendringkategori';
 import {useGeografiskbostedSelector} from '../hooks/redux/use-geografiskbosted-selector';
 import {useTolkbehovSelector} from '../hooks/redux/use-tolkbehovspraak-selector';
 import {LenkeKolonne} from '../components/tabell/kolonner/lenkekolonne';
+import {mapOmAktivitetsPlikt, oppfolingsdatoEnsligeForsorgere} from '../utils/enslig-forsorger';
 import './enhetsportefolje.css';
 import './brukerliste.css';
 

--- a/src/minoversikt/minoversikt-kolonner.tsx
+++ b/src/minoversikt/minoversikt-kolonner.tsx
@@ -5,9 +5,7 @@ import {
     bostedBydelEllerUkjent,
     bostedKommuneUtlandEllerUkjent,
     capitalize,
-    mapOmAktivitetsPlikt,
     nesteUtlopsdatoEllerNull,
-    oppfolingsdatoEnsligeForsorgere,
     parseDatoString,
     tolkBehov,
     tolkBehovSpraak,
@@ -38,6 +36,7 @@ import {useGeografiskbostedSelector} from '../hooks/redux/use-geografiskbosted-s
 import {useTolkbehovSelector} from '../hooks/redux/use-tolkbehovspraak-selector';
 import {truncateTekst} from '../utils/tekst-utils';
 import {LenkeKolonne} from '../components/tabell/kolonner/lenkekolonne';
+import {mapOmAktivitetsPlikt, oppfolingsdatoEnsligeForsorgere} from '../utils/enslig-forsorger';
 import './minoversikt.css';
 
 interface MinOversiktKolonnerProps {

--- a/src/utils/enslig-forsorger.ts
+++ b/src/utils/enslig-forsorger.ts
@@ -1,0 +1,25 @@
+import moment from 'moment';
+import {toDatePrettyPrint} from './dato-utils';
+
+export const mapOmAktivitetsPlikt = (aktivitetsplikt?: boolean): string => {
+    if (aktivitetsplikt === undefined) {
+        return 'Ukjent';
+    }
+    return aktivitetsplikt ? 'Aktivitetsplikt' : 'Ikke aktivitetsplikt';
+};
+
+export const oppfolingsdatoEnsligeForsorgere = (alderBarn?: Date) => {
+    if (!alderBarn) {
+        return '';
+    }
+    const alderBarnMoment = moment(alderBarn);
+
+    if (moment().diff(alderBarnMoment, 'months') < 6) {
+        const datoBarnSeksMnd = alderBarnMoment.add({months: 6}).toDate();
+        const formatertDato = toDatePrettyPrint(datoBarnSeksMnd);
+        return `${formatertDato} (Barn 6 mnd)`;
+    }
+    const datoBarnEttAar = alderBarnMoment.add({years: 1}).toDate();
+    const formatertDato = toDatePrettyPrint(datoBarnEttAar);
+    return `${formatertDato} (Barn 1 år)`;
+};

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -1,13 +1,9 @@
 import 'babel-polyfill';
 import moment from 'moment';
-import {
-    nesteUtlopsdatoEllerNull,
-    oppfolingsdatoEnsligeForsorgere,
-    utledValgteAktivitetsTyper,
-    utlopsdatoUker
-} from './utils';
+import {nesteUtlopsdatoEllerNull, utledValgteAktivitetsTyper, utlopsdatoUker} from './utils';
 import {oppfolgingStartetDato, toDatePrettyPrint} from './dato-utils';
 import {AktiviteterValg} from '../filtrering/filter-konstanter';
+import {oppfolingsdatoEnsligeForsorgere} from './enslig-forsorger';
 
 describe('Date utils', () => {
     describe('Utlopsdato aktiviteter', () => {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,8 +1,7 @@
 import {RefObject} from 'react';
-import moment from 'moment/moment';
 import {AktiviteterModell, BrukerModell, FiltervalgModell, Innsatsgruppe} from '../model-interfaces';
 import {Maybe} from './types';
-import {dateGreater, toDatePrettyPrint, toDateString} from './dato-utils';
+import {dateGreater, toDateString} from './dato-utils';
 import {settBrukerIKontekst} from '../middleware/api';
 import {AktiviteterValg} from '../filtrering/filter-konstanter';
 
@@ -269,29 +268,6 @@ export function bostedKommuneUtlandEllerUkjent(bruker: BrukerModell, geografiskb
 
 export const bostedBydelEllerUkjent = (bostedBydel: string, geografiskbostedData: Map<string, string>): string => {
     return geografiskbostedData.get(bostedBydel) ?? '–';
-};
-
-export const mapOmAktivitetsPlikt = (aktivitetsplikt?: boolean): string => {
-    if (aktivitetsplikt === undefined) {
-        return 'Ukjent';
-    }
-    return aktivitetsplikt ? 'Aktivitetsplikt' : 'Ikke aktivitetsplikt';
-};
-
-export const oppfolingsdatoEnsligeForsorgere = (alderBarn?: Date) => {
-    if (!alderBarn) {
-        return '';
-    }
-    const alderBarnMoment = moment(alderBarn);
-
-    if (moment().diff(alderBarnMoment, 'months') < 6) {
-        const datoBarnSeksMnd = alderBarnMoment.add({months: 6}).toDate();
-        const formatertDato = toDatePrettyPrint(datoBarnSeksMnd);
-        return `${formatertDato} (Barn 6 mnd)`;
-    }
-    const datoBarnEttAar = alderBarnMoment.add({years: 1}).toDate();
-    const formatertDato = toDatePrettyPrint(datoBarnEttAar);
-    return `${formatertDato} (Barn 1 år)`;
 };
 
 export const oppdaterBrukerIKontekstOgNavigerTilLenke = (fnr: string, lenke: string, apneNyFane?: boolean) => {


### PR DESCRIPTION
Verdi:
- lettare å sjå kva vi gjer med dataa vi får frå backend
- lettare kan dele denne koden med samarbeidspartnarar, sidan vi slepp referere til enkeltfunksjonar i ei diger fil