### PR TITLE
Fjern ubrukte felt på brukarmodellen

### DIFF
--- a/src/mocks/data/portefolje.ts
+++ b/src/mocks/data/portefolje.ts
@@ -36,8 +36,6 @@ const huskelapp: any = {};
 let i = 123456;
 
 function lagGrunndata() {
-    const dag = rnd(1, 31);
-    const mnd = rnd(1, 12);
     const ar = rnd(0, 99);
     const erDoed = Math.random() < (100 - ar * 20) / 100;
 
@@ -55,21 +53,14 @@ function lagGrunndata() {
 
     return {
         fnr: String(i++).padStart(11, '0'),
-        fodselsdato: {
-            dayOfMonth: dag,
-            monthValue: mnd,
-            year: 1900 + ar
-        },
         fornavn: faker.person.firstName(kjonn === 'K' ? 'female' : 'male'),
         etternavn: 'Testson',
-        kjonn,
         erDoed,
         nesteUtlopteAktivitet,
         venterPaSvarFraBruker,
         venterPaSvarFraNAV,
         aktiviteter: brukerAktiviteter,
         moteStartTid,
-        moteSluttTid: moteStartTid && new Date(moteStartTid.getTime() + 15 * 60 * 1000),
         alleMoterStartTid,
         alleMoterSluttTid: alleMoterStartTid && new Date(alleMoterStartTid.getTime() + 45 * 60 * 1000)
     };
@@ -252,9 +243,6 @@ function lagBruker(sikkerhetstiltak = []) {
         egenAnsatt: random_egenAnsatt ? true : '',
         skjermetTil: random_harSkjermetTil ? randomDateInNearFuture() : '',
         erDoed: grunndata.erDoed,
-        fodselsdagIMnd: grunndata.fodselsdato.dayOfMonth,
-        fodselsdato: grunndata.fodselsdato,
-        kjonn: grunndata.kjonn,
         ytelse: ytelse.ytelse,
         utlopsdato: ytelse.utlopsdato,
         aktivitetStart: ytelse.utlopsdato,
@@ -266,7 +254,6 @@ function lagBruker(sikkerhetstiltak = []) {
         aktiviteter: grunndata.aktiviteter,
         erSykmeldtMedArbeidsgiver,
         moteStartTid: grunndata.moteStartTid,
-        moteSluttTid: grunndata.moteSluttTid,
         alleMoterStartTid: grunndata.alleMoterStartTid,
         alleMoterSluttTid: grunndata.alleMoterSluttTid,
         moteErAvtaltMedNAV: grunndata.moteStartTid != null && Math.random() < 0.5,
@@ -281,8 +268,6 @@ function lagBruker(sikkerhetstiltak = []) {
             gyldigTil: ''
         },
         foedeland: hentLand(),
-        harFlereStatsborgerskap: Boolean(Math.random() > 0.5),
-        innflyttingTilNorgeFraLand: '',
         bostedKommune: hentBostedKommune(),
         bostedBydel: hentBostedBydel(),
         bostedSistOppdatert: randomDate({past: true}),

--- a/src/typer/bruker-modell.ts
+++ b/src/typer/bruker-modell.ts
@@ -1,5 +1,3 @@
-import {ArbeidslisteModell} from './arbeidsliste';
-
 export interface BrukerModell {
     fnr: string;
     guid: string;
@@ -13,38 +11,29 @@ export interface BrukerModell {
     skjermetTil?: string;
     nyForVeileder: boolean;
     nyForEnhet: boolean;
-    trengerOppfolgingsvedtak: boolean;
     vurderingsBehov?: VurderingsBehov;
+    trengerOppfolgingsvedtak: boolean;
     profileringResultat?: Profileringsresultat;
     innsatsgruppe: Innsatsgruppe;
     erDoed: boolean;
-    fodselsdagIMnd: number;
-    fodselsdato: string; // dato
-    kjonn: string; // enum
     ytelse?: string;
     utlopsdato?: string; // dato
-    aapUnntakUkerIgjen?: number;
     dagputlopUke?: number;
     permutlopUke?: number;
     aapmaxtidUke?: number;
+    aapUnntakUkerIgjen?: number;
     aapordinerutlopsdato?: string; // dato
-    arbeidsliste: ArbeidslisteModell;
-    venterPaSvarFraNAV?: string;
-    venterPaSvarFraBruker?: string;
+    venterPaSvarFraNAV?: string; // dato
+    venterPaSvarFraBruker?: string; // dato
     nyesteUtlopteAktivitet?: string; // dato
-    veilederNavn?: string;
-    brukertiltak?: string[];
     tiltakshendelse: TiltakshendelseModell | null;
     aktiviteter?: AktiviteterModell; // kun avtalte aktiviteter
-    alleAktiviteter?: AktiviteterModell;
     aktivitetStart?: string; // dato
     nesteAktivitetStart?: string; // dato
     forrigeAktivitetStart?: string; // dato
     markert?: boolean;
-    manuellBrukerStatus: string;
     erSykmeldtMedArbeidsgiver: boolean;
-    moteStartTid: string; // kun avtalte moter
-    moteSluttTid: string; // kun avtalte moter
+    moteStartTid: string; // kun avtalte moter, // moteStartTid verdien blir brukt til å avgjere kva status som vert vist i kolonna for "avtalt med Nav". Vurder å gje den betre namn og tydelegare verdi. 2025-06-18, Ingrid.
     alleMoterStartTid?: string;
     alleMoterSluttTid?: string;
     utkast14a: Utkast14a | null;
@@ -53,8 +42,6 @@ export interface BrukerModell {
     sisteEndringAktivitetId?: string;
     nesteUtlopsdatoAktivitet?: string;
     hovedStatsborgerskap: Statsborgerskap;
-    harFlereStatsborgerskap: boolean;
-    innflyttingTilNorgeFraLand: string;
     foedeland?: string;
     tolkebehov: Tolkebehov;
     bostedKommune?: string;
@@ -66,11 +53,10 @@ export interface BrukerModell {
     avvik14aVedtak: string;
     ensligeForsorgereOvergangsstonad?: EnsligeForsorgereOvergangsstonad;
     barnUnder18AarData: BarnUnder18AarModell[];
-    brukersSituasjonSistEndret: string;
     fargekategori: FargekategoriModell | null;
     fargekategoriEnhetId: string | null;
     huskelapp?: HuskelappModell;
-    utdanningOgSituasjonSistEndret: string;
+    utdanningOgSituasjonSistEndret: string; // dato
     gjeldendeVedtak14a: GjeldendeVedtak14aModell | null;
     utgattVarsel: UtgattVarselHendelse | null;
 }


### PR DESCRIPTION
Vi har felt som vert sendt til frontend, men som frontenden ikkje brukar. Det gjer at vi sender og tilgjengeleggjer meir data enn vi burde.

https://trello.com/c/ediXhBkP/1190-veilarbportefoljeflatefs-fjerne-kj%C3%B8nn-f%C3%B8dselsdato-og-dag-i-mnd-fr%C3%A5-frontend-objektet-dei-er-ikkje-brukt?filter=*