### PR TITLE
Flytt typar for veileder og enhet til eiga fil

### DIFF
--- a/src/components/modal/tildel-veileder/tildel-veileder-renderer.tsx
+++ b/src/components/modal/tildel-veileder/tildel-veileder-renderer.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import {Button, Radio, RadioGroup} from '@navikt/ds-react';
-import {VeilederModell} from '../../../model-interfaces';
+import {VeilederModell} from '../../../typer/enhet-og-veiledere-modeller';
 
 interface TildelVeilederRendererProps {
     data: VeilederModell[];

--- a/src/components/tabell/veiledernavn.tsx
+++ b/src/components/tabell/veiledernavn.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import {BodyShort, Tag} from '@navikt/ds-react';
-import {VeilederModell} from '../../model-interfaces';
+import {VeilederModell} from '../../typer/enhet-og-veiledere-modeller';
 import {BrukerModell} from '../../typer/bruker-modell';
 
 interface VeiledernavnProps {

--- a/src/components/veileder-checkbox-liste/veileder-checkbox-liste.tsx
+++ b/src/components/veileder-checkbox-liste/veileder-checkbox-liste.tsx
@@ -2,7 +2,7 @@ import {useEffect, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {Alert, Checkbox, CheckboxGroup} from '@navikt/ds-react';
 import {VeiledereState} from '../../ducks/veiledere';
-import {VeilederModell} from '../../model-interfaces';
+import {VeilederModell} from '../../typer/enhet-og-veiledere-modeller';
 import {FiltervalgModell} from '../../typer/filtervalg-modell';
 import {AppState} from '../../reducer';
 import {NullstillKnapp} from '../nullstill-valg-knapp/nullstill-knapp';

--- a/src/ducks/innlogget-veileder.ts
+++ b/src/ducks/innlogget-veileder.ts
@@ -1,6 +1,6 @@
 import {hentAktivBruker} from '../middleware/api';
 import {STATUS, doThenDispatch} from './utils';
-import {VeilederModell} from '../model-interfaces';
+import {VeilederModell} from '../typer/enhet-og-veiledere-modeller';
 import {OrNothing} from '../utils/types/types';
 
 // Actions

--- a/src/ducks/lagret-filter.ts
+++ b/src/ducks/lagret-filter.ts
@@ -1,4 +1,4 @@
-import {VeilederModell} from '../model-interfaces';
+import {VeilederModell} from '../typer/enhet-og-veiledere-modeller';
 import {FiltervalgModell} from '../typer/filtervalg-modell';
 
 export interface LagretFilter {

--- a/src/ducks/veiledere.ts
+++ b/src/ducks/veiledere.ts
@@ -1,6 +1,6 @@
 import {hentEnhetsVeiledere} from '../middleware/api';
 import {STATUS, doThenDispatch} from './utils';
-import {VeilederModell} from '../model-interfaces';
+import {VeilederModell} from '../typer/enhet-og-veiledere-modeller';
 
 // Actions
 export const OK = 'veilarbveileder/veiledere/OK';

--- a/src/enhetsportefolje/enhet-brukerpanel.tsx
+++ b/src/enhetsportefolje/enhet-brukerpanel.tsx
@@ -3,7 +3,7 @@ import {useDispatch} from 'react-redux';
 import classNames from 'classnames';
 import {Checkbox} from '@navikt/ds-react';
 import {Etiketter} from '../components/tabell/etiketter';
-import {VeilederModell} from '../model-interfaces';
+import {VeilederModell} from '../typer/enhet-og-veiledere-modeller';
 import {BrukerModell} from '../typer/bruker-modell';
 import {FiltervalgModell} from '../typer/filtervalg-modell';
 import {Kolonne} from '../ducks/ui/listevisning';

--- a/src/enhetsportefolje/enhet-kolonner.tsx
+++ b/src/enhetsportefolje/enhet-kolonner.tsx
@@ -5,7 +5,8 @@ import {UkeKolonne} from '../components/tabell/kolonner/ukekolonne';
 import {avvik14aVedtakAvhengigeFilter, ytelseAapSortering, ytelsevalg} from '../filtrering/filter-konstanter';
 import {DatoKolonne} from '../components/tabell/kolonner/datokolonne';
 import {Kolonne} from '../ducks/ui/listevisning';
-import {HovedmalNavn, innsatsgruppeNavn, VeilederModell} from '../model-interfaces';
+import {HovedmalNavn, innsatsgruppeNavn} from '../model-interfaces';
+import {VeilederModell} from '../typer/enhet-og-veiledere-modeller';
 import {BarnUnder18Aar, BrukerModell} from '../typer/bruker-modell';
 import {FiltervalgModell} from '../typer/filtervalg-modell';
 import {

--- a/src/filtrering/filtrering-label-container.tsx
+++ b/src/filtrering/filtrering-label-container.tsx
@@ -10,7 +10,7 @@ import {
     hendelserEtikett,
     MINE_FARGEKATEGORIER
 } from './filter-konstanter';
-import {EnhetModell} from '../model-interfaces';
+import {EnhetModell} from '../typer/enhet-og-veiledere-modeller';
 import {FiltervalgModell} from '../typer/filtervalg-modell';
 import {oppdaterKolonneAlternativer, OversiktType} from '../ducks/ui/listevisning';
 import {hentMineFilterForVeileder} from '../ducks/mine-filter';

--- a/src/hooks/redux/use-innlogget-ident.tsx
+++ b/src/hooks/redux/use-innlogget-ident.tsx
@@ -1,7 +1,7 @@
 import {useSelector} from 'react-redux';
 import {AppState} from '../../reducer';
 import {OrNothing} from '../../utils/types/types';
-import {VeilederModell} from '../../model-interfaces';
+import {VeilederModell} from '../../typer/enhet-og-veiledere-modeller';
 
 const selectIdent = (state: AppState) => state.innloggetVeileder.data;
 

--- a/src/middleware/api.ts
+++ b/src/middleware/api.ts
@@ -1,4 +1,5 @@
-import {FargekategoriDataModell, VeilederePaEnhetModell, VeilederModell} from '../model-interfaces';
+import {FargekategoriDataModell} from '../model-interfaces';
+import {VeilederePaEnhetModell, VeilederModell} from '../typer/enhet-og-veiledere-modeller';
 import {FiltervalgModell} from '../typer/filtervalg-modell';
 import {NyttLagretFilter, RedigerLagretFilter, SorteringOgId} from '../ducks/lagret-filter';
 import {erDev, loginUrl} from '../utils/url-utils';

--- a/src/mocks/data/innloggetVeileder.ts
+++ b/src/mocks/data/innloggetVeileder.ts
@@ -1,5 +1,5 @@
 import {innloggetVeileder as innloggetVeilederFraVeiledereliste} from './veiledere';
-import {EnhetModell, VeilederModell} from '../../model-interfaces';
+import {EnhetModell, VeilederModell} from '../../typer/enhet-og-veiledere-modeller';
 
 export const innloggetEnhet: EnhetModell = {
     enhetId: '1234',

--- a/src/mocks/data/veiledere.ts
+++ b/src/mocks/data/veiledere.ts
@@ -1,7 +1,7 @@
 import {fakerNB_NO as faker} from '@faker-js/faker';
 import {rnd} from '../utils';
 import {MOCK_CONFIG} from '../constants';
-import {VeilederePaEnhetModell, VeilederUtenEnhetModell} from '../../model-interfaces';
+import {VeilederePaEnhetModell, VeilederUtenEnhetModell} from '../../typer/enhet-og-veiledere-modeller';
 
 faker.seed(MOCK_CONFIG.seed);
 

--- a/src/model-interfaces.ts
+++ b/src/model-interfaces.ts
@@ -1,30 +1,5 @@
 import {FargekategoriModell, Hovedmal, InnsatsgruppeGjeldendeVedtak14a} from './typer/bruker-modell';
 
-/* Enhet og veileder */
-
-export interface EnhetModell {
-    enhetId: string;
-    navn?: string;
-}
-
-/* Formatet vi får innlogga veileder på frå veilarbveileder/api/veileder/v2/me */
-export interface VeilederModell {
-    ident: string;
-    navn: string;
-    fornavn: string;
-    etternavn: string;
-    enheter: EnhetModell[];
-}
-
-/* Formatet vi får kvar veileder på enheten på, frå veilarbveileder/api/enhet/${enhetId}/veiledere */
-export type VeilederUtenEnhetModell = Omit<VeilederModell, 'enheter'>;
-
-/* Responstypen for veilarbveileder/api/enhet/${enhetId}/veiledere */
-export interface VeilederePaEnhetModell {
-    veilederListe: VeilederUtenEnhetModell[];
-    enhet: EnhetModell;
-}
-
 /* Visningstekstar */
 
 /** Korte visningsnavn for innsatsgrupper.

--- a/src/typer/enhet-og-veiledere-modeller.ts
+++ b/src/typer/enhet-og-veiledere-modeller.ts
@@ -1,0 +1,22 @@
+export interface EnhetModell {
+    enhetId: string;
+    navn?: string;
+}
+
+/* Formatet vi får innlogga veileder på frå veilarbveileder/api/veileder/v2/me */
+export interface VeilederModell {
+    ident: string;
+    navn: string;
+    fornavn: string;
+    etternavn: string;
+    enheter: EnhetModell[];
+}
+
+/* Formatet vi får kvar veileder på enheten på, frå veilarbveileder/api/enhet/${enhetId}/veiledere */
+export type VeilederUtenEnhetModell = Omit<VeilederModell, 'enheter'>;
+
+/* Responstypen for veilarbveileder/api/enhet/${enhetId}/veiledere */
+export interface VeilederePaEnhetModell {
+    veilederListe: VeilederUtenEnhetModell[];
+    enhet: EnhetModell;
+}

--- a/src/utils/metrikker/browser-metrikker.ts
+++ b/src/utils/metrikker/browser-metrikker.ts
@@ -10,7 +10,7 @@ import {
     isSafari
 } from 'react-device-detect';
 import {OrNothing} from '../types/types';
-import {VeilederModell} from '../../model-interfaces';
+import {VeilederModell} from '../../typer/enhet-og-veiledere-modeller';
 import {logEvent} from '../frontend-logger';
 import {mapVeilederIdentTilNonsens} from '../../middleware/metrics-middleware';
 

--- a/src/utils/metrikker/side-visning-metrikker.ts
+++ b/src/utils/metrikker/side-visning-metrikker.ts
@@ -1,7 +1,7 @@
 import {logEvent} from '../frontend-logger';
 import {Side} from './skjerm-metrikker';
 import {OrNothing} from '../types/types';
-import {VeilederModell} from '../../model-interfaces';
+import {VeilederModell} from '../../typer/enhet-og-veiledere-modeller';
 import {getCrypto} from './crypto';
 
 export const loggSideVisning = (veilederIdent: OrNothing<VeilederModell>, side: Side): void => {

--- a/src/veilederoversikt/veilederoversikt-sidevisning.tsx
+++ b/src/veilederoversikt/veilederoversikt-sidevisning.tsx
@@ -6,7 +6,7 @@ import {sorter} from '../utils/sortering';
 import {selectFraIndex, selectSeFlere, selectSidestorrelse} from '../components/toolbar/paginering/paginering-selector';
 import {OversiktType} from '../ducks/ui/listevisning';
 import {PortefoljeStorrelser} from '../ducks/portefoljestorrelser';
-import {VeilederModell} from '../model-interfaces';
+import {VeilederModell} from '../typer/enhet-og-veiledere-modeller';
 import {AppState} from '../reducer';
 import './veilederoversikt.css';
 


### PR DESCRIPTION
Flytt typar for veileder og enhet til eiga fil slik at det er lettare å sjå at desse heng saman, og ikkje har noko med dei andre typane i model-interfaces å gjere