### PR TITLE
Gjer props for statusfilter-radioknappar litt tydelegare

### DIFF
--- a/src/components/barinput/barinput-radio.tsx
+++ b/src/components/barinput/barinput-radio.tsx
@@ -3,7 +3,6 @@ import {Label, Radio} from '@navikt/ds-react';
 import './bar.css';
 
 interface BarinputRadioProps {
-    filterNavn: string;
     handleChange: ChangeEventHandler<HTMLInputElement>;
     antall: number;
     labelTekst: string;
@@ -11,14 +10,7 @@ interface BarinputRadioProps {
     testId: string;
 }
 
-export const BarInputRadio = ({
-    filterNavn,
-    handleChange,
-    antall,
-    labelTekst,
-    filterVerdi,
-    testId
-}: BarinputRadioProps) => {
+export const BarInputRadio = ({handleChange, antall, labelTekst, filterVerdi, testId}: BarinputRadioProps) => {
     return (
         <div className="barinput-radio">
             <Radio

--- a/src/components/barinput/barinput-radio.tsx
+++ b/src/components/barinput/barinput-radio.tsx
@@ -24,7 +24,7 @@ export const BarInputRadio = ({
             <Radio
                 className="mine-filter__filternavn"
                 data-testid={testId}
-                key={filterNavn}
+                key={filterVerdi}
                 name="ferdigfilter"
                 onChange={handleChange}
                 value={filterVerdi}

--- a/src/components/barinput/barinput-radio.tsx
+++ b/src/components/barinput/barinput-radio.tsx
@@ -3,23 +3,23 @@ import {Label, Radio} from '@navikt/ds-react';
 import './bar.css';
 
 interface BarinputRadioProps {
-    handleChange: ChangeEventHandler<HTMLInputElement>;
-    statustall: number;
-    labelTekst: string;
     filterVerdi: string;
+    handleChange: ChangeEventHandler<HTMLInputElement>;
+    labelTekst: string;
+    statustall: number;
     testId?: string;
 }
 
-export const BarInputRadio = ({handleChange, statustall, labelTekst, filterVerdi, testId}: BarinputRadioProps) => {
+export const BarInputRadio = ({filterVerdi, handleChange, labelTekst, statustall, testId}: BarinputRadioProps) => {
     return (
         <div className="barinput-radio">
             <Radio
-                className="mine-filter__filternavn"
+                name="ferdigfilter"
+                value={filterVerdi}
+                onChange={handleChange}
                 data-testid={testId}
                 key={filterVerdi}
-                name="ferdigfilter"
-                onChange={handleChange}
-                value={filterVerdi}
+                className="mine-filter__filternavn"
                 size="small"
             >
                 {labelTekst}

--- a/src/components/barinput/barinput-radio.tsx
+++ b/src/components/barinput/barinput-radio.tsx
@@ -8,14 +8,22 @@ interface BarinputRadioProps {
     antall: number;
     labelTekst: string;
     filterVerdi: string;
+    testId: string;
 }
 
-export const BarInputRadio = ({filterNavn, handleChange, antall, labelTekst, filterVerdi}: BarinputRadioProps) => {
+export const BarInputRadio = ({
+    filterNavn,
+    handleChange,
+    antall,
+    labelTekst,
+    filterVerdi,
+    testId
+}: BarinputRadioProps) => {
     return (
         <div className="barinput-radio">
             <Radio
                 className="mine-filter__filternavn"
-                data-testid={`filter_checkboks-container_${filterNavn}`}
+                data-testid={testId}
                 key={filterNavn}
                 name="ferdigfilter"
                 onChange={handleChange}

--- a/src/components/barinput/barinput-radio.tsx
+++ b/src/components/barinput/barinput-radio.tsx
@@ -4,13 +4,13 @@ import './bar.css';
 
 interface BarinputRadioProps {
     handleChange: ChangeEventHandler<HTMLInputElement>;
-    antall: number;
+    statustall: number;
     labelTekst: string;
     filterVerdi: string;
     testId?: string;
 }
 
-export const BarInputRadio = ({handleChange, antall, labelTekst, filterVerdi, testId}: BarinputRadioProps) => {
+export const BarInputRadio = ({handleChange, statustall, labelTekst, filterVerdi, testId}: BarinputRadioProps) => {
     return (
         <div className="barinput-radio">
             <Radio
@@ -24,9 +24,9 @@ export const BarInputRadio = ({handleChange, antall, labelTekst, filterVerdi, te
             >
                 {labelTekst}
             </Radio>
-            {(!!antall || antall === 0) && (
+            {(!!statustall || statustall === 0) && (
                 <Label className="barlabel__antall" size="small">
-                    {antall}
+                    {statustall}
                 </Label>
             )}
         </div>

--- a/src/components/barinput/barinput-radio.tsx
+++ b/src/components/barinput/barinput-radio.tsx
@@ -7,7 +7,7 @@ interface BarinputRadioProps {
     antall: number;
     labelTekst: string;
     filterVerdi: string;
-    testId: string;
+    testId?: string;
 }
 
 export const BarInputRadio = ({handleChange, antall, labelTekst, filterVerdi, testId}: BarinputRadioProps) => {

--- a/src/filtrering/filtrering-status/filtrering-status.tsx
+++ b/src/filtrering/filtrering-status/filtrering-status.tsx
@@ -136,7 +136,6 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
                         testId="filter_checkboks-container_trengerOppfolgingsvedtak"
-                        filterNavn="trengerOppfolgingsvedtak"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.trengerOppfolgingsvedtak}
                         filterVerdi={TRENGER_OPPFOLGINGSVEDTAK}
@@ -144,7 +143,6 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                     />
                     <BarInputRadio
                         testId="filter_checkboks-container_underVurdering"
-                        filterNavn="underVurdering"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.underVurdering}
                         filterVerdi={UNDER_VURDERING}
@@ -152,7 +150,6 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                     />
                     <BarInputRadio
                         testId="filter_checkboks-container_erSykmeldtMedArbeidsgiver"
-                        filterNavn="erSykmeldtMedArbeidsgiver"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.erSykmeldtMedArbeidsgiver}
                         filterVerdi={ER_SYKMELDT_MED_ARBEIDSGIVER}
@@ -162,7 +159,6 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
                         testId="filter_checkboks-container_venterPaSvarFraNAV"
-                        filterNavn="venterPaSvarFraNAV"
                         antall={statustallMedBrukerinnsyn.venterPaSvarFraNAV}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={VENTER_PA_SVAR_FRA_NAV}
@@ -170,7 +166,6 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                     />
                     <BarInputRadio
                         testId="filter_checkboks-container_venterPaSvarFraBruker"
-                        filterNavn="venterPaSvarFraBruker"
                         antall={statustallMedBrukerinnsyn.venterPaSvarFraBruker}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={VENTER_PA_SVAR_FRA_BRUKER}
@@ -178,7 +173,6 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                     />
                     <BarInputRadio
                         testId="filter_checkboks-container_avtaltMoteMedNav"
-                        filterNavn="avtaltMoteMedNav"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.moterMedNAVIdag}
                         filterVerdi={MOTER_IDAG}
@@ -186,7 +180,6 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                     />
                     <BarInputRadio
                         testId="filter_checkboks-container_tiltakshendelse"
-                        filterNavn="tiltakshendelse"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.tiltakshendelser}
                         filterVerdi={TILTAKSHENDELSER}
@@ -196,7 +189,6 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
                         testId="filter_checkboks-container_utgatteVarsel"
-                        filterNavn="utgatteVarsel"
                         antall={statustallMedBrukerinnsyn.utgatteVarsel}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={UTGATTE_VARSEL}
@@ -204,7 +196,6 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                     />
                     <BarInputRadio
                         testId="filter_checkboks-container_utlopteAktiviteter"
-                        filterNavn="utlopteAktiviteter"
                         antall={statustallMedBrukerinnsyn.utlopteAktiviteter}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={UTLOPTE_AKTIVITETER}
@@ -212,7 +203,6 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                     />
                     <BarInputRadio
                         testId="filter_checkboks-container_ikkeIavtaltAktivitet"
-                        filterNavn="ikkeIavtaltAktivitet"
                         antall={statustallMedBrukerinnsyn.ikkeIavtaltAktivitet}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={IKKE_I_AVTALT_AKTIVITET}
@@ -220,7 +210,6 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                     />
                     <BarInputRadio
                         testId="filter_checkboks-container_iavtaltAktivitet"
-                        filterNavn="iavtaltAktivitet"
                         antall={statustallMedBrukerinnsyn.iavtaltAktivitet}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={I_AVTALT_AKTIVITET}
@@ -230,7 +219,6 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
                         testId="filter_checkboks-container_inaktiveBrukere"
-                        filterNavn="inaktiveBrukere"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.inaktiveBrukere}
                         filterVerdi={INAKTIVE_BRUKERE}
@@ -241,7 +229,6 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                     <div className="forste-barlabel-i-gruppe">
                         <BarInputRadio
                             testId="filter_checkboks-container_huskelapp"
-                            filterNavn="huskelapp"
                             antall={statustallMedBrukerinnsyn.mineHuskelapper}
                             handleChange={handleRadioButtonChange}
                             filterVerdi={MINE_HUSKELAPPER}

--- a/src/filtrering/filtrering-status/filtrering-status.tsx
+++ b/src/filtrering/filtrering-status/filtrering-status.tsx
@@ -135,21 +135,18 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
             >
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
-                        testId="filter_checkboks-container_trengerOppfolgingsvedtak"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.trengerOppfolgingsvedtak}
                         filterVerdi={TRENGER_OPPFOLGINGSVEDTAK}
                         labelTekst={ferdigfilterListeLabelTekst[TRENGER_OPPFOLGINGSVEDTAK]}
                     />
                     <BarInputRadio
-                        testId="filter_checkboks-container_underVurdering"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.underVurdering}
                         filterVerdi={UNDER_VURDERING}
                         labelTekst={ferdigfilterListeLabelTekst[UNDER_VURDERING]}
                     />
                     <BarInputRadio
-                        testId="filter_checkboks-container_erSykmeldtMedArbeidsgiver"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.erSykmeldtMedArbeidsgiver}
                         filterVerdi={ER_SYKMELDT_MED_ARBEIDSGIVER}
@@ -158,14 +155,12 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                 </div>
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
-                        testId="filter_checkboks-container_venterPaSvarFraNAV"
                         antall={statustallMedBrukerinnsyn.venterPaSvarFraNAV}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={VENTER_PA_SVAR_FRA_NAV}
                         labelTekst={ferdigfilterListeLabelTekst[VENTER_PA_SVAR_FRA_NAV]}
                     />
                     <BarInputRadio
-                        testId="filter_checkboks-container_venterPaSvarFraBruker"
                         antall={statustallMedBrukerinnsyn.venterPaSvarFraBruker}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={VENTER_PA_SVAR_FRA_BRUKER}
@@ -179,7 +174,6 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         labelTekst={ferdigfilterListeLabelTekst[MOTER_IDAG]}
                     />
                     <BarInputRadio
-                        testId="filter_checkboks-container_tiltakshendelse"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.tiltakshendelser}
                         filterVerdi={TILTAKSHENDELSER}
@@ -188,21 +182,18 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                 </div>
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
-                        testId="filter_checkboks-container_utgatteVarsel"
                         antall={statustallMedBrukerinnsyn.utgatteVarsel}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={UTGATTE_VARSEL}
                         labelTekst={ferdigfilterListeLabelTekst[UTGATTE_VARSEL]}
                     />
                     <BarInputRadio
-                        testId="filter_checkboks-container_utlopteAktiviteter"
                         antall={statustallMedBrukerinnsyn.utlopteAktiviteter}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={UTLOPTE_AKTIVITETER}
                         labelTekst={ferdigfilterListeLabelTekst[UTLOPTE_AKTIVITETER]}
                     />
                     <BarInputRadio
-                        testId="filter_checkboks-container_ikkeIavtaltAktivitet"
                         antall={statustallMedBrukerinnsyn.ikkeIavtaltAktivitet}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={IKKE_I_AVTALT_AKTIVITET}
@@ -218,7 +209,6 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                 </div>
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
-                        testId="filter_checkboks-container_inaktiveBrukere"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.inaktiveBrukere}
                         filterVerdi={INAKTIVE_BRUKERE}
@@ -228,7 +218,6 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                 {oversiktType === OversiktType.minOversikt && (
                     <div className="forste-barlabel-i-gruppe">
                         <BarInputRadio
-                            testId="filter_checkboks-container_huskelapp"
                             antall={statustallMedBrukerinnsyn.mineHuskelapper}
                             handleChange={handleRadioButtonChange}
                             filterVerdi={MINE_HUSKELAPPER}

--- a/src/filtrering/filtrering-status/filtrering-status.tsx
+++ b/src/filtrering/filtrering-status/filtrering-status.tsx
@@ -135,93 +135,93 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
             >
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
-                        handleChange={handleRadioButtonChange}
-                        statustall={statustallMedBrukerinnsyn.trengerOppfolgingsvedtak}
                         filterVerdi={TRENGER_OPPFOLGINGSVEDTAK}
+                        handleChange={handleRadioButtonChange}
                         labelTekst={ferdigfilterListeLabelTekst[TRENGER_OPPFOLGINGSVEDTAK]}
+                        statustall={statustallMedBrukerinnsyn.trengerOppfolgingsvedtak}
                     />
                     <BarInputRadio
-                        handleChange={handleRadioButtonChange}
-                        statustall={statustallMedBrukerinnsyn.underVurdering}
                         filterVerdi={UNDER_VURDERING}
+                        handleChange={handleRadioButtonChange}
                         labelTekst={ferdigfilterListeLabelTekst[UNDER_VURDERING]}
+                        statustall={statustallMedBrukerinnsyn.underVurdering}
                     />
                     <BarInputRadio
-                        handleChange={handleRadioButtonChange}
-                        statustall={statustallMedBrukerinnsyn.erSykmeldtMedArbeidsgiver}
                         filterVerdi={ER_SYKMELDT_MED_ARBEIDSGIVER}
+                        handleChange={handleRadioButtonChange}
                         labelTekst={ferdigfilterListeLabelTekst[ER_SYKMELDT_MED_ARBEIDSGIVER]}
+                        statustall={statustallMedBrukerinnsyn.erSykmeldtMedArbeidsgiver}
                     />
                 </div>
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
-                        statustall={statustallMedBrukerinnsyn.venterPaSvarFraNAV}
-                        handleChange={handleRadioButtonChange}
                         filterVerdi={VENTER_PA_SVAR_FRA_NAV}
+                        handleChange={handleRadioButtonChange}
                         labelTekst={ferdigfilterListeLabelTekst[VENTER_PA_SVAR_FRA_NAV]}
+                        statustall={statustallMedBrukerinnsyn.venterPaSvarFraNAV}
                     />
                     <BarInputRadio
-                        statustall={statustallMedBrukerinnsyn.venterPaSvarFraBruker}
-                        handleChange={handleRadioButtonChange}
                         filterVerdi={VENTER_PA_SVAR_FRA_BRUKER}
+                        handleChange={handleRadioButtonChange}
                         labelTekst={ferdigfilterListeLabelTekst[VENTER_PA_SVAR_FRA_BRUKER]}
+                        statustall={statustallMedBrukerinnsyn.venterPaSvarFraBruker}
                     />
                     <BarInputRadio
-                        testId="filter_checkboks-container_avtaltMoteMedNav"
-                        handleChange={handleRadioButtonChange}
-                        statustall={statustallMedBrukerinnsyn.moterMedNAVIdag}
                         filterVerdi={MOTER_IDAG}
+                        handleChange={handleRadioButtonChange}
                         labelTekst={ferdigfilterListeLabelTekst[MOTER_IDAG]}
+                        statustall={statustallMedBrukerinnsyn.moterMedNAVIdag}
+                        testId="filter_checkboks-container_avtaltMoteMedNav"
                     />
                     <BarInputRadio
-                        handleChange={handleRadioButtonChange}
-                        statustall={statustallMedBrukerinnsyn.tiltakshendelser}
                         filterVerdi={TILTAKSHENDELSER}
+                        handleChange={handleRadioButtonChange}
                         labelTekst={ferdigfilterListeLabelTekst[TILTAKSHENDELSER]}
+                        statustall={statustallMedBrukerinnsyn.tiltakshendelser}
                     />
                 </div>
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
-                        statustall={statustallMedBrukerinnsyn.utgatteVarsel}
-                        handleChange={handleRadioButtonChange}
                         filterVerdi={UTGATTE_VARSEL}
+                        handleChange={handleRadioButtonChange}
                         labelTekst={ferdigfilterListeLabelTekst[UTGATTE_VARSEL]}
+                        statustall={statustallMedBrukerinnsyn.utgatteVarsel}
                     />
                     <BarInputRadio
-                        statustall={statustallMedBrukerinnsyn.utlopteAktiviteter}
+                        labelTekst={ferdigfilterListeLabelTekst[UTLOPTE_AKTIVITETER]}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={UTLOPTE_AKTIVITETER}
-                        labelTekst={ferdigfilterListeLabelTekst[UTLOPTE_AKTIVITETER]}
+                        statustall={statustallMedBrukerinnsyn.utlopteAktiviteter}
                     />
                     <BarInputRadio
-                        statustall={statustallMedBrukerinnsyn.ikkeIavtaltAktivitet}
-                        handleChange={handleRadioButtonChange}
                         filterVerdi={IKKE_I_AVTALT_AKTIVITET}
+                        handleChange={handleRadioButtonChange}
                         labelTekst={ferdigfilterListeLabelTekst[IKKE_I_AVTALT_AKTIVITET]}
+                        statustall={statustallMedBrukerinnsyn.ikkeIavtaltAktivitet}
                     />
                     <BarInputRadio
-                        testId="filter_checkboks-container_iavtaltAktivitet"
-                        statustall={statustallMedBrukerinnsyn.iavtaltAktivitet}
-                        handleChange={handleRadioButtonChange}
                         filterVerdi={I_AVTALT_AKTIVITET}
+                        handleChange={handleRadioButtonChange}
                         labelTekst={ferdigfilterListeLabelTekst[I_AVTALT_AKTIVITET]}
+                        statustall={statustallMedBrukerinnsyn.iavtaltAktivitet}
+                        testId="filter_checkboks-container_iavtaltAktivitet"
                     />
                 </div>
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
-                        handleChange={handleRadioButtonChange}
-                        statustall={statustallMedBrukerinnsyn.inaktiveBrukere}
                         filterVerdi={INAKTIVE_BRUKERE}
+                        handleChange={handleRadioButtonChange}
                         labelTekst={ferdigfilterListeLabelTekst[INAKTIVE_BRUKERE]}
+                        statustall={statustallMedBrukerinnsyn.inaktiveBrukere}
                     />
                 </div>
                 {oversiktType === OversiktType.minOversikt && (
                     <div className="forste-barlabel-i-gruppe">
                         <BarInputRadio
-                            statustall={statustallMedBrukerinnsyn.mineHuskelapper}
-                            handleChange={handleRadioButtonChange}
                             filterVerdi={MINE_HUSKELAPPER}
+                            handleChange={handleRadioButtonChange}
                             labelTekst={ferdigfilterListeLabelTekst[MINE_HUSKELAPPER]}
+                            statustall={statustallMedBrukerinnsyn.mineHuskelapper}
                         />
                         <FilterStatusMineFargekategorier />
                     </div>

--- a/src/filtrering/filtrering-status/filtrering-status.tsx
+++ b/src/filtrering/filtrering-status/filtrering-status.tsx
@@ -135,6 +135,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
             >
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
+                        testId="filter_checkboks-container_trengerOppfolgingsvedtak"
                         filterNavn="trengerOppfolgingsvedtak"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.trengerOppfolgingsvedtak}
@@ -142,6 +143,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         labelTekst={ferdigfilterListeLabelTekst[TRENGER_OPPFOLGINGSVEDTAK]}
                     />
                     <BarInputRadio
+                        testId="filter_checkboks-container_underVurdering"
                         filterNavn="underVurdering"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.underVurdering}
@@ -149,6 +151,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         labelTekst={ferdigfilterListeLabelTekst[UNDER_VURDERING]}
                     />
                     <BarInputRadio
+                        testId="filter_checkboks-container_erSykmeldtMedArbeidsgiver"
                         filterNavn="erSykmeldtMedArbeidsgiver"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.erSykmeldtMedArbeidsgiver}
@@ -158,6 +161,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                 </div>
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
+                        testId="filter_checkboks-container_venterPaSvarFraNAV"
                         filterNavn="venterPaSvarFraNAV"
                         antall={statustallMedBrukerinnsyn.venterPaSvarFraNAV}
                         handleChange={handleRadioButtonChange}
@@ -165,6 +169,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         labelTekst={ferdigfilterListeLabelTekst[VENTER_PA_SVAR_FRA_NAV]}
                     />
                     <BarInputRadio
+                        testId="filter_checkboks-container_venterPaSvarFraBruker"
                         filterNavn="venterPaSvarFraBruker"
                         antall={statustallMedBrukerinnsyn.venterPaSvarFraBruker}
                         handleChange={handleRadioButtonChange}
@@ -172,6 +177,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         labelTekst={ferdigfilterListeLabelTekst[VENTER_PA_SVAR_FRA_BRUKER]}
                     />
                     <BarInputRadio
+                        testId="filter_checkboks-container_avtaltMoteMedNav"
                         filterNavn="avtaltMoteMedNav"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.moterMedNAVIdag}
@@ -179,6 +185,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         labelTekst={ferdigfilterListeLabelTekst[MOTER_IDAG]}
                     />
                     <BarInputRadio
+                        testId="filter_checkboks-container_tiltakshendelse"
                         filterNavn="tiltakshendelse"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.tiltakshendelser}
@@ -188,6 +195,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                 </div>
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
+                        testId="filter_checkboks-container_utgatteVarsel"
                         filterNavn="utgatteVarsel"
                         antall={statustallMedBrukerinnsyn.utgatteVarsel}
                         handleChange={handleRadioButtonChange}
@@ -195,6 +203,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         labelTekst={ferdigfilterListeLabelTekst[UTGATTE_VARSEL]}
                     />
                     <BarInputRadio
+                        testId="filter_checkboks-container_utlopteAktiviteter"
                         filterNavn="utlopteAktiviteter"
                         antall={statustallMedBrukerinnsyn.utlopteAktiviteter}
                         handleChange={handleRadioButtonChange}
@@ -202,6 +211,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         labelTekst={ferdigfilterListeLabelTekst[UTLOPTE_AKTIVITETER]}
                     />
                     <BarInputRadio
+                        testId="filter_checkboks-container_ikkeIavtaltAktivitet"
                         filterNavn="ikkeIavtaltAktivitet"
                         antall={statustallMedBrukerinnsyn.ikkeIavtaltAktivitet}
                         handleChange={handleRadioButtonChange}
@@ -209,6 +219,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                         labelTekst={ferdigfilterListeLabelTekst[IKKE_I_AVTALT_AKTIVITET]}
                     />
                     <BarInputRadio
+                        testId="filter_checkboks-container_iavtaltAktivitet"
                         filterNavn="iavtaltAktivitet"
                         antall={statustallMedBrukerinnsyn.iavtaltAktivitet}
                         handleChange={handleRadioButtonChange}
@@ -218,6 +229,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                 </div>
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
+                        testId="filter_checkboks-container_inaktiveBrukere"
                         filterNavn="inaktiveBrukere"
                         handleChange={handleRadioButtonChange}
                         antall={statustallMedBrukerinnsyn.inaktiveBrukere}
@@ -228,6 +240,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                 {oversiktType === OversiktType.minOversikt && (
                     <div className="forste-barlabel-i-gruppe">
                         <BarInputRadio
+                            testId="filter_checkboks-container_huskelapp"
                             filterNavn="huskelapp"
                             antall={statustallMedBrukerinnsyn.mineHuskelapper}
                             handleChange={handleRadioButtonChange}

--- a/src/filtrering/filtrering-status/filtrering-status.tsx
+++ b/src/filtrering/filtrering-status/filtrering-status.tsx
@@ -136,32 +136,32 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
                         handleChange={handleRadioButtonChange}
-                        antall={statustallMedBrukerinnsyn.trengerOppfolgingsvedtak}
+                        statustall={statustallMedBrukerinnsyn.trengerOppfolgingsvedtak}
                         filterVerdi={TRENGER_OPPFOLGINGSVEDTAK}
                         labelTekst={ferdigfilterListeLabelTekst[TRENGER_OPPFOLGINGSVEDTAK]}
                     />
                     <BarInputRadio
                         handleChange={handleRadioButtonChange}
-                        antall={statustallMedBrukerinnsyn.underVurdering}
+                        statustall={statustallMedBrukerinnsyn.underVurdering}
                         filterVerdi={UNDER_VURDERING}
                         labelTekst={ferdigfilterListeLabelTekst[UNDER_VURDERING]}
                     />
                     <BarInputRadio
                         handleChange={handleRadioButtonChange}
-                        antall={statustallMedBrukerinnsyn.erSykmeldtMedArbeidsgiver}
+                        statustall={statustallMedBrukerinnsyn.erSykmeldtMedArbeidsgiver}
                         filterVerdi={ER_SYKMELDT_MED_ARBEIDSGIVER}
                         labelTekst={ferdigfilterListeLabelTekst[ER_SYKMELDT_MED_ARBEIDSGIVER]}
                     />
                 </div>
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
-                        antall={statustallMedBrukerinnsyn.venterPaSvarFraNAV}
+                        statustall={statustallMedBrukerinnsyn.venterPaSvarFraNAV}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={VENTER_PA_SVAR_FRA_NAV}
                         labelTekst={ferdigfilterListeLabelTekst[VENTER_PA_SVAR_FRA_NAV]}
                     />
                     <BarInputRadio
-                        antall={statustallMedBrukerinnsyn.venterPaSvarFraBruker}
+                        statustall={statustallMedBrukerinnsyn.venterPaSvarFraBruker}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={VENTER_PA_SVAR_FRA_BRUKER}
                         labelTekst={ferdigfilterListeLabelTekst[VENTER_PA_SVAR_FRA_BRUKER]}
@@ -169,39 +169,39 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                     <BarInputRadio
                         testId="filter_checkboks-container_avtaltMoteMedNav"
                         handleChange={handleRadioButtonChange}
-                        antall={statustallMedBrukerinnsyn.moterMedNAVIdag}
+                        statustall={statustallMedBrukerinnsyn.moterMedNAVIdag}
                         filterVerdi={MOTER_IDAG}
                         labelTekst={ferdigfilterListeLabelTekst[MOTER_IDAG]}
                     />
                     <BarInputRadio
                         handleChange={handleRadioButtonChange}
-                        antall={statustallMedBrukerinnsyn.tiltakshendelser}
+                        statustall={statustallMedBrukerinnsyn.tiltakshendelser}
                         filterVerdi={TILTAKSHENDELSER}
                         labelTekst={ferdigfilterListeLabelTekst[TILTAKSHENDELSER]}
                     />
                 </div>
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
-                        antall={statustallMedBrukerinnsyn.utgatteVarsel}
+                        statustall={statustallMedBrukerinnsyn.utgatteVarsel}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={UTGATTE_VARSEL}
                         labelTekst={ferdigfilterListeLabelTekst[UTGATTE_VARSEL]}
                     />
                     <BarInputRadio
-                        antall={statustallMedBrukerinnsyn.utlopteAktiviteter}
+                        statustall={statustallMedBrukerinnsyn.utlopteAktiviteter}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={UTLOPTE_AKTIVITETER}
                         labelTekst={ferdigfilterListeLabelTekst[UTLOPTE_AKTIVITETER]}
                     />
                     <BarInputRadio
-                        antall={statustallMedBrukerinnsyn.ikkeIavtaltAktivitet}
+                        statustall={statustallMedBrukerinnsyn.ikkeIavtaltAktivitet}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={IKKE_I_AVTALT_AKTIVITET}
                         labelTekst={ferdigfilterListeLabelTekst[IKKE_I_AVTALT_AKTIVITET]}
                     />
                     <BarInputRadio
                         testId="filter_checkboks-container_iavtaltAktivitet"
-                        antall={statustallMedBrukerinnsyn.iavtaltAktivitet}
+                        statustall={statustallMedBrukerinnsyn.iavtaltAktivitet}
                         handleChange={handleRadioButtonChange}
                         filterVerdi={I_AVTALT_AKTIVITET}
                         labelTekst={ferdigfilterListeLabelTekst[I_AVTALT_AKTIVITET]}
@@ -210,7 +210,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                 <div className="forste-barlabel-i-gruppe">
                     <BarInputRadio
                         handleChange={handleRadioButtonChange}
-                        antall={statustallMedBrukerinnsyn.inaktiveBrukere}
+                        statustall={statustallMedBrukerinnsyn.inaktiveBrukere}
                         filterVerdi={INAKTIVE_BRUKERE}
                         labelTekst={ferdigfilterListeLabelTekst[INAKTIVE_BRUKERE]}
                     />
@@ -218,7 +218,7 @@ export function FiltreringStatus({filtervalg, oversiktType, statustall}: Filtrer
                 {oversiktType === OversiktType.minOversikt && (
                     <div className="forste-barlabel-i-gruppe">
                         <BarInputRadio
-                            antall={statustallMedBrukerinnsyn.mineHuskelapper}
+                            statustall={statustallMedBrukerinnsyn.mineHuskelapper}
                             handleChange={handleRadioButtonChange}
                             filterVerdi={MINE_HUSKELAPPER}
                             labelTekst={ferdigfilterListeLabelTekst[MINE_HUSKELAPPER]}


### PR DESCRIPTION
Propen `filterNavn` vart brukt til to ting:
- Som postfiks i test-id
- Som key for react-elementet

Endring:
- Hardkode test-id.
- Fjern ubrukte test-id'ar.
- Bruke `value` til key i staden for filterNavn slik at vi kan fjerne heile filternavn-propen.
- Rydd litt i rekkefølgja på props i radioknapp-komponenten.
- Endre namn på prop `antall` til `statustall`, sidan det er det vi kallar talet i daglegtale.

Fordel:
- Lettare å finne bruken av test-id'ane
- Eit ledd i å gjere det tydelegare kva "filterNavn"-propen gjer for noko, og at den ikkje har noko med Filtermodellen å gjere