### PR TITLE
Bugfiks: Bruk eventlisteners for å fange opp webcomp-events

### DIFF
--- a/cypress/e2e/diverse_spec.ts
+++ b/cypress/e2e/diverse_spec.ts
@@ -120,13 +120,20 @@ describe('Diverse', () => {
 
         // Finn og vel den fyrste brukaren i lista
         cy.scrollTo('top');
-        cy.wait(100);
         cy.checkboxFirst('min-oversikt_brukerliste-checkbox');
-        cy.wait(300);
+        cy.get('[data-testid=min-oversikt_brukerliste-checkbox]:checked').should('have.length.at.least', 1);
 
-        // Opne val av veileder
+        // Opne val av veileder.
+        // Dersom knappetrykket ikkje opnar dropdown-en (t.d. fordi avhukinga ikkje rakk å
+        // registrerast i tide), prøver vi på nytt utan å huke av igjen – checkboxen er allereie vald.
         cy.getByTestId('tildel-veileder_knapp').should('be.enabled').click({force: true});
-        cy.getByTestId('tildel-veileder_dropdown').should('be.visible');
+        cy.get('body').then($body => {
+            if ($body.find('[data-testid=tildel-veileder_dropdown]').length === 0) {
+                cy.get('[data-testid=min-oversikt_brukerliste-checkbox]:checked').should('have.length.at.least', 1);
+                cy.getByTestId('tildel-veileder_knapp').should('be.enabled').click({force: true});
+            }
+        });
+        cy.get('[data-testid=tildel-veileder_dropdown]', {timeout: 10000}).should('be.visible');
 
         // Vel den øvste veiledaren i lista
         cy.checkbox('tildel-veileder_valg_0');

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -69,7 +69,7 @@ Cypress.Commands.add('gaTilOversikt', side => {
 
     cy.getByTestId(testId).should('be.visible').click({force: true});
     cy.url().should('include', url);
-    cy.get('.navds-loader', {timeout: 15000}).should('not.exist');
+    cy.get('.aksel-loader', {timeout: 15000}).should('not.exist');
     cy.getByTestId(`side-storrelse_${testId}`).should('be.visible');
 });
 

--- a/src/decorator.tsx
+++ b/src/decorator.tsx
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import {useEffect, useLayoutEffect, useRef} from 'react';
 import {useEnhetSelector} from './hooks/redux/use-enhet-selector';
 import {useBrukerIKontekstSelector} from './hooks/redux/use-bruker-i-kontekst-selector';
 import {EnvType, getEnv, getVeilarbpersonflateBasePath} from './utils/url-utils';
@@ -12,6 +12,7 @@ declare module 'react' {
     namespace JSX {
         interface IntrinsicElements {
             'internarbeidsflate-decorator': {
+                ref?: React.Ref<HTMLElement>;
                 'app-name': string;
                 enhet?: string;
                 environment: string;
@@ -20,8 +21,6 @@ declare module 'react' {
                 'show-enheter'?: boolean;
                 'show-search-area'?: boolean;
                 'url-format': 'LOCAL' | 'NAV_NO' | 'ANSATT';
-                onEnhetChanged?: (event: CustomEvent<{enhet?: string | null}>) => void;
-                onFnrChanged?: (event: CustomEvent<{fnr?: string | null}>) => void;
             };
         }
     }
@@ -38,17 +37,37 @@ function getDecoratorEnv(): Environment {
     }
 }
 
-function handterFnrEndret(event: CustomEvent<{fnr?: string | null}>) {
-    const fnr = event.detail.fnr;
-    if (fnr) {
-        window.location.href = getVeilarbpersonflateBasePath();
-    }
-}
-
 export function Decorator() {
     const dispatch = useAppDispatch();
     const enhetId = useEnhetSelector();
     const brukerIKontekst = useBrukerIKontekstSelector();
+    const decoratorRef = useRef<HTMLElement>(null);
+
+    useLayoutEffect(() => {
+        const el = decoratorRef.current;
+        if (!el) return;
+
+        const onEnhetChanged = (e: Event) => {
+            const enhet = (e as CustomEvent<{enhet?: string | null}>).detail.enhet;
+            if (enhet) {
+                dispatch(oppdaterValgtEnhet(enhet));
+            }
+        };
+
+        const onFnrChanged = (e: Event) => {
+            const fnr = (e as CustomEvent<{fnr?: string | null}>).detail.fnr;
+            if (fnr) {
+                window.location.href = getVeilarbpersonflateBasePath();
+            }
+        };
+
+        el.addEventListener('enhet-changed', onEnhetChanged);
+        el.addEventListener('fnr-changed', onFnrChanged);
+        return () => {
+            el.removeEventListener('enhet-changed', onEnhetChanged);
+            el.removeEventListener('fnr-changed', onFnrChanged);
+        };
+    }, [dispatch]);
 
     useEffect(() => {
         if (brukerIKontekst && !window.location.href.includes('/tilbake')) {
@@ -56,21 +75,11 @@ export function Decorator() {
         }
     }, [brukerIKontekst, dispatch]);
 
-    function velgEnhet(enhet: string) {
-        dispatch(oppdaterValgtEnhet(enhet));
-    }
-
-    function handterEnhetEndret(event: CustomEvent<{enhet?: string | null}>) {
-        const enhet = event.detail.enhet;
-        if (enhet) {
-            velgEnhet(enhet);
-        }
-    }
-
     const urlFormat = getEnv().ingressType === 'ansatt' ? 'ANSATT' : 'NAV_NO';
 
     return (
         <internarbeidsflate-decorator
+            ref={decoratorRef}
             app-name="Arbeidsrettet oppfølging"
             enhet={enhetId ?? undefined}
             environment={getDecoratorEnv()}
@@ -79,8 +88,6 @@ export function Decorator() {
             show-enheter
             show-search-area
             url-format={urlFormat}
-            onEnhetChanged={handterEnhetEndret}
-            onFnrChanged={handterFnrEndret}
         />
     );
 }


### PR DESCRIPTION
ClaudePilot melder:
> React 19 strips on and lowercases → `onEnhetChanged` listens for `enhetchanged` 
> Decorator dispatches → `enhet-changed `(with hyphen)  
> `enhetchanged` ≠ `enhet-changed` — the hyphen can't be represented in a camelCase prop name, so React never matches the actual DOM event.

Funker i dev 👌 