### PR TITLE
Oppdater namnet på kolonneoverskrifter-komponentar for Utkast § 14 a

### DIFF
--- a/src/components/tabell/headerceller/Utkast14aAnsvarligVeileder.tsx
+++ b/src/components/tabell/headerceller/Utkast14aAnsvarligVeileder.tsx
@@ -3,20 +3,20 @@ import {Kolonne} from '../../../ducks/ui/listevisning';
 import {SorteringHeader} from '../sortering-header';
 import {Sorteringsfelt} from '../../../typer/kolonnesortering';
 
-export const UnderVurderingVedtaksstatus = ({
+export const Utkast14aAnsvarligVeileder = ({
     gjeldendeSorteringsfelt,
     valgteKolonner,
     rekkefolge,
     onClick
 }: HeadercelleProps) => (
     <SorteringHeader
-        skalVises={valgteKolonner.includes(Kolonne.VEDTAKSTATUS)}
-        sortering={Sorteringsfelt.UTKAST_14A_STATUS}
-        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS}
+        skalVises={valgteKolonner.includes(Kolonne.ANSVARLIG_VEILEDER_FOR_VEDTAK)}
+        sortering={Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
         rekkefolge={rekkefolge}
         onClick={onClick}
-        tekst="Status oppfølgingsvedtak"
-        title="Status oppfølgingsvedtak § 14 a"
+        tekst="Ansvarlig for oppfølgingsvedtak"
+        title="Ansvarlig veileder for utkast til oppfølgingsvedtak § 14 a"
         className="col col-xs-2"
     />
 );

--- a/src/components/tabell/headerceller/Utkast14aVedtaksstatus.tsx
+++ b/src/components/tabell/headerceller/Utkast14aVedtaksstatus.tsx
@@ -3,20 +3,20 @@ import {Kolonne} from '../../../ducks/ui/listevisning';
 import {SorteringHeader} from '../sortering-header';
 import {Sorteringsfelt} from '../../../typer/kolonnesortering';
 
-export const UnderVurderingVedtaksstatusEndret = ({
+export const Utkast14aVedtaksstatus = ({
     gjeldendeSorteringsfelt,
     valgteKolonner,
     rekkefolge,
     onClick
 }: HeadercelleProps) => (
     <SorteringHeader
-        skalVises={valgteKolonner.includes(Kolonne.VEDTAKSTATUS_ENDRET)}
-        sortering={Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
-        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
+        skalVises={valgteKolonner.includes(Kolonne.VEDTAKSTATUS)}
+        sortering={Sorteringsfelt.UTKAST_14A_STATUS}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS}
         rekkefolge={rekkefolge}
         onClick={onClick}
-        tekst="Dager siden statusendring"
-        title="Dager siden statusendring på utkast for oppfølgingsvedtak § 14 a"
+        tekst="Status oppfølgingsvedtak"
+        title="Status oppfølgingsvedtak § 14 a"
         className="col col-xs-2"
     />
 );

--- a/src/components/tabell/headerceller/Utkast14aVedtaksstatusEndret.tsx
+++ b/src/components/tabell/headerceller/Utkast14aVedtaksstatusEndret.tsx
@@ -3,20 +3,20 @@ import {Kolonne} from '../../../ducks/ui/listevisning';
 import {SorteringHeader} from '../sortering-header';
 import {Sorteringsfelt} from '../../../typer/kolonnesortering';
 
-export const UnderVurderingAnsvarligVeileder = ({
+export const Utkast14aVedtaksstatusEndret = ({
     gjeldendeSorteringsfelt,
     valgteKolonner,
     rekkefolge,
     onClick
 }: HeadercelleProps) => (
     <SorteringHeader
-        skalVises={valgteKolonner.includes(Kolonne.ANSVARLIG_VEILEDER_FOR_VEDTAK)}
-        sortering={Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
-        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER}
+        skalVises={valgteKolonner.includes(Kolonne.VEDTAKSTATUS_ENDRET)}
+        sortering={Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
+        erValgt={gjeldendeSorteringsfelt === Sorteringsfelt.UTKAST_14A_STATUS_ENDRET}
         rekkefolge={rekkefolge}
         onClick={onClick}
-        tekst="Ansvarlig for oppfølgingsvedtak"
-        title="Ansvarlig veileder for utkast til oppfølgingsvedtak § 14 a"
+        tekst="Dager siden statusendring"
+        title="Dager siden statusendring på utkast for oppfølgingsvedtak § 14 a"
         className="col col-xs-2"
     />
 );

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -49,9 +49,9 @@ import {AvtaltAktivitet} from '../components/tabell/headerceller/AvtaltAktivitet
 import {MoterIDag} from '../components/tabell/headerceller/MoterIDag';
 import {MoteVarighet} from '../components/tabell/headerceller/MoteVarighet';
 import {Motestatus} from '../components/tabell/headerceller/Motestatus';
-import {UnderVurderingVedtaksstatus} from '../components/tabell/headerceller/UnderVurderingVedtaksstatus';
-import {UnderVurderingVedtaksstatusEndret} from '../components/tabell/headerceller/UnderVurderingVedtaksstatusEndret';
-import {UnderVurderingAnsvarligVeileder} from '../components/tabell/headerceller/UnderVurderingAnsvarligVeileder';
+import {Utkast14aVedtaksstatus} from '../components/tabell/headerceller/Utkast14aVedtaksstatus';
+import {Utkast14aVedtaksstatusEndret} from '../components/tabell/headerceller/Utkast14aVedtaksstatusEndret';
+import {Utkast14aAnsvarligVeileder} from '../components/tabell/headerceller/Utkast14aAnsvarligVeileder';
 import {VeilederNavident} from '../components/tabell/headerceller/enhetens-oversikt/VeilederNavident';
 import {VeilederNavn} from '../components/tabell/headerceller/enhetens-oversikt/VeilederNavn';
 import './enhetsportefolje.css';
@@ -230,9 +230,9 @@ export function EnhetListehode({
                 <MoteVarighet {...sorteringTilHeadercelle} />
                 <Motestatus {...sorteringTilHeadercelle} />
 
-                <UnderVurderingVedtaksstatus {...sorteringTilHeadercelle} />
-                <UnderVurderingVedtaksstatusEndret {...sorteringTilHeadercelle} />
-                <UnderVurderingAnsvarligVeileder {...sorteringTilHeadercelle} />
+                <Utkast14aVedtaksstatus {...sorteringTilHeadercelle} />
+                <Utkast14aVedtaksstatusEndret {...sorteringTilHeadercelle} />
+                <Utkast14aAnsvarligVeileder {...sorteringTilHeadercelle} />
 
                 <SisteEndring {...sorteringTilHeadercelle} />
                 <SisteEndringDato {...sorteringTilHeadercelle} />

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -52,9 +52,9 @@ import {AvtaltAktivitet} from '../components/tabell/headerceller/AvtaltAktivitet
 import {MoterIDag} from '../components/tabell/headerceller/MoterIDag';
 import {MoteVarighet} from '../components/tabell/headerceller/MoteVarighet';
 import {Motestatus} from '../components/tabell/headerceller/Motestatus';
-import {UnderVurderingVedtaksstatus} from '../components/tabell/headerceller/UnderVurderingVedtaksstatus';
-import {UnderVurderingVedtaksstatusEndret} from '../components/tabell/headerceller/UnderVurderingVedtaksstatusEndret';
-import {UnderVurderingAnsvarligVeileder} from '../components/tabell/headerceller/UnderVurderingAnsvarligVeileder';
+import {Utkast14aVedtaksstatus} from '../components/tabell/headerceller/Utkast14aVedtaksstatus';
+import {Utkast14aVedtaksstatusEndret} from '../components/tabell/headerceller/Utkast14aVedtaksstatusEndret';
+import {Utkast14aAnsvarligVeileder} from '../components/tabell/headerceller/Utkast14aAnsvarligVeileder';
 import {Fargekategori} from '../components/tabell/headerceller/min-oversikt/Fargekategori';
 import {Huskelapp} from '../components/tabell/headerceller/min-oversikt/Huskelapp';
 import './minoversikt.css';
@@ -223,9 +223,9 @@ export function MinOversiktListehode({
                 <MoteVarighet {...sorteringTilHeadercelle} />
                 <Motestatus {...sorteringTilHeadercelle} />
 
-                <UnderVurderingVedtaksstatus {...sorteringTilHeadercelle} />
-                <UnderVurderingVedtaksstatusEndret {...sorteringTilHeadercelle} />
-                <UnderVurderingAnsvarligVeileder {...sorteringTilHeadercelle} />
+                <Utkast14aVedtaksstatus {...sorteringTilHeadercelle} />
+                <Utkast14aVedtaksstatusEndret {...sorteringTilHeadercelle} />
+                <Utkast14aAnsvarligVeileder {...sorteringTilHeadercelle} />
 
                 <SorteringHeader
                     skalVises={avansertAktivitet || forenkletAktivitet || tiltaksType}


### PR DESCRIPTION
Før kalla vi det tilsvarande filteret "Under vurdering". No heiter det "Utkast oppfølgingsvedtak $ 14 a" (ish). Oppdaterer komponentnamnet så vi i større grad bruker same terminologi alle stadar.