### PR TITLE
Bruk nytt mønster for routing

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -16,10 +16,18 @@ export function Routes() {
             <div className="maincontent side-innhold">
                 <Innholdslaster avhengigheter={[enhettiltak, veiledere, portefoljestorrelser]}>
                     <Switch>
-                        <Route path="/enhet" component={EnhetSide} />
-                        <Route path="/veiledere" component={VeilederoversiktSide} />
-                        <Route path="/portefolje/:ident" component={MinoversiktSide} />
-                        <Route path="/portefolje" component={MinoversiktSide} />
+                        <Route path="/enhet">
+                            <EnhetSide />
+                        </Route>
+                        <Route path="/veiledere">
+                            <VeilederoversiktSide />
+                        </Route>
+                        <Route path="/portefolje/:ident">
+                            <MinoversiktSide />
+                        </Route>
+                        <Route path="/portefolje">
+                            <MinoversiktSide />
+                        </Route>
                     </Switch>
                     <TilToppenKnapp />
                 </Innholdslaster>


### PR DESCRIPTION
Send inn sider som born av Route, i staden som component. Dette gjer overgangen til React Router v6 lettare.

Sjå https://reactrouter.com/6.30.1/upgrading/v5#upgrade-to-react-router-v51 for meir bakgrunn for endringa.