### PR TITLE
Gjer cypress-test raskare

### DIFF
--- a/cypress/e2e/mine-filter_spec.ts
+++ b/cypress/e2e/mine-filter_spec.ts
@@ -47,7 +47,7 @@ describe('Mine filter', () => {
             cy.getByTestId('lagre-nytt-filter_modal_form').contains('Filteret mangler navn.');
 
             // Skriv inn eit for langt namn, prøvar lagre, får feilmelding
-            cy.getByTestId('lagre-nytt-filter_modal_navn-input').type(forLangtFilterNavn);
+            cy.getByTestId('lagre-nytt-filter_modal_navn-input').type(forLangtFilterNavn, {delay: 0});
             cy.getByTestId('lagre-nytt-filter_modal_lagre-knapp').click();
             cy.getByTestId('lagre-nytt-filter_modal_form').contains(
                 'Filternavn er for langt, kan ikke ha mer enn 255 bokstaver.'


### PR DESCRIPTION
Ved å unngå å skrive inn ein tekst på 256 teikn eit teikn om gongen, med 10 millisekund venting mellom kvart teikn.

I staden: Lim inn tekst, legg til eit ekstra utropsteikn, fortel inputboksen at det har skjedd endringar, prøv å lagre.


Før:
![bilde](https://github.com/user-attachments/assets/4f57374e-209c-47d0-b4c6-f19ed078a836)


Etter:
![bilde](https://github.com/user-attachments/assets/9c692e53-0db6-4af3-beb4-dfe2e8f12f41)



