### PR TITLE
Flytt arbeidslistetypar til eiga fil

### DIFF
--- a/src/components/tabell/arbeidslisteikon.tsx
+++ b/src/components/tabell/arbeidslisteikon.tsx
@@ -2,7 +2,7 @@ import {ReactComponent as FargekategoriIkonBlaHalvsirkel} from '../ikoner/fargek
 import {ReactComponent as FargekategoriIkonGronnTrekant} from '../ikoner/fargekategorier/Fargekategoriikon_gronn_trekant.svg';
 import {ReactComponent as FargekategoriIkonGulSirkel} from '../ikoner/fargekategorier/Fargekategoriikon_gul_sirkel.svg';
 import {ReactComponent as FargekategoriIkonLillaFirkant} from '../ikoner/fargekategorier/Fargekategoriikon_lilla_firkant.svg';
-import {KategoriModell} from '../../model-interfaces';
+import {KategoriModell} from '../../typer/arbeidsliste';
 import '../../minoversikt/minoversikt.css';
 
 interface ArbeidslistekategoriProps {

--- a/src/model-interfaces.ts
+++ b/src/model-interfaces.ts
@@ -1,3 +1,5 @@
+import {ArbeidslisteModell} from './typer/arbeidsliste';
+
 /* Enhet og veileder */
 
 export interface EnhetModell {
@@ -233,28 +235,6 @@ export interface BrukerModell {
     utdanningOgSituasjonSistEndret: string;
     gjeldendeVedtak14a: GjeldendeVedtak14aModell | null;
     utgattVarsel: UtgattVarselHendelse | null;
-}
-
-/* Arbeidsliste */
-/** OpenSearch-verdiar for å filtrere på arbeidslista sine fargekategoriar */
-export enum KategoriModell {
-    BLA = 'BLA',
-    LILLA = 'LILLA',
-    GRONN = 'GRONN',
-    GUL = 'GUL'
-}
-
-export interface ArbeidslisteModell {
-    kommentar?: string;
-    overskrift?: string;
-    frist: string;
-    arbeidslisteAktiv: boolean;
-    endringstidspunkt: string; // dato
-    isOppfolgendeVeileder: boolean;
-    sistEndretAv: {veilederId: string};
-    kategori: KategoriModell;
-    hentetKommentarOgTittel: boolean;
-    navkontorForArbeidsliste?: string;
 }
 
 /* Anna */

--- a/src/model-interfaces.ts
+++ b/src/model-interfaces.ts
@@ -257,13 +257,6 @@ export interface ArbeidslisteModell {
     navkontorForArbeidsliste?: string;
 }
 
-export interface ArbeidslisteDataModell {
-    fnr: string;
-    kommentar: string | null;
-    frist: string | null;
-    kategori: KategoriModell | null;
-}
-
 /* Anna */
 
 export interface FargekategoriDataModell {

--- a/src/typer/arbeidsliste.ts
+++ b/src/typer/arbeidsliste.ts
@@ -1,0 +1,23 @@
+/* Denne modellen finst framleis fordi vi kan filtrere på arbeidslister via Lagra filter,
+ * og difor også har filtertags/filtrering-label'ar å vise med dei gamle kategoriane. 2025-05-19, Ingrid. */
+/** OpenSearch-verdiar for å filtrere på arbeidslista sine fargekategoriar */
+export enum KategoriModell {
+    BLA = 'BLA',
+    LILLA = 'LILLA',
+    GRONN = 'GRONN',
+    GUL = 'GUL'
+}
+
+/* Denne modellen finst framleis fordi vi framleis får Arbeidslister på brukermodellen frå OpenSearch. 2025-05-19, Ingrid. */
+export interface ArbeidslisteModell {
+    kommentar?: string;
+    overskrift?: string;
+    frist: string;
+    arbeidslisteAktiv: boolean;
+    endringstidspunkt: string; // dato
+    isOppfolgendeVeileder: boolean;
+    sistEndretAv: {veilederId: string};
+    kategori: KategoriModell;
+    hentetKommentarOgTittel: boolean;
+    navkontorForArbeidsliste?: string;
+}

--- a/src/typer/filtervalg-modell.ts
+++ b/src/typer/filtervalg-modell.ts
@@ -1,5 +1,6 @@
 import {FiltreringAktiviteterValg} from '../ducks/filtrering';
-import {FargekategoriModell, Hovedmal, InnsatsgruppeGjeldendeVedtak14a, KategoriModell} from '../model-interfaces';
+import {FargekategoriModell, Hovedmal, InnsatsgruppeGjeldendeVedtak14a} from '../model-interfaces';
+import {KategoriModell} from './arbeidsliste';
 
 /**
  * * * * * VIKTIG! * * * * * VIKTIG! * * * * * VIKTIG! * * * * * VIKTIG! * * * * * VIKTIG! * * * * *


### PR DESCRIPTION
- Fjern gamal og ubrukt type
- Flytt arbeidslistetypane til ei eiga fil, så det vert enno litt tydelegare at desse burde slettast.
- Legg til kommentarar på kvifor arbeidslistetypane ikkje er sletta, så eg slepp leite det fram kvar gong eg snublar over dei og tenker "burde ikkje desse vore sletta no?"