### PR TITLE
Validering filtervalg tweaks

### DIFF
--- a/src/components/modal/mine-filter/mine-filter-mapper.tsx
+++ b/src/components/modal/mine-filter/mine-filter-mapper.tsx
@@ -1,5 +1,5 @@
 import {LagretFilter, LagretFilterDTO} from '../../../ducks/lagret-filter';
-import {initialState as filtervalgInitialState} from '../../../ducks/filtrering';
+import {initialState, initialState as filtervalgInitialState} from '../../../ducks/filtrering';
 import {Filtervalg, FiltervalgModell} from '../../../typer/filtervalg-modell';
 import {AktiviteterFilternokler, AktiviteterValg} from '../../../filtrering/filter-konstanter';
 import {filtervalgValidators} from './mine-filter-validering-filtermodel-utils';
@@ -9,9 +9,7 @@ export function mapLagretFilterFraDTO(dto: LagretFilterDTO, brukAktiveFiltervalg
     return {
         filterNavn: dto.filterNavn,
         filterId: dto.filterId,
-        filterValg: brukAktiveFiltervalg
-            ? mapAktiveValgTilFiltermodell(dto.filterValg, dto.aktiveFilterValg)
-            : dto.filterValg,
+        filterValg: brukAktiveFiltervalg ? mapAktiveValgTilFiltermodell(dto.aktiveFilterValg) : dto.filterValg,
         sortOrder: dto.sortOrder,
         filterCleanup: dto.filterCleanup,
         aktiv: dto.aktiv,
@@ -19,13 +17,10 @@ export function mapLagretFilterFraDTO(dto: LagretFilterDTO, brukAktiveFiltervalg
     };
 }
 
-export function mapAktiveValgTilFiltermodell(
-    filtervalg: FiltervalgModell,
-    aktiveFilterValg: string | null | undefined
-): FiltervalgModell {
-    // midlertidig sjekk til databasen får populert data for alle brukere, default til opprinnelige filtervalg
+export function mapAktiveValgTilFiltermodell(aktiveFilterValg: string | null | undefined): FiltervalgModell {
+    // Noen filtre har ikke lengre verdier pga fjerning av gamle filtervalg, og da skal vi ikke kaste feil, men heller returnere default state
     if (!aktiveFilterValg) {
-        return {...filtervalg};
+        return {...initialState};
     }
 
     try {

--- a/src/components/modal/mine-filter/mine-filter-validering-filtermodel-utils.ts
+++ b/src/components/modal/mine-filter/mine-filter-validering-filtermodel-utils.ts
@@ -4,7 +4,6 @@ import {
     AktiviteterAvtaltMedNav,
     AktiviteterFilternokler,
     AktiviteterValg,
-    alder,
     alleFargekategoriFilterAlternativer,
     barnUnder18Aar as barnUnder18AarKonst,
     cvJobbprofil,
@@ -43,9 +42,11 @@ const isStringArray = (v: unknown): v is string[] => Array.isArray(v) && v.every
 
 /** Sjekker at verdier kun er de som ligger i `tillate`. Returner undefined om input ikke er en liste. */
 const enumArray =
-    (tillate: readonly string[]): Validator =>
-    v =>
-        isStringArray(v) ? v.filter(x => tillate.includes(x)) : undefined;
+    (tillateEnums: readonly string[]): Validator =>
+    v => {
+        if (!isStringArray(v)) return undefined;
+        return v.every(x => tillateEnums.includes(x)) ? v : undefined;
+    };
 
 /** Aksepter en liste av strenger uten enum-sjekk (fritekst fra backend, f eks veileder-ID-er). */
 const stringArray: Validator = v => (isStringArray(v) ? v : undefined);
@@ -76,7 +77,7 @@ const aktiviteterValidator: Validator = v => {
 
 export const filtervalgValidators: Partial<Record<Filtervalg, Validator>> = {
     [Filtervalg.ferdigfilterListe]: enumArray(Object.keys(ferdigfilterListeLabelTekst)),
-    [Filtervalg.alder]: enumArray(Object.keys(alder)),
+    [Filtervalg.alder]: stringArray,
     [Filtervalg.kjonn]: nullableEnum(Object.keys(kjonn)),
     [Filtervalg.landgruppe]: enumArray(Object.keys(landgruppe)),
     [Filtervalg.foedeland]: stringArray,

--- a/src/typer/filtervalg-modell.ts
+++ b/src/typer/filtervalg-modell.ts
@@ -76,15 +76,15 @@ export const erGyldigFiltervalg = (filtervalg: string): filtervalg is Filtervalg
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 export interface FiltervalgModell {
     [Filtervalg.ferdigfilterListe]: string[];
-    [Filtervalg.alder]?: string[];
-    [Filtervalg.kjonn]?: null | string;
+    [Filtervalg.alder]: string[];
+    [Filtervalg.kjonn]: null | string;
     [Filtervalg.landgruppe]: string[];
     [Filtervalg.foedeland]: string[];
     [Filtervalg.fodselsdagIMnd]?: string[];
     [Filtervalg.formidlingsgruppe]?: string[];
     [Filtervalg.servicegruppe]?: string[];
     [Filtervalg.veiledere]: string[];
-    [Filtervalg.aktiviteter]?: AktiviteterFilternokler;
+    [Filtervalg.aktiviteter]: AktiviteterFilternokler;
     [Filtervalg.aktiviteterForenklet]: string[];
     [Filtervalg.tiltakstyper]: string[];
     [Filtervalg.navnEllerFnrQuery]: string;


### PR DESCRIPTION
Setter filtermodell til defaults om aktive vaglte filter er tomt object. 
Alder er ikke alltid en enum så har endret til stringArray. 
Fikset en liten bug i enumArray validator, der sjekkt på gyldige enums ikke ble validert. 