### PR TITLE
Legg til manglande "(Arena)" bak AAP-valg

### DIFF
--- a/src/filtrering/filter-konstanter.ts
+++ b/src/filtrering/filter-konstanter.ts
@@ -204,7 +204,7 @@ export const ytelseArena = {
         label: 'Lønnsgarantimidler dagpenger (Arena)',
         className: skjemaelementInnrykkKlasse
     },
-    AAP: {label: 'AAP'},
+    AAP: {label: 'AAP (Arena)'},
     AAP_MAXTID: {label: 'AAP ordinær (Arena)', className: skjemaelementInnrykkKlasse},
     AAP_UNNTAK: {label: 'AAP unntak (Arena)', className: skjemaelementInnrykkKlasse},
     TILTAKSPENGER: {label: 'Tiltakspenger (Arena)'}


### PR DESCRIPTION
🏆 til Mathias som oppdaga at det mangla ein (Arena) bak "AAP"


Før:
<img width="200" height="421" alt="bilde" src="https://github.com/user-attachments/assets/101da621-9638-431c-baa9-885b1611af7a" />



Etter:
<img width="200" height="431" alt="bilde" src="https://github.com/user-attachments/assets/1a761fb6-e247-4125-8a58-a2cbfef370b5" />

