### PR TITLE
Fiks: Boks rundt valgt element i filtermenyen

### DIFF
--- a/src/components/barinput/bar.css
+++ b/src/components/barinput/bar.css
@@ -1,12 +1,15 @@
 .barinput-checkbox,
 .barinput-radio {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
     margin-bottom: var(--ax-space-4);
 }
-.barlabel__antall {
-    padding-right: 0.5rem;
+.barinput-checkbox__checkbox,
+.barinput-radio__radio {
+    width: 100%;
+}
+.barinput-checkbox__checkbox label,
+.barinput-radio__radio label {
+    display: flex;
+    justify-content: space-between;
 }
 .forste-barlabel-i-gruppe {
     padding-top: 1rem;

--- a/src/components/barinput/barinput-checkbox.tsx
+++ b/src/components/barinput/barinput-checkbox.tsx
@@ -1,5 +1,5 @@
 import {ChangeEventHandler, ReactNode} from 'react';
-import {Checkbox, Detail, Label} from '@navikt/ds-react';
+import {Checkbox, Detail} from '@navikt/ds-react';
 import './bar.css';
 
 interface BarInputCheckboxProps {

--- a/src/components/barinput/barinput-checkbox.tsx
+++ b/src/components/barinput/barinput-checkbox.tsx
@@ -1,5 +1,5 @@
 import {ChangeEventHandler, ReactNode} from 'react';
-import {Checkbox, Label} from '@navikt/ds-react';
+import {Checkbox, Detail, Label} from '@navikt/ds-react';
 import './bar.css';
 
 interface BarInputCheckboxProps {
@@ -31,15 +31,16 @@ export function BarInputCheckbox({
                 onChange={handleChange}
                 checked={checked}
                 indeterminate={indeterminate}
+                className="barinput-checkbox__checkbox"
                 data-testid={`filter_checkboks-container_${filterNavn}`}
             >
                 {labelTekst}
+                {(antall || antall === 0) && (
+                    <Detail weight="semibold" data-testid={`filter_checkboks-label_${filterNavn}`}>
+                        {antall}
+                    </Detail>
+                )}
             </Checkbox>
-            {(antall || antall === 0) && (
-                <Label className="barlabel__antall" size="small" data-testid={`filter_checkboks-label_${filterNavn}`}>
-                    {antall}
-                </Label>
-            )}
         </div>
     );
 }

--- a/src/components/barinput/barinput-radio.tsx
+++ b/src/components/barinput/barinput-radio.tsx
@@ -1,5 +1,5 @@
 import {ChangeEventHandler} from 'react';
-import {Detail, Label, Radio} from '@navikt/ds-react';
+import {Detail, Radio} from '@navikt/ds-react';
 import './bar.css';
 
 interface BarinputRadioProps {

--- a/src/components/barinput/barinput-radio.tsx
+++ b/src/components/barinput/barinput-radio.tsx
@@ -1,5 +1,5 @@
 import {ChangeEventHandler} from 'react';
-import {Label, Radio} from '@navikt/ds-react';
+import {Detail, Label, Radio} from '@navikt/ds-react';
 import './bar.css';
 
 interface BarinputRadioProps {
@@ -19,16 +19,12 @@ export const BarInputRadio = ({filterVerdi, handleChange, labelTekst, statustall
                 onChange={handleChange}
                 data-testid={testId}
                 key={filterVerdi}
-                className="mine-filter__filternavn"
+                className="barinput-radio__radio"
                 size="small"
             >
                 {labelTekst}
+                {(!!statustall || statustall === 0) && <Detail weight="semibold">{statustall}</Detail>}
             </Radio>
-            {(!!statustall || statustall === 0) && (
-                <Label className="barlabel__antall" size="small">
-                    {statustall}
-                </Label>
-            )}
         </div>
     );
 };

--- a/src/filtrering/filtrering-mine-filter/mine-filter_innhold.css
+++ b/src/filtrering/filtrering-mine-filter/mine-filter_innhold.css
@@ -26,6 +26,7 @@
 .veilarbportefoljeflatefs .mine-filter__filternavn {
     flex: 1;
     min-width: 0;
+    margin-right: var(--ax-space-12);
 }
 .veilarbportefoljeflatefs .mine-filter_alertstripe {
     display: flex;

--- a/src/filtrering/filtrering-mine-filter/mine-filter_innhold.css
+++ b/src/filtrering/filtrering-mine-filter/mine-filter_innhold.css
@@ -23,11 +23,6 @@
     justify-content: space-between;
     align-items: center;
 }
-.veilarbportefoljeflatefs .mine-filter__filternavn {
-    flex: 1;
-    min-width: 0;
-    margin-right: var(--ax-space-12);
-}
 .veilarbportefoljeflatefs .mine-filter_alertstripe {
     display: flex;
     justify-content: space-between;

--- a/src/filtrering/filtrering-status/filtrering-status.css
+++ b/src/filtrering/filtrering-status/filtrering-status.css
@@ -1,6 +1,5 @@
 .veilarbportefoljeflatefs .filter-checkboks-container {
-    padding-top: 1rem;
-    padding-left: 0.25rem;
+    padding: 1rem 0.75em 0;
 }
 .veilarbportefoljeflatefs .permittering_checkboksgruppe {
     border-top: 1px solid #6a6a6a;


### PR DESCRIPTION
Flytta statustallet inn i Checkbox, så alt omkranses av boksen som dukker opp når man trykker på et element. Justerte også innrykket på nye/ufordelte brukere sjekkboksen så alt er på linje nedover.

Før:
<img width="339" height="355" alt="image" src="https://github.com/user-attachments/assets/60cab5dc-db2e-455b-a1a5-0e12f7160ccc" />


Nå:
<img width="353" height="385" alt="bilde" src="https://github.com/user-attachments/assets/319c77ea-cdfc-4c98-b1ae-74ee01d7c768" />

