### PR TITLE
Potential fix for code scanning alert no. 98: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -2,6 +2,9 @@ name: Install, build, run Cypress on PR
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
     cypress-run:
         name: Install, build, run Cypress tests


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/veilarbportefoljeflatefs/security/code-scanning/98](https://github.com/navikt/veilarbportefoljeflatefs/security/code-scanning/98)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Based on the workflow's actions, the following permissions are needed:
- `contents: read` for `actions/checkout` to access repository contents.
- `contents: read` for `actions/upload-artifact` to upload artifacts.

This ensures the workflow has only the necessary permissions and avoids granting unnecessary write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
