### PR TITLE
Fiks at data kjem under rett overskrift i tabellar

### DIFF
--- a/src/enhetsportefolje/enhet-kolonner.tsx
+++ b/src/enhetsportefolje/enhet-kolonner.tsx
@@ -96,13 +96,13 @@ export function EnhetKolonner({className, bruker, enhetId, filtervalg, valgteKol
             <Statsborgerskap bruker={bruker} valgteKolonner={valgteKolonner} />
             <StatsborgerskapGyldigFra bruker={bruker} valgteKolonner={valgteKolonner} />
 
-            <GeografiskBosted bruker={bruker} valgteKolonner={valgteKolonner} />
-            <GeografiskBostedDetaljer bruker={bruker} valgteKolonner={valgteKolonner} />
-            <GeografiskBostedSistOppdatert bruker={bruker} valgteKolonner={valgteKolonner} />
-
             <Tolkebehov bruker={bruker} valgteKolonner={valgteKolonner} filtervalg={filtervalg} />
             <Tolkesprak bruker={bruker} valgteKolonner={valgteKolonner} filtervalg={filtervalg} />
             <TolkebehovSistOppdatert bruker={bruker} valgteKolonner={valgteKolonner} />
+
+            <GeografiskBosted bruker={bruker} valgteKolonner={valgteKolonner} />
+            <GeografiskBostedDetaljer bruker={bruker} valgteKolonner={valgteKolonner} />
+            <GeografiskBostedSistOppdatert bruker={bruker} valgteKolonner={valgteKolonner} />
 
             <OppfolgingStartet bruker={bruker} valgteKolonner={valgteKolonner} />
 

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -125,13 +125,13 @@ export function EnhetListehode({
                 <Statsborgerskap {...sorteringTilHeadercelle} />
                 <StatsborgerskapGyldigFra {...sorteringTilHeadercelle} />
 
-                <GeografiskBosted {...sorteringTilHeadercelle} />
-                <GeografiskBostedDetaljer {...sorteringTilHeadercelle} />
-                <GeografiskBostedSistOppdatert {...sorteringTilHeadercelle} />
-
                 <Tolkebehov {...sorteringTilHeadercelle} />
                 <Tolkesprak {...sorteringTilHeadercelle} />
                 <TolkebehovSistOppdatert {...sorteringTilHeadercelle} />
+
+                <GeografiskBosted {...sorteringTilHeadercelle} />
+                <GeografiskBostedDetaljer {...sorteringTilHeadercelle} />
+                <GeografiskBostedSistOppdatert {...sorteringTilHeadercelle} />
 
                 <OppfolgingStartet {...sorteringTilHeadercelle} />
 

--- a/src/enhetsportefolje/enhet-listehode.tsx
+++ b/src/enhetsportefolje/enhet-listehode.tsx
@@ -212,6 +212,9 @@ export function EnhetListehode({
                 <FilterhendelseLenke {...sorteringTilHeadercelle} />
                 <FilterhendelseDatoOpprettet {...sorteringTilHeadercelle} />
 
+                <TiltakshendelseLenke {...sorteringTilHeadercelle} />
+                <TiltakshendelseDatoOpprettet {...sorteringTilHeadercelle} />
+
                 <UtlopteAktiviteter {...sorteringTilHeadercelle} />
                 <AvtaltAktivitet {...sorteringTilHeadercelle} />
 
@@ -253,9 +256,6 @@ export function EnhetListehode({
                 <BarnUnder18Aar {...sorteringTilHeadercelle} />
 
                 <UtdanningOgSituasjonSistEndret {...sorteringTilHeadercelle} />
-
-                <TiltakshendelseLenke {...sorteringTilHeadercelle} />
-                <TiltakshendelseDatoOpprettet {...sorteringTilHeadercelle} />
             </div>
             <div className="brukerliste__gutter-right" />
         </div>

--- a/src/minoversikt/minoversikt-kolonner.tsx
+++ b/src/minoversikt/minoversikt-kolonner.tsx
@@ -168,6 +168,9 @@ export function MinOversiktKolonner({bruker, enhetId, filtervalg, valgteKolonner
             <TiltakshendelseLenke bruker={bruker} valgteKolonner={valgteKolonner} enhetId={enhetId} />
             <TiltakshendelseDatoOpprettet bruker={bruker} valgteKolonner={valgteKolonner} />
 
+            <UtlopteAktiviteter bruker={bruker} valgteKolonner={valgteKolonner} />
+            <AvtaltAktivitet bruker={bruker} valgteKolonner={valgteKolonner} />
+
             <MoterIDag bruker={bruker} valgteKolonner={valgteKolonner} />
             <MoteVarighet bruker={bruker} valgteKolonner={valgteKolonner} />
             <Motestatus bruker={bruker} valgteKolonner={valgteKolonner} />
@@ -175,9 +178,6 @@ export function MinOversiktKolonner({bruker, enhetId, filtervalg, valgteKolonner
             <Utkast14aVedtaksstatus bruker={bruker} valgteKolonner={valgteKolonner} />
             <Utkast14aVedtaksstatusEndret bruker={bruker} valgteKolonner={valgteKolonner} />
             <Utkast14aAnsvarligVeileder bruker={bruker} valgteKolonner={valgteKolonner} />
-
-            <AvtaltAktivitet bruker={bruker} valgteKolonner={valgteKolonner} />
-            <UtlopteAktiviteter bruker={bruker} valgteKolonner={valgteKolonner} />
 
             <DatoKolonne
                 className="col col-xs-2"

--- a/src/minoversikt/minoversikt-kolonner.tsx
+++ b/src/minoversikt/minoversikt-kolonner.tsx
@@ -165,6 +165,9 @@ export function MinOversiktKolonner({bruker, enhetId, filtervalg, valgteKolonner
             <FilterhendelseLenke bruker={bruker} valgteKolonner={valgteKolonner} enhetId={enhetId} />
             <FilterhendelseDatoOpprettet bruker={bruker} valgteKolonner={valgteKolonner} />
 
+            <TiltakshendelseLenke bruker={bruker} valgteKolonner={valgteKolonner} enhetId={enhetId} />
+            <TiltakshendelseDatoOpprettet bruker={bruker} valgteKolonner={valgteKolonner} />
+
             <MoterIDag bruker={bruker} valgteKolonner={valgteKolonner} />
             <MoteVarighet bruker={bruker} valgteKolonner={valgteKolonner} />
             <Motestatus bruker={bruker} valgteKolonner={valgteKolonner} />
@@ -172,9 +175,6 @@ export function MinOversiktKolonner({bruker, enhetId, filtervalg, valgteKolonner
             <Utkast14aVedtaksstatus bruker={bruker} valgteKolonner={valgteKolonner} />
             <Utkast14aVedtaksstatusEndret bruker={bruker} valgteKolonner={valgteKolonner} />
             <Utkast14aAnsvarligVeileder bruker={bruker} valgteKolonner={valgteKolonner} />
-
-            <TiltakshendelseLenke bruker={bruker} valgteKolonner={valgteKolonner} enhetId={enhetId} />
-            <TiltakshendelseDatoOpprettet bruker={bruker} valgteKolonner={valgteKolonner} />
 
             <AvtaltAktivitet bruker={bruker} valgteKolonner={valgteKolonner} />
             <UtlopteAktiviteter bruker={bruker} valgteKolonner={valgteKolonner} />

--- a/src/minoversikt/minoversikt-kolonner.tsx
+++ b/src/minoversikt/minoversikt-kolonner.tsx
@@ -169,6 +169,10 @@ export function MinOversiktKolonner({bruker, enhetId, filtervalg, valgteKolonner
             <MoteVarighet bruker={bruker} valgteKolonner={valgteKolonner} />
             <Motestatus bruker={bruker} valgteKolonner={valgteKolonner} />
 
+            <Utkast14aVedtaksstatus bruker={bruker} valgteKolonner={valgteKolonner} />
+            <Utkast14aVedtaksstatusEndret bruker={bruker} valgteKolonner={valgteKolonner} />
+            <Utkast14aAnsvarligVeileder bruker={bruker} valgteKolonner={valgteKolonner} />
+
             <TiltakshendelseLenke bruker={bruker} valgteKolonner={valgteKolonner} enhetId={enhetId} />
             <TiltakshendelseDatoOpprettet bruker={bruker} valgteKolonner={valgteKolonner} />
 
@@ -195,10 +199,6 @@ export function MinOversiktKolonner({bruker, enhetId, filtervalg, valgteKolonner
                 dato={bruker.forrigeAktivitetStart ? new Date(bruker.forrigeAktivitetStart) : null}
                 skalVises={valgteKolonner.includes(Kolonne.FORRIGE_START_DATO_AKTIVITET)}
             />
-
-            <Utkast14aVedtaksstatus bruker={bruker} valgteKolonner={valgteKolonner} />
-            <Utkast14aVedtaksstatusEndret bruker={bruker} valgteKolonner={valgteKolonner} />
-            <Utkast14aAnsvarligVeileder bruker={bruker} valgteKolonner={valgteKolonner} />
 
             <SisteEndring bruker={bruker} enhetId={enhetId} valgteKolonner={valgteKolonner} />
             <SisteEndringDato bruker={bruker} valgteKolonner={valgteKolonner} />

--- a/src/minoversikt/minoversikt-listehode.tsx
+++ b/src/minoversikt/minoversikt-listehode.tsx
@@ -216,6 +216,9 @@ export function MinOversiktListehode({
                 <FilterhendelseLenke {...sorteringTilHeadercelle} />
                 <FilterhendelseDatoOpprettet {...sorteringTilHeadercelle} />
 
+                <TiltakshendelseLenke {...sorteringTilHeadercelle} />
+                <TiltakshendelseDatoOpprettet {...sorteringTilHeadercelle} />
+
                 <UtlopteAktiviteter {...sorteringTilHeadercelle} />
                 <AvtaltAktivitet {...sorteringTilHeadercelle} />
 
@@ -290,9 +293,6 @@ export function MinOversiktListehode({
 
                 <HuskelappKommentar {...sorteringTilHeadercelle} />
                 <HuskelappFrist {...sorteringTilHeadercelle} />
-
-                <TiltakshendelseLenke {...sorteringTilHeadercelle} />
-                <TiltakshendelseDatoOpprettet {...sorteringTilHeadercelle} />
             </div>
             <div className="brukerliste__gutter-right" />
         </div>


### PR DESCRIPTION
https://trello.com/b/BcjrjQZk/team-obo

Problemet:

Rekkefølgja på komponentane for overskrifter og innhaldsceller er ikkje lik mellom *-listehode- og *-kolonne-filene. Dette gjer at data kan havne under feil overskrift (“i feil kolonne”) dersom ein vel mange ulike filter samstundes.

Løysinga:

Endrar rekkefølgja slik at vi unngår feil. Held i utgangspunktet på rekkefølgja frå overskrifta.